### PR TITLE
Make executor synchronous

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -145,13 +145,10 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Errors: nil,
 	}
 
-	resultChannel := make(chan *graphql.Result)
-
-	go graphql.Graphql(graphql.Params{
+	result := graphql.Graphql(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
-	}, resultChannel)
-	result := <-resultChannel
+	})
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -280,13 +277,10 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 		Errors: nil,
 	}
 
-	resultChannel := make(chan *graphql.Result)
-
-	go graphql.Graphql(graphql.Params{
+	result := graphql.Graphql(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
-	}, resultChannel)
-	result := <-resultChannel
+	})
 
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
@@ -451,13 +445,10 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		},
 	}
 
-	resultChannel := make(chan *graphql.Result)
-
-	go graphql.Graphql(graphql.Params{
+	result := graphql.Graphql(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
-	}, resultChannel)
-	result := <-resultChannel
+	})
 	if len(result.Errors) == 0 {
 		t.Fatalf("wrong result, expected errors: %v, got: %v", len(expected.Errors), len(result.Errors))
 	}
@@ -609,13 +600,10 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		},
 	}
 
-	resultChannel := make(chan *graphql.Result)
-
-	go graphql.Graphql(graphql.Params{
+	result := graphql.Graphql(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
-	}, resultChannel)
-	result := <-resultChannel
+	})
 	if len(result.Errors) == 0 {
 		t.Fatalf("wrong result, expected errors: %v, got: %v", len(expected.Errors), len(result.Errors))
 	}

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -74,13 +74,10 @@ var schema, _ = graphql.NewSchema(
 )
 
 func executeQuery(query string, schema graphql.Schema) *graphql.Result {
-	params := graphql.Params{
+	result := graphql.Graphql(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
-	}
-	resultChannel := make(chan *graphql.Result)
-	go graphql.Graphql(params, resultChannel)
-	result := <-resultChannel
+	})
 	if len(result.Errors) > 0 {
 		fmt.Println("wrong result, unexpected errors: %v", result.Errors)
 	}

--- a/graphql.go
+++ b/graphql.go
@@ -14,36 +14,30 @@ type Params struct {
 	OperationName  string
 }
 
-func Graphql(p Params, resultChannel chan *Result) {
+func Graphql(p Params) *Result {
 	source := source.NewSource(&source.Source{
 		Body: p.RequestString,
 		Name: "GraphQL request",
 	})
 	AST, err := parser.Parse(parser.ParseParams{Source: source})
 	if err != nil {
-		result := Result{
+		return &Result{
 			Errors: gqlerrors.FormatErrors(err),
 		}
-		resultChannel <- &result
-		return
 	}
 	validationResult := ValidateDocument(p.Schema, AST)
 
 	if !validationResult.IsValid {
-		result := Result{
+		return &Result{
 			Errors: validationResult.Errors,
 		}
-		resultChannel <- &result
-		return
-	} else {
-		ep := ExecuteParams{
-			Schema:        p.Schema,
-			Root:          p.RootObject,
-			AST:           AST,
-			OperationName: p.OperationName,
-			Args:          p.VariableValues,
-		}
-		Execute(ep, resultChannel)
-		return
 	}
+
+	return Execute(ExecuteParams{
+		Schema:        p.Schema,
+		Root:          p.RootObject,
+		AST:           AST,
+		OperationName: p.OperationName,
+		Args:          p.VariableValues,
+	})
 }

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -82,9 +82,7 @@ func TestQuery(t *testing.T) {
 }
 
 func testGraphql(test T, p graphql.Params, t *testing.T) {
-	resultChannel := make(chan *graphql.Result)
-	go graphql.Graphql(p, resultChannel)
-	result := <-resultChannel
+	result := graphql.Graphql(p)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -121,12 +119,10 @@ func TestBasicGraphQLExample(t *testing.T) {
 		"hello": "world",
 	}
 
-	resultChannel := make(chan *graphql.Result)
-	go graphql.Graphql(graphql.Params{
+	result := graphql.Graphql(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
-	}, resultChannel)
-	result := <-resultChannel
+	})
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -11,10 +11,7 @@ import (
 )
 
 func g(t *testing.T, p graphql.Params) *graphql.Result {
-	resultChannel := make(chan *graphql.Result)
-	go graphql.Graphql(p, resultChannel)
-	result := <-resultChannel
-	return result
+	return graphql.Graphql(p)
 }
 
 func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -357,10 +357,7 @@ func TestParse(t *testing.T, query string) *ast.Document {
 	return astDoc
 }
 func TestExecute(t *testing.T, ep graphql.ExecuteParams) *graphql.Result {
-	resultChannel := make(chan *graphql.Result)
-	go graphql.Execute(ep, resultChannel)
-	result := <-resultChannel
-	return result
+	return graphql.Execute(ep)
 }
 
 func Diff(a, b interface{}) []string {


### PR DESCRIPTION
This changes the API for `graphql.Graphql ` to no longer require a channel as a parameter, and instead just returns the `*Result`. My hope is that this makes the API simpler and improves the readability of the code by reducing the duplication of error handling.

As far as I can tell, the channel was only ever used once, and wasn't required for any sort of concurrency. All the tests still pass. However, it may still be required for future concurrency work. My hope is that if that's the case, the internal function can handle creating the channel itself.