### PR TITLE
Implement graphql.Do as described in #44

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -505,7 +505,7 @@ type ResolveInfo struct {
 	FieldASTs      []*ast.Field
 	ReturnType     Output
 	ParentType     Composite
-	Schema         Schema
+	Schema         *Schema
 	Fragments      map[string]ast.Definition
 	RootValue      interface{}
 	Operation      ast.Definition

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -31,8 +31,7 @@ func main() {
 			hello
 		}
 	`
-	params := graphql.Params{Schema: schema, RequestString: query}
-	r := graphql.Graphql(params)
+	r := graphql.Do(schema, query)
 	if len(r.Errors) > 0 {
 		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
 	}

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -73,11 +73,8 @@ var schema, _ = graphql.NewSchema(
 	},
 )
 
-func executeQuery(query string, schema graphql.Schema) *graphql.Result {
-	result := graphql.Graphql(graphql.Params{
-		Schema:        schema,
-		RequestString: query,
-	})
+func executeQuery(query string, schema *graphql.Schema) *graphql.Result {
+	result := graphql.Do(schema, query)
 	if len(result.Errors) > 0 {
 		fmt.Println("wrong result, unexpected errors: %v", result.Errors)
 	}

--- a/language/ast/name.go
+++ b/language/ast/name.go
@@ -23,9 +23,22 @@ func NewName(node *Name) *Name {
 }
 
 func (node *Name) GetKind() string {
+	if node == nil {
+		return ""
+	}
 	return node.Kind
 }
 
 func (node *Name) GetLoc() *Location {
+	if node == nil {
+		return nil
+	}
 	return node.Loc
+}
+
+func (node *Name) GetValue() string {
+	if node == nil {
+		return ""
+	}
+	return node.Value
 }

--- a/language/source/source.go
+++ b/language/source/source.go
@@ -1,20 +1,21 @@
 package source
 
 const (
-	name = "GraphQL"
+	defaultName = "GraphQL"
 )
 
 type Source struct {
-	Body string
 	Name string
+	Body string
 }
 
-func NewSource(s *Source) *Source {
-	if s == nil {
-		s = &Source{Name: name}
+func NewSource(name string, body string) *Source {
+	s := &Source{
+		Name: name,
+		Body: body,
 	}
 	if s.Name == "" {
-		s.Name = name
+		s.Name = defaultName
 	}
 	return s
 }

--- a/schema.go
+++ b/schema.go
@@ -29,10 +29,10 @@ type Schema struct {
 	directives   []*Directive
 }
 
-func NewSchema(config SchemaConfig) (Schema, error) {
+func NewSchema(config SchemaConfig) (*Schema, error) {
 	var err error
 
-	schema := Schema{}
+	schema := &Schema{}
 
 	err = invariant(config.Query != nil, "Schema query must be Object Type but got: nil.")
 	if err != nil {

--- a/validator.go
+++ b/validator.go
@@ -1,16 +1,7 @@
 package graphql
 
-import (
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-)
+import "github.com/graphql-go/graphql/language/ast"
 
-type ValidationResult struct {
-	IsValid bool
-	Errors  []gqlerrors.FormattedError
-}
-
-func ValidateDocument(schema Schema, ast *ast.Document) (vr ValidationResult) {
-	vr.IsValid = true
-	return vr
+func ValidateDocument(schema *Schema, ast *ast.Document) (bool, []error) {
+	return true, nil
 }

--- a/values.go
+++ b/values.go
@@ -15,7 +15,7 @@ import (
 // Prepares an object map of variableValues of the correct type based on the
 // provided variable definitions and arbitrary input. If the input cannot be
 // parsed to match the variable definitions, a GraphQLError will be returned.
-func getVariableValues(schema Schema, definitionASTs []*ast.VariableDefinition, inputs map[string]interface{}) (map[string]interface{}, error) {
+func getVariableValues(schema *Schema, definitionASTs []*ast.VariableDefinition, inputs map[string]interface{}) (map[string]interface{}, error) {
 	values := map[string]interface{}{}
 	for _, defAST := range definitionASTs {
 		if defAST == nil || defAST.Variable == nil || defAST.Variable.Name == nil {
@@ -62,7 +62,7 @@ func getArgumentValues(argDefs []*Argument, argASTs []*ast.Argument, variableVar
 
 // Given a variable definition, and any value of input, return a value which
 // adheres to the variable definition, or throw an error.
-func getVariableValue(schema Schema, definitionAST *ast.VariableDefinition, input interface{}) (interface{}, error) {
+func getVariableValue(schema *Schema, definitionAST *ast.VariableDefinition, input interface{}) (interface{}, error) {
 	ttype, err := typeFromAST(schema, definitionAST.Type)
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func coerceValue(ttype Input, value interface{}) interface{} {
 // graphql-js/src/utilities.js`
 // TODO: figure out where to organize utils
 
-func typeFromAST(schema Schema, inputTypeAST ast.Type) (Type, error) {
+func typeFromAST(schema *Schema, inputTypeAST ast.Type) (Type, error) {
 	switch inputTypeAST := inputTypeAST.(type) {
 	case *ast.List:
 		innerType, err := typeFromAST(schema, inputTypeAST.Type)


### PR DESCRIPTION
This is an attempt to simplify `graphql.Do` as described in #44. While I greatly enjoy not having to pass in a struct, this appears to remove ability for the user to define `RootValue`, `OperationName` and `VariableValues`. I'm not sure if the struct or just having five arguments is better. Maybe compromise with having a wrapper around `Do` that only takes two arguments for the simple case? I don't know how common it'll be in practice.

This is expected to not pass tests, as I haven't yet updated all the tests to the new API. I'm holding off on that until it's determined what API is ideal.