### PR TITLE
Remove Google Code Dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
-  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - go get golang.org/x/tools/cmd/cover
 
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,3 @@ before_install:
 
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci
-


### PR DESCRIPTION
I don't see a reason why it should try Google Code first when it's archived and the repository is now updated on `golang.org/x/tools/cmd/cover`.