### PR TITLE
Renames

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -145,7 +145,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Errors: nil,
 	}
 
-	result := graphql.Graphql(graphql.Params{
+	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -277,7 +277,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 		Errors: nil,
 	}
 
-	result := graphql.Graphql(graphql.Params{
+	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -445,7 +445,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		},
 	}
 
-	result := graphql.Graphql(graphql.Params{
+	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -600,7 +600,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		},
 	}
 
-	result := graphql.Graphql(graphql.Params{
+	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})

--- a/abstract_test.go
+++ b/abstract_test.go
@@ -48,7 +48,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name
 					}
@@ -57,7 +57,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs
 					}
@@ -79,7 +79,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name
 					}
@@ -88,7 +88,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows
 					}
@@ -103,7 +103,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.GQLFRParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) interface{} {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -168,7 +168,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name
 					}
@@ -177,7 +177,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs
 					}
@@ -195,7 +195,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name
 					}
@@ -204,7 +204,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows
 					}
@@ -235,7 +235,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.GQLFRParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) interface{} {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -321,7 +321,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if human, ok := p.Source.(*testHuman); ok {
 						return human.Name
 					}
@@ -342,7 +342,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name
 					}
@@ -351,7 +351,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs
 					}
@@ -372,7 +372,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name
 					}
@@ -381,7 +381,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows
 					}
@@ -396,7 +396,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.GQLFRParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) interface{} {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -464,7 +464,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if human, ok := p.Source.(*testHuman); ok {
 						return human.Name
 					}
@@ -482,7 +482,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name
 					}
@@ -491,7 +491,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs
 					}
@@ -509,7 +509,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name
 					}
@@ -518,7 +518,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows
 					}
@@ -551,7 +551,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.GQLFRParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) interface{} {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},

--- a/abstract_test.go
+++ b/abstract_test.go
@@ -28,7 +28,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 
 	petType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "Pet",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -45,7 +45,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			_, ok := value.(*testDog)
 			return ok
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -76,7 +76,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			_, ok := value.(*testCat)
 			return ok
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -100,7 +100,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"pets": &graphql.FieldConfig{
 					Type: graphql.NewList(petType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -165,7 +165,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			_, ok := value.(*testDog)
 			return ok
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -192,7 +192,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			_, ok := value.(*testCat)
 			return ok
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -232,7 +232,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"pets": &graphql.FieldConfig{
 					Type: graphql.NewList(petType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -297,7 +297,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 	var humanType *graphql.Object
 	petType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "Pet",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -318,7 +318,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 
 	humanType = graphql.NewObject(graphql.ObjectConfig{
 		Name: "Human",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -339,7 +339,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			_, ok := value.(*testDog)
 			return ok
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -369,7 +369,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			_, ok := value.(*testCat)
 			return ok
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -393,7 +393,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"pets": &graphql.FieldConfig{
 					Type: graphql.NewList(petType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -461,7 +461,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 
 	humanType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Human",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -479,7 +479,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			_, ok := value.(*testDog)
 			return ok
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -506,7 +506,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			_, ok := value.(*testCat)
 			return ok
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -548,7 +548,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"pets": &graphql.FieldConfig{
 					Type: graphql.NewList(petType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {

--- a/abstract_test.go
+++ b/abstract_test.go
@@ -29,7 +29,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 	petType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "Pet",
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -46,7 +46,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			return ok
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
@@ -55,7 +55,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 					return nil
 				},
 			},
-			"woofs": &graphql.FieldConfig{
+			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
@@ -77,7 +77,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			return ok
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
@@ -86,7 +86,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 					return nil
 				},
 			},
-			"meows": &graphql.FieldConfig{
+			"meows": &graphql.Field{
 				Type: graphql.Boolean,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
@@ -101,7 +101,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"pets": &graphql.FieldConfig{
+				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
 						return []interface{}{
@@ -166,7 +166,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			return ok
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
@@ -175,7 +175,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 					return nil
 				},
 			},
-			"woofs": &graphql.FieldConfig{
+			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
@@ -193,7 +193,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			return ok
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
@@ -202,7 +202,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 					return nil
 				},
 			},
-			"meows": &graphql.FieldConfig{
+			"meows": &graphql.Field{
 				Type: graphql.Boolean,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
@@ -233,7 +233,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"pets": &graphql.FieldConfig{
+				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
 						return []interface{}{
@@ -298,7 +298,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 	petType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "Pet",
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -319,7 +319,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 	humanType = graphql.NewObject(graphql.ObjectConfig{
 		Name: "Human",
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if human, ok := p.Source.(*testHuman); ok {
@@ -340,7 +340,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			return ok
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
@@ -349,7 +349,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 					return nil
 				},
 			},
-			"woofs": &graphql.FieldConfig{
+			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
@@ -370,7 +370,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			return ok
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
@@ -379,7 +379,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 					return nil
 				},
 			},
-			"meows": &graphql.FieldConfig{
+			"meows": &graphql.Field{
 				Type: graphql.Boolean,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
@@ -394,7 +394,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"pets": &graphql.FieldConfig{
+				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
 						return []interface{}{
@@ -462,7 +462,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 	humanType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Human",
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if human, ok := p.Source.(*testHuman); ok {
@@ -480,7 +480,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			return ok
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
@@ -489,7 +489,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 					return nil
 				},
 			},
-			"woofs": &graphql.FieldConfig{
+			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
@@ -507,7 +507,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			return ok
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
@@ -516,7 +516,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 					return nil
 				},
 			},
-			"meows": &graphql.FieldConfig{
+			"meows": &graphql.Field{
 				Type: graphql.Boolean,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
@@ -549,7 +549,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"pets": &graphql.FieldConfig{
+				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
 						return []interface{}{

--- a/definition.go
+++ b/definition.go
@@ -156,8 +156,8 @@ func GetNamed(ttype Type) Named {
  *
  */
 type Scalar struct {
-	name        string `json:"name"`
-	description string `json:"description"`
+	PrivateName        string `json:"name"`
+	PrivateDescription string `json:"description"`
 
 	scalarConfig ScalarConfig
 	err          error
@@ -187,8 +187,8 @@ func NewScalar(config ScalarConfig) *Scalar {
 		return st
 	}
 
-	st.name = config.Name
-	st.description = config.Description
+	st.PrivateName = config.Name
+	st.PrivateDescription = config.Description
 
 	err = invariant(
 		config.Serialize != nil,
@@ -233,14 +233,14 @@ func (st *Scalar) ParseLiteral(valueAST ast.Value) interface{} {
 	return st.scalarConfig.ParseLiteral(valueAST)
 }
 func (st *Scalar) Name() string {
-	return st.name
+	return st.PrivateName
 }
 func (st *Scalar) Description() string {
-	return st.description
+	return st.PrivateDescription
 
 }
 func (st *Scalar) String() string {
-	return st.name
+	return st.PrivateName
 }
 func (st *Scalar) Error() error {
 	return st.err
@@ -284,9 +284,9 @@ func (st *Scalar) Error() error {
  *
  */
 type Object struct {
-	name        string `json:"name"`
-	description string `json:"description"`
-	IsTypeOf    IsTypeOfFn
+	PrivateName        string `json:"name"`
+	PrivateDescription string `json:"description"`
+	IsTypeOf           IsTypeOfFn
 
 	typeConfig ObjectConfig
 	fields     FieldDefinitionMap
@@ -321,8 +321,8 @@ func NewObject(config ObjectConfig) *Object {
 		return objectType
 	}
 
-	objectType.name = config.Name
-	objectType.description = config.Description
+	objectType.PrivateName = config.Name
+	objectType.PrivateDescription = config.Description
 	objectType.IsTypeOf = config.IsTypeOf
 	objectType.typeConfig = config
 
@@ -351,13 +351,13 @@ func (gt *Object) AddFieldConfig(fieldName string, fieldConfig *Field) {
 
 }
 func (gt *Object) Name() string {
-	return gt.name
+	return gt.PrivateName
 }
 func (gt *Object) Description() string {
 	return ""
 }
 func (gt *Object) String() string {
-	return gt.name
+	return gt.PrivateName
 }
 func (gt *Object) Fields() FieldDefinitionMap {
 	fields, err := defineFieldMap(gt, gt.typeConfig.Fields)
@@ -477,10 +477,10 @@ func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 				return resultFieldMap, err
 			}
 			fieldArg := &Argument{
-				name:         argName,
-				description:  arg.Description,
-				Type:         arg.Type,
-				DefaultValue: arg.DefaultValue,
+				PrivateName:        argName,
+				PrivateDescription: arg.Description,
+				Type:               arg.Type,
+				DefaultValue:       arg.DefaultValue,
 			}
 			fieldDef.Args = append(fieldDef.Args, fieldArg)
 		}
@@ -549,21 +549,21 @@ type FieldArgument struct {
 }
 
 type Argument struct {
-	name         string      `json:"name"`
-	Type         Input       `json:"type"`
-	DefaultValue interface{} `json:"defaultValue"`
-	description  string      `json:"description"`
+	PrivateName        string      `json:"name"`
+	Type               Input       `json:"type"`
+	DefaultValue       interface{} `json:"defaultValue"`
+	PrivateDescription string      `json:"description"`
 }
 
 func (st *Argument) Name() string {
-	return st.name
+	return st.PrivateName
 }
 func (st *Argument) Description() string {
-	return st.description
+	return st.PrivateDescription
 
 }
 func (st *Argument) String() string {
-	return st.name
+	return st.PrivateName
 }
 func (st *Argument) Error() error {
 	return nil
@@ -588,9 +588,9 @@ func (st *Argument) Error() error {
  *
  */
 type Interface struct {
-	name        string `json:"name"`
-	description string `json:"description"`
-	ResolveType ResolveTypeFn
+	PrivateName        string `json:"name"`
+	PrivateDescription string `json:"description"`
+	ResolveType        ResolveTypeFn
 
 	typeConfig      InterfaceConfig
 	fields          FieldDefinitionMap
@@ -620,8 +620,8 @@ func NewInterface(config InterfaceConfig) *Interface {
 		it.err = err
 		return it
 	}
-	it.name = config.Name
-	it.description = config.Description
+	it.PrivateName = config.Name
+	it.PrivateDescription = config.Description
 	it.ResolveType = config.ResolveType
 	it.typeConfig = config
 	it.implementations = []*Object{}
@@ -636,10 +636,10 @@ func (it *Interface) AddFieldConfig(fieldName string, fieldConfig *Field) {
 	it.typeConfig.Fields[fieldName] = fieldConfig
 }
 func (it *Interface) Name() string {
-	return it.name
+	return it.PrivateName
 }
 func (it *Interface) Description() string {
-	return it.description
+	return it.PrivateDescription
 }
 func (it *Interface) Fields() (fields FieldDefinitionMap) {
 	it.fields, it.err = defineFieldMap(it, it.typeConfig.Fields)
@@ -658,11 +658,11 @@ func (it *Interface) IsPossibleType(ttype *Object) bool {
 			if possibleType == nil {
 				continue
 			}
-			possibleTypes[possibleType.name] = true
+			possibleTypes[possibleType.PrivateName] = true
 		}
 		it.possibleTypes = possibleTypes
 	}
-	if val, ok := it.possibleTypes[ttype.name]; ok {
+	if val, ok := it.possibleTypes[ttype.PrivateName]; ok {
 		return val
 	}
 	return false
@@ -674,7 +674,7 @@ func (it *Interface) ObjectType(value interface{}, info ResolveInfo) *Object {
 	return getTypeOf(value, info, it)
 }
 func (it *Interface) String() string {
-	return it.name
+	return it.PrivateName
 }
 func (it *Interface) Error() error {
 	return it.err
@@ -717,9 +717,9 @@ func getTypeOf(value interface{}, info ResolveInfo, abstractType Abstract) *Obje
  *
  */
 type Union struct {
-	name        string `json:"name"`
-	description string `json:"description"`
-	ResolveType ResolveTypeFn
+	PrivateName        string `json:"name"`
+	PrivateDescription string `json:"description"`
+	ResolveType        ResolveTypeFn
 
 	typeConfig    UnionConfig
 	types         []*Object
@@ -747,8 +747,8 @@ func NewUnion(config UnionConfig) *Union {
 		objectType.err = err
 		return objectType
 	}
-	objectType.name = config.Name
-	objectType.description = config.Description
+	objectType.PrivateName = config.Name
+	objectType.PrivateDescription = config.Description
 	objectType.ResolveType = config.ResolveType
 
 	err = invariant(
@@ -801,12 +801,12 @@ func (ut *Union) IsPossibleType(ttype *Object) bool {
 			if possibleType == nil {
 				continue
 			}
-			possibleTypes[possibleType.name] = true
+			possibleTypes[possibleType.PrivateName] = true
 		}
 		ut.possibleTypes = possibleTypes
 	}
 
-	if val, ok := ut.possibleTypes[ttype.name]; ok {
+	if val, ok := ut.possibleTypes[ttype.PrivateName]; ok {
 		return val
 	}
 	return false
@@ -818,13 +818,13 @@ func (ut *Union) ObjectType(value interface{}, info ResolveInfo) *Object {
 	return getTypeOf(value, info, ut)
 }
 func (ut *Union) String() string {
-	return ut.name
+	return ut.PrivateName
 }
 func (ut *Union) Name() string {
-	return ut.name
+	return ut.PrivateName
 }
 func (ut *Union) Description() string {
-	return ut.description
+	return ut.PrivateDescription
 }
 func (ut *Union) Error() error {
 	return ut.err
@@ -852,8 +852,8 @@ func (ut *Union) Error() error {
  * will be used as it's internal value.
  */
 type Enum struct {
-	name        string `json:"name"`
-	description string `json:"description"`
+	PrivateName        string `json:"name"`
+	PrivateDescription string `json:"description"`
 
 	enumConfig   EnumConfig
 	values       []*EnumValueDefinition
@@ -890,8 +890,8 @@ func NewEnum(config EnumConfig) *Enum {
 		return gt
 	}
 
-	gt.name = config.Name
-	gt.description = config.Description
+	gt.PrivateName = config.Name
+	gt.PrivateDescription = config.Description
 	gt.values, err = gt.defineEnumValues(config.Values)
 	if err != nil {
 		gt.err = err
@@ -965,13 +965,13 @@ func (gt *Enum) ParseLiteral(valueAST ast.Value) interface{} {
 	return nil
 }
 func (gt *Enum) Name() string {
-	return gt.name
+	return gt.PrivateName
 }
 func (gt *Enum) Description() string {
 	return ""
 }
 func (gt *Enum) String() string {
-	return gt.name
+	return gt.PrivateName
 }
 func (gt *Enum) Error() error {
 	return gt.err
@@ -1021,8 +1021,8 @@ func (gt *Enum) getNameLookup() map[string]*EnumValueDefinition {
  *
  */
 type InputObject struct {
-	name        string `json:"name"`
-	description string `json:"description"`
+	PrivateName        string `json:"name"`
+	PrivateDescription string `json:"description"`
 
 	typeConfig InputObjectConfig
 	fields     InputObjectFieldMap
@@ -1035,21 +1035,21 @@ type InputObjectFieldConfig struct {
 	Description  string      `json:"description"`
 }
 type InputObjectField struct {
-	name         string      `json:"name"`
-	Type         Input       `json:"type"`
-	DefaultValue interface{} `json:"defaultValue"`
-	description  string      `json:"description"`
+	PrivateName        string      `json:"name"`
+	Type               Input       `json:"type"`
+	DefaultValue       interface{} `json:"defaultValue"`
+	PrivateDescription string      `json:"description"`
 }
 
 func (st *InputObjectField) Name() string {
-	return st.name
+	return st.PrivateName
 }
 func (st *InputObjectField) Description() string {
-	return st.description
+	return st.PrivateDescription
 
 }
 func (st *InputObjectField) String() string {
-	return st.name
+	return st.PrivateName
 }
 func (st *InputObjectField) Error() error {
 	return nil
@@ -1073,8 +1073,8 @@ func NewInputObject(config InputObjectConfig) *InputObject {
 		return gt
 	}
 
-	gt.name = config.Name
-	gt.description = config.Description
+	gt.PrivateName = config.Name
+	gt.PrivateDescription = config.Description
 	gt.typeConfig = config
 	gt.fields = gt.defineFieldMap()
 	return gt
@@ -1116,9 +1116,9 @@ func (gt *InputObject) defineFieldMap() InputObjectFieldMap {
 			return resultFieldMap
 		}
 		field := &InputObjectField{}
-		field.name = fieldName
+		field.PrivateName = fieldName
 		field.Type = fieldConfig.Type
-		field.description = fieldConfig.Description
+		field.PrivateDescription = fieldConfig.Description
 		field.DefaultValue = fieldConfig.DefaultValue
 		resultFieldMap[fieldName] = field
 	}
@@ -1128,13 +1128,13 @@ func (gt *InputObject) Fields() InputObjectFieldMap {
 	return gt.fields
 }
 func (gt *InputObject) Name() string {
-	return gt.name
+	return gt.PrivateName
 }
 func (gt *InputObject) Description() string {
-	return gt.description
+	return gt.PrivateDescription
 }
 func (gt *InputObject) String() string {
-	return gt.name
+	return gt.PrivateName
 }
 func (gt *InputObject) Error() error {
 	return gt.err
@@ -1213,8 +1213,8 @@ func (gl *List) Error() error {
  * Note: the enforcement of non-nullability occurs within the executor.
  */
 type NonNull struct {
-	name   string `json:"name"` // added to conform with introspection for NonNull.Name = nil
-	OfType Type   `json:"ofType"`
+	PrivateName string `json:"name"` // added to conform with introspection for NonNull.Name = nil
+	OfType      Type   `json:"ofType"`
 
 	err error
 }

--- a/definition.go
+++ b/definition.go
@@ -343,7 +343,7 @@ func NewObject(config ObjectConfig) *Object {
 
 	return objectType
 }
-func (gt *Object) AddFieldConfig(fieldName string, fieldConfig *FieldConfig) {
+func (gt *Object) AddFieldConfig(fieldName string, fieldConfig *Field) {
 	if fieldName == "" || fieldConfig == nil {
 		return
 	}
@@ -512,9 +512,9 @@ type ResolveInfo struct {
 	VariableValues map[string]interface{}
 }
 
-type Fields map[string]*FieldConfig
+type Fields map[string]*Field
 
-type FieldConfig struct {
+type Field struct {
 	Name              string              `json:"name"` // used by graphlql-relay
 	Type              Output              `json:"type"`
 	Args              FieldConfigArgument `json:"args"`
@@ -629,7 +629,7 @@ func NewInterface(config InterfaceConfig) *Interface {
 	return it
 }
 
-func (it *Interface) AddFieldConfig(fieldName string, fieldConfig *FieldConfig) {
+func (it *Interface) AddFieldConfig(fieldName string, fieldConfig *Field) {
 	if fieldName == "" || fieldConfig == nil {
 		return
 	}

--- a/definition.go
+++ b/definition.go
@@ -490,7 +490,7 @@ func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 }
 
 // TODO: clean up GQLFRParams fields
-type GQLFRParams struct {
+type ResolveParams struct {
 	Source interface{}
 	Args   map[string]interface{}
 	Info   ResolveInfo
@@ -498,7 +498,7 @@ type GQLFRParams struct {
 }
 
 // TODO: relook at FieldResolveFn params
-type FieldResolveFn func(p GQLFRParams) interface{}
+type FieldResolveFn func(p ResolveParams) interface{}
 
 type ResolveInfo struct {
 	FieldName      string

--- a/definition.go
+++ b/definition.go
@@ -300,11 +300,11 @@ type IsTypeOfFn func(value interface{}, info ResolveInfo) bool
 type InterfacesThunk func() []*Interface
 
 type ObjectConfig struct {
-	Name        string         `json:"description"`
-	Interfaces  interface{}    `json:"interfaces"`
-	Fields      FieldConfigMap `json:"fields"`
-	IsTypeOf    IsTypeOfFn     `json:"isTypeOf"`
-	Description string         `json:"description"`
+	Name        string      `json:"description"`
+	Interfaces  interface{} `json:"interfaces"`
+	Fields      Fields      `json:"fields"`
+	IsTypeOf    IsTypeOfFn  `json:"isTypeOf"`
+	Description string      `json:"description"`
 }
 
 func NewObject(config ObjectConfig) *Object {
@@ -418,7 +418,7 @@ func defineInterfaces(ttype *Object, interfaces []*Interface) ([]*Interface, err
 	return ifaces, nil
 }
 
-func defineFieldMap(ttype Named, fields FieldConfigMap) (FieldDefinitionMap, error) {
+func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 
 	resultFieldMap := FieldDefinitionMap{}
 
@@ -512,7 +512,7 @@ type ResolveInfo struct {
 	VariableValues map[string]interface{}
 }
 
-type FieldConfigMap map[string]*FieldConfig
+type Fields map[string]*FieldConfig
 
 type FieldConfig struct {
 	Name              string              `json:"name"` // used by graphlql-relay
@@ -600,8 +600,8 @@ type Interface struct {
 	err error
 }
 type InterfaceConfig struct {
-	Name        string         `json:"name"`
-	Fields      FieldConfigMap `json:"fields"`
+	Name        string `json:"name"`
+	Fields      Fields `json:"fields"`
 	ResolveType ResolveTypeFn
 	Description string `json:"description"`
 }

--- a/definition_test.go
+++ b/definition_test.go
@@ -12,13 +12,13 @@ import (
 var blogImage = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Image",
 	Fields: graphql.Fields{
-		"url": &graphql.FieldConfig{
+		"url": &graphql.Field{
 			Type: graphql.String,
 		},
-		"width": &graphql.FieldConfig{
+		"width": &graphql.Field{
 			Type: graphql.Int,
 		},
-		"height": &graphql.FieldConfig{
+		"height": &graphql.Field{
 			Type: graphql.Int,
 		},
 	},
@@ -26,13 +26,13 @@ var blogImage = graphql.NewObject(graphql.ObjectConfig{
 var blogAuthor = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Author",
 	Fields: graphql.Fields{
-		"id": &graphql.FieldConfig{
+		"id": &graphql.Field{
 			Type: graphql.String,
 		},
-		"name": &graphql.FieldConfig{
+		"name": &graphql.Field{
 			Type: graphql.String,
 		},
-		"pic": &graphql.FieldConfig{
+		"pic": &graphql.Field{
 			Type: blogImage,
 			Args: graphql.FieldConfigArgument{
 				"width": &graphql.ArgumentConfig{
@@ -43,25 +43,25 @@ var blogAuthor = graphql.NewObject(graphql.ObjectConfig{
 				},
 			},
 		},
-		"recentArticle": &graphql.FieldConfig{},
+		"recentArticle": &graphql.Field{},
 	},
 })
 var blogArticle = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Article",
 	Fields: graphql.Fields{
-		"id": &graphql.FieldConfig{
+		"id": &graphql.Field{
 			Type: graphql.String,
 		},
-		"isPublished": &graphql.FieldConfig{
+		"isPublished": &graphql.Field{
 			Type: graphql.Boolean,
 		},
-		"author": &graphql.FieldConfig{
+		"author": &graphql.Field{
 			Type: blogAuthor,
 		},
-		"title": &graphql.FieldConfig{
+		"title": &graphql.Field{
 			Type: graphql.String,
 		},
-		"body": &graphql.FieldConfig{
+		"body": &graphql.Field{
 			Type: graphql.String,
 		},
 	},
@@ -69,7 +69,7 @@ var blogArticle = graphql.NewObject(graphql.ObjectConfig{
 var blogQuery = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Query",
 	Fields: graphql.Fields{
-		"article": &graphql.FieldConfig{
+		"article": &graphql.Field{
 			Type: blogArticle,
 			Args: graphql.FieldConfigArgument{
 				"id": &graphql.ArgumentConfig{
@@ -77,7 +77,7 @@ var blogQuery = graphql.NewObject(graphql.ObjectConfig{
 				},
 			},
 		},
-		"feed": &graphql.FieldConfig{
+		"feed": &graphql.Field{
 			Type: graphql.NewList(blogArticle),
 		},
 	},
@@ -86,7 +86,7 @@ var blogQuery = graphql.NewObject(graphql.ObjectConfig{
 var blogMutation = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Mutation",
 	Fields: graphql.Fields{
-		"writeArticle": &graphql.FieldConfig{
+		"writeArticle": &graphql.Field{
 			Type: blogArticle,
 		},
 	},
@@ -118,7 +118,7 @@ var inputObjectType = graphql.NewInputObject(graphql.InputObjectConfig{
 })
 
 func init() {
-	blogAuthor.AddFieldConfig("recentArticle", &graphql.FieldConfig{
+	blogAuthor.AddFieldConfig("recentArticle", &graphql.Field{
 		Type: blogArticle,
 	})
 }
@@ -247,7 +247,7 @@ func TestTypeSystem_DefinitionExample_IncludesNestedInputObjectsInTheMap(t *test
 	someMutation := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeMutation",
 		Fields: graphql.Fields{
-			"mutateSomething": &graphql.FieldConfig{
+			"mutateSomething": &graphql.Field{
 				Type: blogArticle,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -274,7 +274,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesSubTypesInTheTypeMap(t *
 	someInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "SomeInterface",
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.Int,
 			},
 		},
@@ -283,7 +283,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesSubTypesInTheTypeMap(t *
 	someSubType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeSubtype",
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.Int,
 			},
 		},
@@ -296,7 +296,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesSubTypesInTheTypeMap(t *
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"iface": &graphql.FieldConfig{
+				"iface": &graphql.Field{
 					Type: someInterface,
 				},
 			},
@@ -315,7 +315,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesThunkSubtypesInTheTypeMa
 	someInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "SomeInterface",
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.Int,
 			},
 		},
@@ -324,7 +324,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesThunkSubtypesInTheTypeMa
 	someSubType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeSubtype",
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.Int,
 			},
 		},
@@ -339,7 +339,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesThunkSubtypesInTheTypeMa
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"iface": &graphql.FieldConfig{
+				"iface": &graphql.Field{
 					Type: someInterface,
 				},
 			},
@@ -460,10 +460,10 @@ func TestTypeSystem_DefinitionExample_ProhibitsNilTypeInUnions(t *testing.T) {
 }
 func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *testing.T) {
 	fields := graphql.Fields{
-		"field1": &graphql.FieldConfig{
+		"field1": &graphql.Field{
 			Type: graphql.String,
 		},
-		"field2": &graphql.FieldConfig{
+		"field2": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"id": &graphql.ArgumentConfig{
@@ -485,10 +485,10 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 	}
 
 	expectedFields := graphql.Fields{
-		"field1": &graphql.FieldConfig{
+		"field1": &graphql.Field{
 			Type: graphql.String,
 		},
-		"field2": &graphql.FieldConfig{
+		"field2": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"id": &graphql.ArgumentConfig{

--- a/definition_test.go
+++ b/definition_test.go
@@ -131,11 +131,11 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
 
-	if blogSchema.GetQueryType() != blogQuery {
+	if blogSchema.QueryType() != blogQuery {
 		t.Fatalf("expected blogSchema.GetQueryType() == blogQuery")
 	}
 
-	articleField, _ := blogQuery.GetFields()["article"]
+	articleField, _ := blogQuery.Fields()["article"]
 	if articleField == nil {
 		t.Fatalf("articleField is nil")
 	}
@@ -143,8 +143,8 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 	if articleFieldType != blogArticle {
 		t.Fatalf("articleFieldType expected to equal blogArticle, got: %v", articleField.Type)
 	}
-	if articleFieldType.GetName() != "Article" {
-		t.Fatalf("articleFieldType.Name expected to equal `Article`, got: %v", articleField.Type.GetName())
+	if articleFieldType.Name() != "Article" {
+		t.Fatalf("articleFieldType.Name expected to equal `Article`, got: %v", articleField.Type.Name())
 	}
 	if articleField.Name != "article" {
 		t.Fatalf("articleField.Name expected to equal `article`, got: %v", articleField.Name)
@@ -155,7 +155,7 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 	}
 
 	// TODO: expose a Object.GetField(key string), instead of this ghetto way of accessing a field map?
-	titleField := articleFieldTypeObject.GetFields()["title"]
+	titleField := articleFieldTypeObject.Fields()["title"]
 	if titleField == nil {
 		t.Fatalf("titleField is nil")
 	}
@@ -165,11 +165,11 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 	if titleField.Type != graphql.String {
 		t.Fatalf("titleField.Type expected to equal graphql.String, got: %v", titleField.Type)
 	}
-	if titleField.Type.GetName() != "String" {
-		t.Fatalf("titleField.Type.GetName() expected to equal `String`, got: %v", titleField.Type.GetName())
+	if titleField.Type.Name() != "String" {
+		t.Fatalf("titleField.Type.GetName() expected to equal `String`, got: %v", titleField.Type.Name())
 	}
 
-	authorField := articleFieldTypeObject.GetFields()["author"]
+	authorField := articleFieldTypeObject.Fields()["author"]
 	if authorField == nil {
 		t.Fatalf("authorField is nil")
 	}
@@ -178,7 +178,7 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 		t.Fatalf("expected authorField.Type to be Object`, got: %v", authorField)
 	}
 
-	recentArticleField := authorFieldObject.GetFields()["recentArticle"]
+	recentArticleField := authorFieldObject.Fields()["recentArticle"]
 	if recentArticleField == nil {
 		t.Fatalf("recentArticleField is nil")
 	}
@@ -186,7 +186,7 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 		t.Fatalf("recentArticleField.Type expected to equal blogArticle, got: %v", recentArticleField.Type)
 	}
 
-	feedField := blogQuery.GetFields()["feed"]
+	feedField := blogQuery.Fields()["feed"]
 	feedFieldList, ok := feedField.Type.(*graphql.List)
 	if !ok {
 		t.Fatalf("expected feedFieldList to be List`, got: %v", authorField)
@@ -207,11 +207,11 @@ func TestTypeSystem_DefinitionExample_DefinesAMutationScheme(t *testing.T) {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
 
-	if blogSchema.GetMutationType() != blogMutation {
+	if blogSchema.MutationType() != blogMutation {
 		t.Fatalf("expected blogSchema.GetMutationType() == blogMutation")
 	}
 
-	writeMutation, _ := blogMutation.GetFields()["writeArticle"]
+	writeMutation, _ := blogMutation.Fields()["writeArticle"]
 	if writeMutation == nil {
 		t.Fatalf("writeMutation is nil")
 	}
@@ -219,8 +219,8 @@ func TestTypeSystem_DefinitionExample_DefinesAMutationScheme(t *testing.T) {
 	if writeMutationType != blogArticle {
 		t.Fatalf("writeMutationType expected to equal blogArticle, got: %v", writeMutationType)
 	}
-	if writeMutationType.GetName() != "Article" {
-		t.Fatalf("writeMutationType.Name expected to equal `Article`, got: %v", writeMutationType.GetName())
+	if writeMutationType.Name() != "Article" {
+		t.Fatalf("writeMutationType.Name expected to equal `Article`, got: %v", writeMutationType.Name())
 	}
 	if writeMutation.Name != "writeArticle" {
 		t.Fatalf("writeMutation.Name expected to equal `writeArticle`, got: %v", writeMutation.Name)
@@ -264,8 +264,8 @@ func TestTypeSystem_DefinitionExample_IncludesNestedInputObjectsInTheMap(t *test
 	if err != nil {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
-	if schema.GetType("NestedInputObject") != nestedInputObject {
-		t.Fatalf(`schema.GetType("NestedInputObject") expected to equal nestedInputObject, got: %v`, schema.GetType("NestedInputObject"))
+	if schema.Type("NestedInputObject") != nestedInputObject {
+		t.Fatalf(`schema.GetType("NestedInputObject") expected to equal nestedInputObject, got: %v`, schema.Type("NestedInputObject"))
 	}
 }
 
@@ -305,8 +305,8 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesSubTypesInTheTypeMap(t *
 	if err != nil {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
-	if schema.GetType("SomeSubtype") != someSubType {
-		t.Fatalf(`schema.GetType("SomeSubtype") expected to equal someSubType, got: %v`, schema.GetType("SomeSubtype"))
+	if schema.Type("SomeSubtype") != someSubType {
+		t.Fatalf(`schema.GetType("SomeSubtype") expected to equal someSubType, got: %v`, schema.Type("SomeSubtype"))
 	}
 }
 
@@ -348,8 +348,8 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesThunkSubtypesInTheTypeMa
 	if err != nil {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
-	if schema.GetType("SomeSubtype") != someSubType {
-		t.Fatalf(`schema.GetType("SomeSubtype") expected to equal someSubType, got: %v`, schema.GetType("SomeSubtype"))
+	if schema.Type("SomeSubtype") != someSubType {
+		t.Fatalf(`schema.GetType("SomeSubtype") expected to equal someSubType, got: %v`, schema.Type("SomeSubtype"))
 	}
 }
 
@@ -437,15 +437,15 @@ func TestTypeSystem_DefinitionExample_IdentifiesOutputTypes(t *testing.T) {
 func TestTypeSystem_DefinitionExample_ProhibitsNestingNonNullInsideNonNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewNonNull(graphql.Int))
 	expected := `Can only create NonNull of a Nullable Type but got: Int!.`
-	if ttype.GetError().Error() != expected {
-		t.Fatalf(`expected %v , got: %v`, expected, ttype.GetError())
+	if ttype.Error().Error() != expected {
+		t.Fatalf(`expected %v , got: %v`, expected, ttype.Error())
 	}
 }
 func TestTypeSystem_DefinitionExample_ProhibitsNilInNonNull(t *testing.T) {
 	ttype := graphql.NewNonNull(nil)
 	expected := `Can only create NonNull of a Nullable Type but got: <nil>.`
-	if ttype.GetError().Error() != expected {
-		t.Fatalf(`expected %v , got: %v`, expected, ttype.GetError())
+	if ttype.Error().Error() != expected {
+		t.Fatalf(`expected %v , got: %v`, expected, ttype.Error())
 	}
 }
 func TestTypeSystem_DefinitionExample_ProhibitsNilTypeInUnions(t *testing.T) {
@@ -454,8 +454,8 @@ func TestTypeSystem_DefinitionExample_ProhibitsNilTypeInUnions(t *testing.T) {
 		Types: []*graphql.Object{nil},
 	})
 	expected := `BadUnion may only contain Object types, it cannot contain: <nil>.`
-	if ttype.GetError().Error() != expected {
-		t.Fatalf(`expected %v , got: %v`, expected, ttype.GetError())
+	if ttype.Error().Error() != expected {
+		t.Fatalf(`expected %v , got: %v`, expected, ttype.Error())
 	}
 }
 func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *testing.T) {
@@ -480,8 +480,8 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 		Name:   "Test2",
 		Fields: fields,
 	})
-	if !reflect.DeepEqual(testObject1.GetFields(), testObject2.GetFields()) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(testObject1.GetFields(), testObject2.GetFields()))
+	if !reflect.DeepEqual(testObject1.Fields(), testObject2.Fields()) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(testObject1.Fields(), testObject2.Fields()))
 	}
 
 	expectedFields := graphql.Fields{
@@ -525,8 +525,8 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 		Name:   "Test2",
 		Fields: inputFields,
 	})
-	if !reflect.DeepEqual(testInputObject1.GetFields(), testInputObject2.GetFields()) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(testInputObject1.GetFields(), testInputObject2.GetFields()))
+	if !reflect.DeepEqual(testInputObject1.Fields(), testInputObject2.Fields()) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(testInputObject1.Fields(), testInputObject2.Fields()))
 	}
 	if !reflect.DeepEqual(inputFields, expectedInputFields) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedInputFields, fields))

--- a/definition_test.go
+++ b/definition_test.go
@@ -11,7 +11,7 @@ import (
 
 var blogImage = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Image",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"url": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -25,7 +25,7 @@ var blogImage = graphql.NewObject(graphql.ObjectConfig{
 })
 var blogAuthor = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Author",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"id": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -48,7 +48,7 @@ var blogAuthor = graphql.NewObject(graphql.ObjectConfig{
 })
 var blogArticle = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Article",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"id": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -68,7 +68,7 @@ var blogArticle = graphql.NewObject(graphql.ObjectConfig{
 })
 var blogQuery = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Query",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"article": &graphql.FieldConfig{
 			Type: blogArticle,
 			Args: graphql.FieldConfigArgument{
@@ -85,7 +85,7 @@ var blogQuery = graphql.NewObject(graphql.ObjectConfig{
 
 var blogMutation = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Mutation",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"writeArticle": &graphql.FieldConfig{
 			Type: blogArticle,
 		},
@@ -246,7 +246,7 @@ func TestTypeSystem_DefinitionExample_IncludesNestedInputObjectsInTheMap(t *test
 	})
 	someMutation := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeMutation",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"mutateSomething": &graphql.FieldConfig{
 				Type: blogArticle,
 				Args: graphql.FieldConfigArgument{
@@ -273,7 +273,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesSubTypesInTheTypeMap(t *
 
 	someInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "SomeInterface",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.Int,
 			},
@@ -282,7 +282,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesSubTypesInTheTypeMap(t *
 
 	someSubType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeSubtype",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.Int,
 			},
@@ -295,7 +295,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesSubTypesInTheTypeMap(t *
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"iface": &graphql.FieldConfig{
 					Type: someInterface,
 				},
@@ -314,7 +314,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesThunkSubtypesInTheTypeMa
 
 	someInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "SomeInterface",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.Int,
 			},
@@ -323,7 +323,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesThunkSubtypesInTheTypeMa
 
 	someSubType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeSubtype",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.Int,
 			},
@@ -338,7 +338,7 @@ func TestTypeSystem_DefinitionExample_IncludesInterfacesThunkSubtypesInTheTypeMa
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"iface": &graphql.FieldConfig{
 					Type: someInterface,
 				},
@@ -459,7 +459,7 @@ func TestTypeSystem_DefinitionExample_ProhibitsNilTypeInUnions(t *testing.T) {
 	}
 }
 func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *testing.T) {
-	fields := graphql.FieldConfigMap{
+	fields := graphql.Fields{
 		"field1": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -484,7 +484,7 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(testObject1.GetFields(), testObject2.GetFields()))
 	}
 
-	expectedFields := graphql.FieldConfigMap{
+	expectedFields := graphql.Fields{
 		"field1": &graphql.FieldConfig{
 			Type: graphql.String,
 		},

--- a/directives.go
+++ b/directives.go
@@ -36,9 +36,9 @@ var IncludeDirective *Directive = NewDirective(&Directive{
 		"the `if` argument is true.",
 	Args: []*Argument{
 		&Argument{
-			name:        "if",
-			Type:        NewNonNull(Boolean),
-			description: "Included when true.",
+			PrivateName:        "if",
+			Type:               NewNonNull(Boolean),
+			PrivateDescription: "Included when true.",
 		},
 	},
 	OnOperation: false,
@@ -55,9 +55,9 @@ var SkipDirective *Directive = NewDirective(&Directive{
 		"argument is true.",
 	Args: []*Argument{
 		&Argument{
-			name:        "if",
-			Type:        NewNonNull(Boolean),
-			description: "Skipped when true.",
+			PrivateName:        "if",
+			Type:               NewNonNull(Boolean),
+			PrivateDescription: "Skipped when true.",
 		},
 	},
 	OnOperation: false,

--- a/directives.go
+++ b/directives.go
@@ -36,9 +36,9 @@ var IncludeDirective *Directive = NewDirective(&Directive{
 		"the `if` argument is true.",
 	Args: []*Argument{
 		&Argument{
-			Name:        "if",
+			name:        "if",
 			Type:        NewNonNull(Boolean),
-			Description: "Included when true.",
+			description: "Included when true.",
 		},
 	},
 	OnOperation: false,
@@ -55,9 +55,9 @@ var SkipDirective *Directive = NewDirective(&Directive{
 		"argument is true.",
 	Args: []*Argument{
 		&Argument{
-			Name:        "if",
+			name:        "if",
 			Type:        NewNonNull(Boolean),
-			Description: "Skipped when true.",
+			description: "Skipped when true.",
 		},
 	},
 	OnOperation: false,

--- a/directives_test.go
+++ b/directives_test.go
@@ -11,7 +11,7 @@ import (
 var directivesTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 	Query: graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"a": &graphql.FieldConfig{
 				Type: graphql.String,
 			},

--- a/directives_test.go
+++ b/directives_test.go
@@ -12,10 +12,10 @@ var directivesTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 	Query: graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
 		Fields: graphql.Fields{
-			"a": &graphql.FieldConfig{
+			"a": &graphql.Field{
 				Type: graphql.String,
 			},
-			"b": &graphql.FieldConfig{
+			"b": &graphql.Field{
 				Type: graphql.String,
 			},
 		},

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -39,7 +39,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.String,
 				},
 			},
-			Resolve: func(p graphql.GQLFRParams) interface{} {
+			Resolve: func(p graphql.ResolveParams) interface{} {
 				if fromInt, ok := p.Args["fromInt"]; ok {
 					return fromInt
 				}
@@ -62,7 +62,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.Int,
 				},
 			},
-			Resolve: func(p graphql.GQLFRParams) interface{} {
+			Resolve: func(p graphql.ResolveParams) interface{} {
 				if fromInt, ok := p.Args["fromInt"]; ok {
 					return fromInt
 				}
@@ -84,7 +84,7 @@ var enumTypeTestMutationType = graphql.NewObject(graphql.ObjectConfig{
 					Type: enumTypeTestColorType,
 				},
 			},
-			Resolve: func(p graphql.GQLFRParams) interface{} {
+			Resolve: func(p graphql.ResolveParams) interface{} {
 				if color, ok := p.Args["color"]; ok {
 					return color
 				}

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -26,7 +26,7 @@ var enumTypeTestColorType = graphql.NewEnum(graphql.EnumConfig{
 var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Query",
 	Fields: graphql.Fields{
-		"colorEnum": &graphql.FieldConfig{
+		"colorEnum": &graphql.Field{
 			Type: enumTypeTestColorType,
 			Args: graphql.FieldConfigArgument{
 				"fromEnum": &graphql.ArgumentConfig{
@@ -52,7 +52,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 				return nil
 			},
 		},
-		"colorInt": &graphql.FieldConfig{
+		"colorInt": &graphql.Field{
 			Type: graphql.Int,
 			Args: graphql.FieldConfigArgument{
 				"fromEnum": &graphql.ArgumentConfig{
@@ -77,7 +77,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 var enumTypeTestMutationType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Mutation",
 	Fields: graphql.Fields{
-		"favoriteEnum": &graphql.FieldConfig{
+		"favoriteEnum": &graphql.Field{
 			Type: enumTypeTestColorType,
 			Args: graphql.FieldConfigArgument{
 				"color": &graphql.ArgumentConfig{

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -25,7 +25,7 @@ var enumTypeTestColorType = graphql.NewEnum(graphql.EnumConfig{
 })
 var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Query",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"colorEnum": &graphql.FieldConfig{
 			Type: enumTypeTestColorType,
 			Args: graphql.FieldConfigArgument{
@@ -76,7 +76,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 })
 var enumTypeTestMutationType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Mutation",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"favoriteEnum": &graphql.FieldConfig{
 			Type: enumTypeTestColorType,
 			Args: graphql.FieldConfigArgument{

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -32,7 +32,7 @@ func main() {
 		}
 	`
 	params := graphql.Params{Schema: schema, RequestString: query}
-	r := graphql.Graphql(params)
+	r := graphql.Do(params)
 	if len(r.Errors) > 0 {
 		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
 	}

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	// Schema
-	fields := graphql.FieldConfigMap{
+	fields := graphql.Fields{
 		"hello": &graphql.FieldConfig{
 			Type: graphql.String,
 			Resolve: func(p graphql.GQLFRParams) interface{} {

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	// Schema
 	fields := graphql.Fields{
-		"hello": &graphql.FieldConfig{
+		"hello": &graphql.Field{
 			Type: graphql.String,
 			Resolve: func(p graphql.GQLFRParams) interface{} {
 				return "world"

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -13,7 +13,7 @@ func main() {
 	fields := graphql.Fields{
 		"hello": &graphql.Field{
 			Type: graphql.String,
-			Resolve: func(p graphql.GQLFRParams) interface{} {
+			Resolve: func(p graphql.ResolveParams) interface{} {
 				return "world"
 			},
 		},

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -74,7 +74,7 @@ var schema, _ = graphql.NewSchema(
 )
 
 func executeQuery(query string, schema graphql.Schema) *graphql.Result {
-	result := graphql.Graphql(graphql.Params{
+	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -25,7 +25,7 @@ var data map[string]user
 var userType = graphql.NewObject(
 	graphql.ObjectConfig{
 		Name: "User",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"id": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -48,7 +48,7 @@ var userType = graphql.NewObject(
 var queryType = graphql.NewObject(
 	graphql.ObjectConfig{
 		Name: "Query",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"user": &graphql.FieldConfig{
 				Type: userType,
 				Args: graphql.FieldConfigArgument{

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -56,7 +56,7 @@ var queryType = graphql.NewObject(
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					idQuery, isOK := p.Args["id"].(string)
 					if isOK {
 						return data[idQuery]

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -26,10 +26,10 @@ var userType = graphql.NewObject(
 	graphql.ObjectConfig{
 		Name: "User",
 		Fields: graphql.Fields{
-			"id": &graphql.FieldConfig{
+			"id": &graphql.Field{
 				Type: graphql.String,
 			},
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -49,7 +49,7 @@ var queryType = graphql.NewObject(
 	graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{
-			"user": &graphql.FieldConfig{
+			"user": &graphql.Field{
 				Type: userType,
 				Args: graphql.FieldConfigArgument{
 					"id": &graphql.ArgumentConfig{

--- a/executor.go
+++ b/executor.go
@@ -167,10 +167,10 @@ func getOperationRootType(schema Schema, operation ast.Definition) (*Object, err
 
 	switch operation.GetOperation() {
 	case "query":
-		return schema.GetQueryType(), nil
+		return schema.QueryType(), nil
 	case "mutation":
-		mutationType := schema.GetMutationType()
-		if mutationType.Name == "" {
+		mutationType := schema.MutationType()
+		if mutationType.name == "" {
 			return nil, errors.New("Schema is not configured for mutations")
 		}
 		return mutationType, nil
@@ -622,7 +622,7 @@ func completeValue(eCtx *ExecutionContext, returnType Type, fieldASTs []*ast.Fie
 	case *Object:
 		objectType = returnType
 	case Abstract:
-		objectType = returnType.GetObjectType(result, info)
+		objectType = returnType.ObjectType(result, info)
 		if objectType != nil && !returnType.IsPossibleType(objectType) {
 			panic(gqlerrors.NewFormattedError(
 				fmt.Sprintf(`Runtime Object type "%v" is not a possible type `+
@@ -743,15 +743,15 @@ func getFieldDef(schema Schema, parentType *Object, fieldName string) *FieldDefi
 	}
 
 	if fieldName == SchemaMetaFieldDef.Name &&
-		schema.GetQueryType() == parentType {
+		schema.QueryType() == parentType {
 		return SchemaMetaFieldDef
 	}
 	if fieldName == TypeMetaFieldDef.Name &&
-		schema.GetQueryType() == parentType {
+		schema.QueryType() == parentType {
 		return TypeMetaFieldDef
 	}
 	if fieldName == TypeNameMetaFieldDef.Name {
 		return TypeNameMetaFieldDef
 	}
-	return parentType.GetFields()[fieldName]
+	return parentType.Fields()[fieldName]
 }

--- a/executor.go
+++ b/executor.go
@@ -498,7 +498,7 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 	// it is wrapped as a Error with locations. Log this error and return
 	// null if allowed, otherwise throw the error so the parent field can handle
 	// it.
-	result = resolveFn(GQLFRParams{
+	result = resolveFn(ResolveParams{
 		Source: source,
 		Args:   args,
 		Info:   info,
@@ -674,7 +674,7 @@ func completeValue(eCtx *ExecutionContext, returnType Type, fieldASTs []*ast.Fie
 
 }
 
-func defaultResolveFn(p GQLFRParams) interface{} {
+func defaultResolveFn(p ResolveParams) interface{} {
 	// try to resolve p.Source as a struct first
 	sourceVal := reflect.ValueOf(p.Source)
 	if sourceVal.IsValid() && sourceVal.Type().Kind() == reflect.Ptr {

--- a/executor.go
+++ b/executor.go
@@ -170,7 +170,7 @@ func getOperationRootType(schema Schema, operation ast.Definition) (*Object, err
 		return schema.QueryType(), nil
 	case "mutation":
 		mutationType := schema.MutationType()
-		if mutationType.name == "" {
+		if mutationType.PrivateName == "" {
 			return nil, errors.New("Schema is not configured for mutations")
 		}
 		return mutationType, nil

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -75,7 +75,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 
 	blogImage := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Image",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"url": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -89,7 +89,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 	})
 	blogAuthor := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Author",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"id": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -120,7 +120,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 	})
 	blogArticle := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Article",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"id": &graphql.FieldConfig{
 				Type: graphql.NewNonNull(graphql.String),
 			},
@@ -148,7 +148,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 
 	blogQuery := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"article": &graphql.FieldConfig{
 				Type: blogArticle,
 				Args: graphql.FieldConfigArgument{

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -76,13 +76,13 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 	blogImage := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Image",
 		Fields: graphql.Fields{
-			"url": &graphql.FieldConfig{
+			"url": &graphql.Field{
 				Type: graphql.String,
 			},
-			"width": &graphql.FieldConfig{
+			"width": &graphql.Field{
 				Type: graphql.Int,
 			},
-			"height": &graphql.FieldConfig{
+			"height": &graphql.Field{
 				Type: graphql.Int,
 			},
 		},
@@ -90,13 +90,13 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 	blogAuthor := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Author",
 		Fields: graphql.Fields{
-			"id": &graphql.FieldConfig{
+			"id": &graphql.Field{
 				Type: graphql.String,
 			},
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 			},
-			"pic": &graphql.FieldConfig{
+			"pic": &graphql.Field{
 				Type: blogImage,
 				Args: graphql.FieldConfigArgument{
 					"width": &graphql.ArgumentConfig{
@@ -115,41 +115,41 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 					return nil
 				},
 			},
-			"recentArticle": &graphql.FieldConfig{},
+			"recentArticle": &graphql.Field{},
 		},
 	})
 	blogArticle := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Article",
 		Fields: graphql.Fields{
-			"id": &graphql.FieldConfig{
+			"id": &graphql.Field{
 				Type: graphql.NewNonNull(graphql.String),
 			},
-			"isPublished": &graphql.FieldConfig{
+			"isPublished": &graphql.Field{
 				Type: graphql.Boolean,
 			},
-			"author": &graphql.FieldConfig{
+			"author": &graphql.Field{
 				Type: blogAuthor,
 			},
-			"title": &graphql.FieldConfig{
+			"title": &graphql.Field{
 				Type: graphql.String,
 			},
-			"body": &graphql.FieldConfig{
+			"body": &graphql.Field{
 				Type: graphql.String,
 			},
-			"keywords": &graphql.FieldConfig{
+			"keywords": &graphql.Field{
 				Type: graphql.NewList(graphql.String),
 			},
 		},
 	})
 
-	blogAuthor.AddFieldConfig("recentArticle", &graphql.FieldConfig{
+	blogAuthor.AddFieldConfig("recentArticle", &graphql.Field{
 		Type: blogArticle,
 	})
 
 	blogQuery := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{
-			"article": &graphql.FieldConfig{
+			"article": &graphql.Field{
 				Type: blogArticle,
 				Args: graphql.FieldConfigArgument{
 					"id": &graphql.ArgumentConfig{
@@ -161,7 +161,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 					return article(id)
 				},
 			},
-			"feed": &graphql.FieldConfig{
+			"feed": &graphql.Field{
 				Type: graphql.NewList(blogArticle),
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					return []*testArticle{

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -106,7 +106,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if author, ok := p.Source.(*testAuthor); ok {
 						width := fmt.Sprintf("%v", p.Args["width"])
 						height := fmt.Sprintf("%v", p.Args["height"])
@@ -156,14 +156,14 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						Type: graphql.ID,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					id := p.Args["id"]
 					return article(id)
 				},
 			},
 			"feed": &graphql.Field{
 				Type: graphql.NewList(blogArticle),
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					return []*testArticle{
 						article(1),
 						article(2),

--- a/executor_test.go
+++ b/executor_test.go
@@ -103,7 +103,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	}
 
 	// Schema Definitions
-	picResolverFn := func(p graphql.GQLFRParams) interface{} {
+	picResolverFn := func(p graphql.ResolveParams) interface{} {
 		// get and type assert ResolveFn for this field
 		picResolver, ok := p.Source.(map[string]interface{})["pic"].(func(size int) string)
 		if !ok {
@@ -244,19 +244,19 @@ func TestMergesParallelFragments(t *testing.T) {
 		Fields: graphql.Fields{
 			"a": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					return "Apple"
 				},
 			},
 			"b": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					return "Banana"
 				},
 			},
 			"c": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					return "Cherry"
 				},
 			},
@@ -264,7 +264,7 @@ func TestMergesParallelFragments(t *testing.T) {
 	})
 	deepTypeFieldConfig := &graphql.Field{
 		Type: typeObjectType,
-		Resolve: func(p graphql.GQLFRParams) interface{} {
+		Resolve: func(p graphql.ResolveParams) interface{} {
 			return p.Source
 		},
 	}
@@ -312,7 +312,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.GQLFRParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) interface{} {
 						resolvedContext = p.Source.(map[string]interface{})
 						return resolvedContext
 					},
@@ -368,7 +368,7 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 						},
 					},
 					Type: graphql.String,
-					Resolve: func(p graphql.GQLFRParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) interface{} {
 						resolvedArgs = p.Args
 						return resolvedArgs
 					},
@@ -944,7 +944,7 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 							Type: graphql.Int,
 						},
 					},
-					Resolve: func(p graphql.GQLFRParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) interface{} {
 						args, _ := json.Marshal(p.Args)
 						return string(args)
 					},
@@ -1019,7 +1019,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		Fields: graphql.Fields{
 			"value": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					return p.Source.(testSpecialType).Value
 				},
 			},
@@ -1031,7 +1031,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 			Fields: graphql.Fields{
 				"specials": &graphql.Field{
 					Type: graphql.NewList(specialType),
-					Resolve: func(p graphql.GQLFRParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) interface{} {
 						return p.Source.(map[string]interface{})["specials"]
 					},
 				},

--- a/executor_test.go
+++ b/executor_test.go
@@ -119,25 +119,25 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	dataType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "DataType",
 		Fields: graphql.Fields{
-			"a": &graphql.FieldConfig{
+			"a": &graphql.Field{
 				Type: graphql.String,
 			},
-			"b": &graphql.FieldConfig{
+			"b": &graphql.Field{
 				Type: graphql.String,
 			},
-			"c": &graphql.FieldConfig{
+			"c": &graphql.Field{
 				Type: graphql.String,
 			},
-			"d": &graphql.FieldConfig{
+			"d": &graphql.Field{
 				Type: graphql.String,
 			},
-			"e": &graphql.FieldConfig{
+			"e": &graphql.Field{
 				Type: graphql.String,
 			},
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
-			"pic": &graphql.FieldConfig{
+			"pic": &graphql.Field{
 				Args: graphql.FieldConfigArgument{
 					"size": &graphql.ArgumentConfig{
 						Type: graphql.Int,
@@ -151,16 +151,16 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	deepDataType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "DeepDataType",
 		Fields: graphql.Fields{
-			"a": &graphql.FieldConfig{
+			"a": &graphql.Field{
 				Type: graphql.String,
 			},
-			"b": &graphql.FieldConfig{
+			"b": &graphql.Field{
 				Type: graphql.String,
 			},
-			"c": &graphql.FieldConfig{
+			"c": &graphql.Field{
 				Type: graphql.NewList(graphql.String),
 			},
-			"deeper": &graphql.FieldConfig{
+			"deeper": &graphql.Field{
 				Type: graphql.NewList(dataType),
 			},
 		},
@@ -168,11 +168,11 @@ func TestExecutesArbitraryCode(t *testing.T) {
 
 	// Exploring a way to have a Object within itself
 	// in this case DataType has DeepDataType has DataType
-	dataType.AddFieldConfig("deep", &graphql.FieldConfig{
+	dataType.AddFieldConfig("deep", &graphql.Field{
 		Type: deepDataType,
 	})
 	// in this case DataType has DataType
-	dataType.AddFieldConfig("promise", &graphql.FieldConfig{
+	dataType.AddFieldConfig("promise", &graphql.Field{
 		Type: dataType,
 	})
 
@@ -242,19 +242,19 @@ func TestMergesParallelFragments(t *testing.T) {
 	typeObjectType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Type",
 		Fields: graphql.Fields{
-			"a": &graphql.FieldConfig{
+			"a": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					return "Apple"
 				},
 			},
-			"b": &graphql.FieldConfig{
+			"b": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					return "Banana"
 				},
 			},
-			"c": &graphql.FieldConfig{
+			"c": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					return "Cherry"
@@ -262,7 +262,7 @@ func TestMergesParallelFragments(t *testing.T) {
 			},
 		},
 	})
-	deepTypeFieldConfig := &graphql.FieldConfig{
+	deepTypeFieldConfig := &graphql.Field{
 		Type: typeObjectType,
 		Resolve: func(p graphql.GQLFRParams) interface{} {
 			return p.Source
@@ -310,7 +310,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 					Resolve: func(p graphql.GQLFRParams) interface{} {
 						resolvedContext = p.Source.(map[string]interface{})
@@ -358,7 +358,7 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"b": &graphql.FieldConfig{
+				"b": &graphql.Field{
 					Args: graphql.FieldConfigArgument{
 						"numArg": &graphql.ArgumentConfig{
 							Type: graphql.Int,
@@ -438,10 +438,10 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"sync": &graphql.FieldConfig{
+				"sync": &graphql.Field{
 					Type: graphql.String,
 				},
-				"syncError": &graphql.FieldConfig{
+				"syncError": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -489,7 +489,7 @@ func TestUsesTheInlineOperationIfNoOperationIsProvided(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -534,7 +534,7 @@ func TestUsesTheOnlyOperationIfNoOperationIsProvided(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -580,7 +580,7 @@ func TestThrowsIfNoOperationIsProvidedWithMultipleOperations(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -629,7 +629,7 @@ func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Q",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -637,7 +637,7 @@ func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 		Mutation: graphql.NewObject(graphql.ObjectConfig{
 			Name: "M",
 			Fields: graphql.Fields{
-				"c": &graphql.FieldConfig{
+				"c": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -684,7 +684,7 @@ func TestUsesTheMutationSchemaForMutations(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Q",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -692,7 +692,7 @@ func TestUsesTheMutationSchemaForMutations(t *testing.T) {
 		Mutation: graphql.NewObject(graphql.ObjectConfig{
 			Name: "M",
 			Fields: graphql.Fields{
-				"c": &graphql.FieldConfig{
+				"c": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -754,19 +754,19 @@ func TestCorrectFieldOrderingDespiteExecutionOrder(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 				},
-				"b": &graphql.FieldConfig{
+				"b": &graphql.Field{
 					Type: graphql.String,
 				},
-				"c": &graphql.FieldConfig{
+				"c": &graphql.Field{
 					Type: graphql.String,
 				},
-				"d": &graphql.FieldConfig{
+				"d": &graphql.Field{
 					Type: graphql.String,
 				},
-				"e": &graphql.FieldConfig{
+				"e": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -832,7 +832,7 @@ func TestAvoidsRecursion(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -876,7 +876,7 @@ func TestDoesNotIncludeIllegalFieldsInOutput(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Q",
 			Fields: graphql.Fields{
-				"a": &graphql.FieldConfig{
+				"a": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -884,7 +884,7 @@ func TestDoesNotIncludeIllegalFieldsInOutput(t *testing.T) {
 		Mutation: graphql.NewObject(graphql.ObjectConfig{
 			Name: "M",
 			Fields: graphql.Fields{
-				"c": &graphql.FieldConfig{
+				"c": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -925,7 +925,7 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
 			Fields: graphql.Fields{
-				"field": &graphql.FieldConfig{
+				"field": &graphql.Field{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
 						"a": &graphql.ArgumentConfig{
@@ -1017,7 +1017,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 			return false
 		},
 		Fields: graphql.Fields{
-			"value": &graphql.FieldConfig{
+			"value": &graphql.Field{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
 					return p.Source.(testSpecialType).Value
@@ -1029,7 +1029,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"specials": &graphql.FieldConfig{
+				"specials": &graphql.Field{
 					Type: graphql.NewList(specialType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
 						return p.Source.(map[string]interface{})["specials"]
@@ -1081,7 +1081,7 @@ func TestFailsToExecuteQueryContainingATypeDefinition(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"foo": &graphql.FieldConfig{
+				"foo": &graphql.Field{
 					Type: graphql.String,
 				},
 			},

--- a/executor_test.go
+++ b/executor_test.go
@@ -118,7 +118,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	}
 	dataType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "DataType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"a": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -150,7 +150,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	})
 	deepDataType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "DeepDataType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"a": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -241,7 +241,7 @@ func TestMergesParallelFragments(t *testing.T) {
 
 	typeObjectType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Type",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"a": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -309,7 +309,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 					Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -357,7 +357,7 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"b": &graphql.FieldConfig{
 					Args: graphql.FieldConfigArgument{
 						"numArg": &graphql.ArgumentConfig{
@@ -437,7 +437,7 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"sync": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -488,7 +488,7 @@ func TestUsesTheInlineOperationIfNoOperationIsProvided(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -533,7 +533,7 @@ func TestUsesTheOnlyOperationIfNoOperationIsProvided(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -579,7 +579,7 @@ func TestThrowsIfNoOperationIsProvidedWithMultipleOperations(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -628,7 +628,7 @@ func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Q",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -636,7 +636,7 @@ func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 		}),
 		Mutation: graphql.NewObject(graphql.ObjectConfig{
 			Name: "M",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"c": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -683,7 +683,7 @@ func TestUsesTheMutationSchemaForMutations(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Q",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -691,7 +691,7 @@ func TestUsesTheMutationSchemaForMutations(t *testing.T) {
 		}),
 		Mutation: graphql.NewObject(graphql.ObjectConfig{
 			Name: "M",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"c": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -753,7 +753,7 @@ func TestCorrectFieldOrderingDespiteExecutionOrder(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -831,7 +831,7 @@ func TestAvoidsRecursion(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -875,7 +875,7 @@ func TestDoesNotIncludeIllegalFieldsInOutput(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Q",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"a": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -883,7 +883,7 @@ func TestDoesNotIncludeIllegalFieldsInOutput(t *testing.T) {
 		}),
 		Mutation: graphql.NewObject(graphql.ObjectConfig{
 			Name: "M",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"c": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -924,7 +924,7 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Type",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"field": &graphql.FieldConfig{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
@@ -1016,7 +1016,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 			}
 			return false
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"value": &graphql.FieldConfig{
 				Type: graphql.String,
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -1028,7 +1028,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"specials": &graphql.FieldConfig{
 					Type: graphql.NewList(specialType),
 					Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -1080,7 +1080,7 @@ func TestFailsToExecuteQueryContainingATypeDefinition(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"foo": &graphql.FieldConfig{
 					Type: graphql.String,
 				},

--- a/gqlerrors/sortutil.go
+++ b/gqlerrors/sortutil.go
@@ -2,17 +2,17 @@ package gqlerrors
 
 import "bytes"
 
-type GQLFormattedErrorSlice []FormattedError
+type FormattedErrors []FormattedError
 
-func (errs GQLFormattedErrorSlice) Len() int {
+func (errs FormattedErrors) Len() int {
 	return len(errs)
 }
 
-func (errs GQLFormattedErrorSlice) Swap(i, j int) {
+func (errs FormattedErrors) Swap(i, j int) {
 	errs[i], errs[j] = errs[j], errs[i]
 }
 
-func (errs GQLFormattedErrorSlice) Less(i, j int) bool {
+func (errs FormattedErrors) Less(i, j int) bool {
 	mCompare := bytes.Compare([]byte(errs[i].Message), []byte(errs[j].Message))
 	lesserLine := errs[i].Locations[0].Line < errs[j].Locations[0].Line
 	eqLine := errs[i].Locations[0].Line == errs[j].Locations[0].Line

--- a/graphql.go
+++ b/graphql.go
@@ -14,7 +14,7 @@ type Params struct {
 	OperationName  string
 }
 
-func Graphql(p Params) *Result {
+func Do(p Params) *Result {
 	source := source.NewSource(&source.Source{
 		Body: p.RequestString,
 		Name: "GraphQL request",

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -101,7 +101,7 @@ func TestBasicGraphQLExample(t *testing.T) {
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "RootQueryType",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"hello": &graphql.FieldConfig{
 					Description: "Returns `world`",
 					Type:        graphql.String,

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -82,7 +82,7 @@ func TestQuery(t *testing.T) {
 }
 
 func testGraphql(test T, p graphql.Params, t *testing.T) {
-	result := graphql.Graphql(p)
+	result := graphql.Do(p)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -119,7 +119,7 @@ func TestBasicGraphQLExample(t *testing.T) {
 		"hello": "world",
 	}
 
-	result := graphql.Graphql(graphql.Params{
+	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -102,7 +102,7 @@ func TestBasicGraphQLExample(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "RootQueryType",
 			Fields: graphql.Fields{
-				"hello": &graphql.FieldConfig{
+				"hello": &graphql.Field{
 					Description: "Returns `world`",
 					Type:        graphql.String,
 					Resolve:     helloFieldResolved,

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -94,7 +94,7 @@ func testGraphql(test T, p graphql.Params, t *testing.T) {
 func TestBasicGraphQLExample(t *testing.T) {
 	// taken from `graphql-js` README
 
-	helloFieldResolved := func(p graphql.GQLFRParams) interface{} {
+	helloFieldResolved := func(p graphql.ResolveParams) interface{} {
 		return "world"
 	}
 

--- a/introspection.go
+++ b/introspection.go
@@ -83,7 +83,7 @@ func init() {
 	// Note: some fields (for e.g "fields", "interfaces") are defined later due to cyclic reference
 	__Type = NewObject(ObjectConfig{
 		Name: "__Type",
-		Fields: FieldConfigMap{
+		Fields: Fields{
 			"kind": &FieldConfig{
 				Type: NewNonNull(__TypeKind),
 				Resolve: func(p GQLFRParams) interface{} {
@@ -125,7 +125,7 @@ func init() {
 
 	__InputValue = NewObject(ObjectConfig{
 		Name: "__InputValue",
-		Fields: FieldConfigMap{
+		Fields: Fields{
 			"name": &FieldConfig{
 				Type: NewNonNull(String),
 			},
@@ -160,7 +160,7 @@ func init() {
 
 	__Field = NewObject(ObjectConfig{
 		Name: "__Field",
-		Fields: FieldConfigMap{
+		Fields: Fields{
 			"name": &FieldConfig{
 				Type: NewNonNull(String),
 			},
@@ -196,7 +196,7 @@ func init() {
 
 	__Directive = NewObject(ObjectConfig{
 		Name: "__Directive",
-		Fields: FieldConfigMap{
+		Fields: Fields{
 			"name": &FieldConfig{
 				Type: NewNonNull(String),
 			},
@@ -226,7 +226,7 @@ func init() {
 server. It exposes all available types and directives on
 the server, as well as the entry points for query and
 mutation operations.`,
-		Fields: FieldConfigMap{
+		Fields: Fields{
 			"types": &FieldConfig{
 				Description: "A list of all types supported by this server.",
 				Type: NewNonNull(NewList(
@@ -283,7 +283,7 @@ mutation operations.`,
 
 	__EnumValue = NewObject(ObjectConfig{
 		Name: "__EnumValue",
-		Fields: FieldConfigMap{
+		Fields: Fields{
 			"name": &FieldConfig{
 				Type: NewNonNull(String),
 			},

--- a/introspection.go
+++ b/introspection.go
@@ -86,7 +86,7 @@ func init() {
 		Fields: Fields{
 			"kind": &Field{
 				Type: NewNonNull(__TypeKind),
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					switch p.Source.(type) {
 					case *Scalar:
 						return TypeKindScalar
@@ -137,7 +137,7 @@ func init() {
 			},
 			"defaultValue": &Field{
 				Type: String,
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					if inputVal, ok := p.Source.(*Argument); ok {
 						if inputVal.DefaultValue == nil {
 							return nil
@@ -169,7 +169,7 @@ func init() {
 			},
 			"args": &Field{
 				Type: NewNonNull(NewList(NewNonNull(__InputValue))),
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					if field, ok := p.Source.(*FieldDefinition); ok {
 						return field.Args
 					}
@@ -181,7 +181,7 @@ func init() {
 			},
 			"isDeprecated": &Field{
 				Type: NewNonNull(Boolean),
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					if field, ok := p.Source.(*FieldDefinition); ok {
 						return (field.DeprecationReason != "")
 					}
@@ -232,7 +232,7 @@ mutation operations.`,
 				Type: NewNonNull(NewList(
 					NewNonNull(__Type),
 				)),
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					if schema, ok := p.Source.(Schema); ok {
 						results := []Type{}
 						for _, ttype := range schema.GetTypeMap() {
@@ -246,7 +246,7 @@ mutation operations.`,
 			"queryType": &Field{
 				Description: "The type that query operations will be rooted at.",
 				Type:        NewNonNull(__Type),
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					if schema, ok := p.Source.(Schema); ok {
 						return schema.GetQueryType()
 					}
@@ -257,7 +257,7 @@ mutation operations.`,
 				Description: `If this server supports mutation, the type that ` +
 					`mutation operations will be rooted at.`,
 				Type: __Type,
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					if schema, ok := p.Source.(Schema); ok {
 						if schema.GetMutationType() != nil {
 							return schema.GetMutationType()
@@ -271,7 +271,7 @@ mutation operations.`,
 				Type: NewNonNull(NewList(
 					NewNonNull(__Directive),
 				)),
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					if schema, ok := p.Source.(Schema); ok {
 						return schema.GetDirectives()
 					}
@@ -292,7 +292,7 @@ mutation operations.`,
 			},
 			"isDeprecated": &Field{
 				Type: NewNonNull(Boolean),
-				Resolve: func(p GQLFRParams) interface{} {
+				Resolve: func(p ResolveParams) interface{} {
 					if field, ok := p.Source.(*EnumValueDefinition); ok {
 						return (field.DeprecationReason != "")
 					}
@@ -315,7 +315,7 @@ mutation operations.`,
 				DefaultValue: false,
 			},
 		},
-		Resolve: func(p GQLFRParams) interface{} {
+		Resolve: func(p ResolveParams) interface{} {
 			includeDeprecated, _ := p.Args["includeDeprecated"].(bool)
 			switch ttype := p.Source.(type) {
 			case *Object:
@@ -348,7 +348,7 @@ mutation operations.`,
 	})
 	__Type.AddFieldConfig("interfaces", &Field{
 		Type: NewList(NewNonNull(__Type)),
-		Resolve: func(p GQLFRParams) interface{} {
+		Resolve: func(p ResolveParams) interface{} {
 			switch ttype := p.Source.(type) {
 			case *Object:
 				return ttype.GetInterfaces()
@@ -358,7 +358,7 @@ mutation operations.`,
 	})
 	__Type.AddFieldConfig("possibleTypes", &Field{
 		Type: NewList(NewNonNull(__Type)),
-		Resolve: func(p GQLFRParams) interface{} {
+		Resolve: func(p ResolveParams) interface{} {
 			switch ttype := p.Source.(type) {
 			case *Interface:
 				return ttype.GetPossibleTypes()
@@ -376,7 +376,7 @@ mutation operations.`,
 				DefaultValue: false,
 			},
 		},
-		Resolve: func(p GQLFRParams) interface{} {
+		Resolve: func(p ResolveParams) interface{} {
 			includeDeprecated, _ := p.Args["includeDeprecated"].(bool)
 			switch ttype := p.Source.(type) {
 			case *Enum:
@@ -397,7 +397,7 @@ mutation operations.`,
 	})
 	__Type.AddFieldConfig("inputFields", &Field{
 		Type: NewList(NewNonNull(__InputValue)),
-		Resolve: func(p GQLFRParams) interface{} {
+		Resolve: func(p ResolveParams) interface{} {
 			switch ttype := p.Source.(type) {
 			case *InputObject:
 				fields := []*InputObjectField{}
@@ -423,7 +423,7 @@ mutation operations.`,
 		Type:        NewNonNull(__Schema),
 		Description: "Access the current type schema of this server.",
 		Args:        []*Argument{},
-		Resolve: func(p GQLFRParams) interface{} {
+		Resolve: func(p ResolveParams) interface{} {
 			return p.Info.Schema
 		},
 	}
@@ -437,7 +437,7 @@ mutation operations.`,
 				Type: NewNonNull(String),
 			},
 		},
-		Resolve: func(p GQLFRParams) interface{} {
+		Resolve: func(p ResolveParams) interface{} {
 			name, ok := p.Args["name"].(string)
 			if !ok {
 				return nil
@@ -451,7 +451,7 @@ mutation operations.`,
 		Type:        NewNonNull(String),
 		Description: "The name of the current Object type at runtime.",
 		Args:        []*Argument{},
-		Resolve: func(p GQLFRParams) interface{} {
+		Resolve: func(p ResolveParams) interface{} {
 			return p.Info.ParentType.GetName()
 		},
 	}

--- a/introspection.go
+++ b/introspection.go
@@ -433,8 +433,8 @@ mutation operations.`,
 		Description: "Request the type information of a single type.",
 		Args: []*Argument{
 			&Argument{
-				name: "name",
-				Type: NewNonNull(String),
+				PrivateName: "name",
+				Type:        NewNonNull(String),
 			},
 		},
 		Resolve: func(p ResolveParams) interface{} {

--- a/introspection.go
+++ b/introspection.go
@@ -235,7 +235,7 @@ mutation operations.`,
 				Resolve: func(p ResolveParams) interface{} {
 					if schema, ok := p.Source.(Schema); ok {
 						results := []Type{}
-						for _, ttype := range schema.GetTypeMap() {
+						for _, ttype := range schema.TypeMap() {
 							results = append(results, ttype)
 						}
 						return results
@@ -248,7 +248,7 @@ mutation operations.`,
 				Type:        NewNonNull(__Type),
 				Resolve: func(p ResolveParams) interface{} {
 					if schema, ok := p.Source.(Schema); ok {
-						return schema.GetQueryType()
+						return schema.QueryType()
 					}
 					return nil
 				},
@@ -259,8 +259,8 @@ mutation operations.`,
 				Type: __Type,
 				Resolve: func(p ResolveParams) interface{} {
 					if schema, ok := p.Source.(Schema); ok {
-						if schema.GetMutationType() != nil {
-							return schema.GetMutationType()
+						if schema.MutationType() != nil {
+							return schema.MutationType()
 						}
 					}
 					return nil
@@ -273,7 +273,7 @@ mutation operations.`,
 				)),
 				Resolve: func(p ResolveParams) interface{} {
 					if schema, ok := p.Source.(Schema); ok {
-						return schema.GetDirectives()
+						return schema.Directives()
 					}
 					return nil
 				},
@@ -323,7 +323,7 @@ mutation operations.`,
 					return nil
 				}
 				fields := []*FieldDefinition{}
-				for _, field := range ttype.GetFields() {
+				for _, field := range ttype.Fields() {
 					if !includeDeprecated && field.DeprecationReason != "" {
 						continue
 					}
@@ -335,7 +335,7 @@ mutation operations.`,
 					return nil
 				}
 				fields := []*FieldDefinition{}
-				for _, field := range ttype.GetFields() {
+				for _, field := range ttype.Fields() {
 					if !includeDeprecated && field.DeprecationReason != "" {
 						continue
 					}
@@ -351,7 +351,7 @@ mutation operations.`,
 		Resolve: func(p ResolveParams) interface{} {
 			switch ttype := p.Source.(type) {
 			case *Object:
-				return ttype.GetInterfaces()
+				return ttype.Interfaces()
 			}
 			return nil
 		},
@@ -361,9 +361,9 @@ mutation operations.`,
 		Resolve: func(p ResolveParams) interface{} {
 			switch ttype := p.Source.(type) {
 			case *Interface:
-				return ttype.GetPossibleTypes()
+				return ttype.PossibleTypes()
 			case *Union:
-				return ttype.GetPossibleTypes()
+				return ttype.PossibleTypes()
 			}
 			return nil
 		},
@@ -381,10 +381,10 @@ mutation operations.`,
 			switch ttype := p.Source.(type) {
 			case *Enum:
 				if includeDeprecated {
-					return ttype.GetValues()
+					return ttype.Values()
 				}
 				values := []*EnumValueDefinition{}
-				for _, value := range ttype.GetValues() {
+				for _, value := range ttype.Values() {
 					if value.DeprecationReason != "" {
 						continue
 					}
@@ -401,7 +401,7 @@ mutation operations.`,
 			switch ttype := p.Source.(type) {
 			case *InputObject:
 				fields := []*InputObjectField{}
-				for _, field := range ttype.GetFields() {
+				for _, field := range ttype.Fields() {
 					fields = append(fields, field)
 				}
 				return fields
@@ -433,7 +433,7 @@ mutation operations.`,
 		Description: "Request the type information of a single type.",
 		Args: []*Argument{
 			&Argument{
-				Name: "name",
+				name: "name",
 				Type: NewNonNull(String),
 			},
 		},
@@ -442,7 +442,7 @@ mutation operations.`,
 			if !ok {
 				return nil
 			}
-			return p.Info.Schema.GetType(name)
+			return p.Info.Schema.Type(name)
 		},
 	}
 
@@ -452,7 +452,7 @@ mutation operations.`,
 		Description: "The name of the current Object type at runtime.",
 		Args:        []*Argument{},
 		Resolve: func(p ResolveParams) interface{} {
-			return p.Info.ParentType.GetName()
+			return p.Info.ParentType.Name()
 		},
 	}
 

--- a/introspection.go
+++ b/introspection.go
@@ -84,7 +84,7 @@ func init() {
 	__Type = NewObject(ObjectConfig{
 		Name: "__Type",
 		Fields: Fields{
-			"kind": &FieldConfig{
+			"kind": &Field{
 				Type: NewNonNull(__TypeKind),
 				Resolve: func(p GQLFRParams) interface{} {
 					switch p.Source.(type) {
@@ -108,34 +108,34 @@ func init() {
 					panic(fmt.Sprintf("Unknown kind of type: %v", p.Source))
 				},
 			},
-			"name": &FieldConfig{
+			"name": &Field{
 				Type: String,
 			},
-			"description": &FieldConfig{
+			"description": &Field{
 				Type: String,
 			},
-			"fields":        &FieldConfig{},
-			"interfaces":    &FieldConfig{},
-			"possibleTypes": &FieldConfig{},
-			"enumValues":    &FieldConfig{},
-			"inputFields":   &FieldConfig{},
-			"ofType":        &FieldConfig{},
+			"fields":        &Field{},
+			"interfaces":    &Field{},
+			"possibleTypes": &Field{},
+			"enumValues":    &Field{},
+			"inputFields":   &Field{},
+			"ofType":        &Field{},
 		},
 	})
 
 	__InputValue = NewObject(ObjectConfig{
 		Name: "__InputValue",
 		Fields: Fields{
-			"name": &FieldConfig{
+			"name": &Field{
 				Type: NewNonNull(String),
 			},
-			"description": &FieldConfig{
+			"description": &Field{
 				Type: String,
 			},
-			"type": &FieldConfig{
+			"type": &Field{
 				Type: NewNonNull(__Type),
 			},
-			"defaultValue": &FieldConfig{
+			"defaultValue": &Field{
 				Type: String,
 				Resolve: func(p GQLFRParams) interface{} {
 					if inputVal, ok := p.Source.(*Argument); ok {
@@ -161,13 +161,13 @@ func init() {
 	__Field = NewObject(ObjectConfig{
 		Name: "__Field",
 		Fields: Fields{
-			"name": &FieldConfig{
+			"name": &Field{
 				Type: NewNonNull(String),
 			},
-			"description": &FieldConfig{
+			"description": &Field{
 				Type: String,
 			},
-			"args": &FieldConfig{
+			"args": &Field{
 				Type: NewNonNull(NewList(NewNonNull(__InputValue))),
 				Resolve: func(p GQLFRParams) interface{} {
 					if field, ok := p.Source.(*FieldDefinition); ok {
@@ -176,10 +176,10 @@ func init() {
 					return []interface{}{}
 				},
 			},
-			"type": &FieldConfig{
+			"type": &Field{
 				Type: NewNonNull(__Type),
 			},
-			"isDeprecated": &FieldConfig{
+			"isDeprecated": &Field{
 				Type: NewNonNull(Boolean),
 				Resolve: func(p GQLFRParams) interface{} {
 					if field, ok := p.Source.(*FieldDefinition); ok {
@@ -188,7 +188,7 @@ func init() {
 					return false
 				},
 			},
-			"deprecationReason": &FieldConfig{
+			"deprecationReason": &Field{
 				Type: String,
 			},
 		},
@@ -197,24 +197,24 @@ func init() {
 	__Directive = NewObject(ObjectConfig{
 		Name: "__Directive",
 		Fields: Fields{
-			"name": &FieldConfig{
+			"name": &Field{
 				Type: NewNonNull(String),
 			},
-			"description": &FieldConfig{
+			"description": &Field{
 				Type: String,
 			},
-			"args": &FieldConfig{
+			"args": &Field{
 				Type: NewNonNull(NewList(
 					NewNonNull(__InputValue),
 				)),
 			},
-			"onOperation": &FieldConfig{
+			"onOperation": &Field{
 				Type: NewNonNull(Boolean),
 			},
-			"onFragment": &FieldConfig{
+			"onFragment": &Field{
 				Type: NewNonNull(Boolean),
 			},
-			"onField": &FieldConfig{
+			"onField": &Field{
 				Type: NewNonNull(Boolean),
 			},
 		},
@@ -227,7 +227,7 @@ server. It exposes all available types and directives on
 the server, as well as the entry points for query and
 mutation operations.`,
 		Fields: Fields{
-			"types": &FieldConfig{
+			"types": &Field{
 				Description: "A list of all types supported by this server.",
 				Type: NewNonNull(NewList(
 					NewNonNull(__Type),
@@ -243,7 +243,7 @@ mutation operations.`,
 					return []Type{}
 				},
 			},
-			"queryType": &FieldConfig{
+			"queryType": &Field{
 				Description: "The type that query operations will be rooted at.",
 				Type:        NewNonNull(__Type),
 				Resolve: func(p GQLFRParams) interface{} {
@@ -253,7 +253,7 @@ mutation operations.`,
 					return nil
 				},
 			},
-			"mutationType": &FieldConfig{
+			"mutationType": &Field{
 				Description: `If this server supports mutation, the type that ` +
 					`mutation operations will be rooted at.`,
 				Type: __Type,
@@ -266,7 +266,7 @@ mutation operations.`,
 					return nil
 				},
 			},
-			"directives": &FieldConfig{
+			"directives": &Field{
 				Description: `A list of all directives supported by this server.`,
 				Type: NewNonNull(NewList(
 					NewNonNull(__Directive),
@@ -284,13 +284,13 @@ mutation operations.`,
 	__EnumValue = NewObject(ObjectConfig{
 		Name: "__EnumValue",
 		Fields: Fields{
-			"name": &FieldConfig{
+			"name": &Field{
 				Type: NewNonNull(String),
 			},
-			"description": &FieldConfig{
+			"description": &Field{
 				Type: String,
 			},
-			"isDeprecated": &FieldConfig{
+			"isDeprecated": &Field{
 				Type: NewNonNull(Boolean),
 				Resolve: func(p GQLFRParams) interface{} {
 					if field, ok := p.Source.(*EnumValueDefinition); ok {
@@ -299,7 +299,7 @@ mutation operations.`,
 					return false
 				},
 			},
-			"deprecationReason": &FieldConfig{
+			"deprecationReason": &Field{
 				Type: String,
 			},
 		},
@@ -307,7 +307,7 @@ mutation operations.`,
 
 	// Again, adding field configs to __Type that have cyclic reference here
 	// because golang don't like them too much during init/compile-time
-	__Type.AddFieldConfig("fields", &FieldConfig{
+	__Type.AddFieldConfig("fields", &Field{
 		Type: NewList(NewNonNull(__Field)),
 		Args: FieldConfigArgument{
 			"includeDeprecated": &ArgumentConfig{
@@ -346,7 +346,7 @@ mutation operations.`,
 			return nil
 		},
 	})
-	__Type.AddFieldConfig("interfaces", &FieldConfig{
+	__Type.AddFieldConfig("interfaces", &Field{
 		Type: NewList(NewNonNull(__Type)),
 		Resolve: func(p GQLFRParams) interface{} {
 			switch ttype := p.Source.(type) {
@@ -356,7 +356,7 @@ mutation operations.`,
 			return nil
 		},
 	})
-	__Type.AddFieldConfig("possibleTypes", &FieldConfig{
+	__Type.AddFieldConfig("possibleTypes", &Field{
 		Type: NewList(NewNonNull(__Type)),
 		Resolve: func(p GQLFRParams) interface{} {
 			switch ttype := p.Source.(type) {
@@ -368,7 +368,7 @@ mutation operations.`,
 			return nil
 		},
 	})
-	__Type.AddFieldConfig("enumValues", &FieldConfig{
+	__Type.AddFieldConfig("enumValues", &Field{
 		Type: NewList(NewNonNull(__EnumValue)),
 		Args: FieldConfigArgument{
 			"includeDeprecated": &ArgumentConfig{
@@ -395,7 +395,7 @@ mutation operations.`,
 			return nil
 		},
 	})
-	__Type.AddFieldConfig("inputFields", &FieldConfig{
+	__Type.AddFieldConfig("inputFields", &Field{
 		Type: NewList(NewNonNull(__InputValue)),
 		Resolve: func(p GQLFRParams) interface{} {
 			switch ttype := p.Source.(type) {
@@ -409,7 +409,7 @@ mutation operations.`,
 			return nil
 		},
 	})
-	__Type.AddFieldConfig("ofType", &FieldConfig{
+	__Type.AddFieldConfig("ofType", &Field{
 		Type: __Type,
 	})
 

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -18,7 +18,7 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 	emptySchema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "QueryRoot",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"onlyField": &graphql.FieldConfig{
 					Type: graphql.String,
 				},
@@ -760,7 +760,7 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 	})
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -860,7 +860,7 @@ func TestIntrospection_SupportsThe__TypeRootField(t *testing.T) {
 
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"testField": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -898,7 +898,7 @@ func TestIntrospection_IdentifiesDeprecatedFields(t *testing.T) {
 
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"nonDeprecated": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -957,7 +957,7 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForFields(t *testing
 
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"nonDeprecated": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -1041,7 +1041,7 @@ func TestIntrospection_IdentifiesDeprecatedEnumValues(t *testing.T) {
 	})
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"testEnum": &graphql.FieldConfig{
 				Type: testEnum,
 			},
@@ -1116,7 +1116,7 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForEnumValues(t *tes
 	})
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"testEnum": &graphql.FieldConfig{
 				Type: testEnum,
 			},
@@ -1190,7 +1190,7 @@ func TestIntrospection_FailsAsExpectedOnThe__TypeRootFieldWithoutAnArg(t *testin
 
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"testField": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -1234,7 +1234,7 @@ func TestIntrospection_ExposesDescriptionsOnTypesAndFields(t *testing.T) {
 
 	queryRoot := graphql.NewObject(graphql.ObjectConfig{
 		Name: "QueryRoot",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"onlyField": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -1300,7 +1300,7 @@ func TestIntrospection_ExposesDescriptionsOnEnums(t *testing.T) {
 
 	queryRoot := graphql.NewObject(graphql.ObjectConfig{
 		Name: "QueryRoot",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"onlyField": &graphql.FieldConfig{
 				Type: graphql.String,
 			},

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -19,7 +19,7 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "QueryRoot",
 			Fields: graphql.Fields{
-				"onlyField": &graphql.FieldConfig{
+				"onlyField": &graphql.Field{
 					Type: graphql.String,
 				},
 			},
@@ -761,7 +761,7 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"complex": &graphql.ArgumentConfig{
@@ -861,7 +861,7 @@ func TestIntrospection_SupportsThe__TypeRootField(t *testing.T) {
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
 		Fields: graphql.Fields{
-			"testField": &graphql.FieldConfig{
+			"testField": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -899,10 +899,10 @@ func TestIntrospection_IdentifiesDeprecatedFields(t *testing.T) {
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
 		Fields: graphql.Fields{
-			"nonDeprecated": &graphql.FieldConfig{
+			"nonDeprecated": &graphql.Field{
 				Type: graphql.String,
 			},
-			"deprecated": &graphql.FieldConfig{
+			"deprecated": &graphql.Field{
 				Type:              graphql.String,
 				DeprecationReason: "Removed in 1.0",
 			},
@@ -958,10 +958,10 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForFields(t *testing
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
 		Fields: graphql.Fields{
-			"nonDeprecated": &graphql.FieldConfig{
+			"nonDeprecated": &graphql.Field{
 				Type: graphql.String,
 			},
-			"deprecated": &graphql.FieldConfig{
+			"deprecated": &graphql.Field{
 				Type:              graphql.String,
 				DeprecationReason: "Removed in 1.0",
 			},
@@ -1042,7 +1042,7 @@ func TestIntrospection_IdentifiesDeprecatedEnumValues(t *testing.T) {
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
 		Fields: graphql.Fields{
-			"testEnum": &graphql.FieldConfig{
+			"testEnum": &graphql.Field{
 				Type: testEnum,
 			},
 		},
@@ -1117,7 +1117,7 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForEnumValues(t *tes
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
 		Fields: graphql.Fields{
-			"testEnum": &graphql.FieldConfig{
+			"testEnum": &graphql.Field{
 				Type: testEnum,
 			},
 		},
@@ -1191,7 +1191,7 @@ func TestIntrospection_FailsAsExpectedOnThe__TypeRootFieldWithoutAnArg(t *testin
 	testType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "TestType",
 		Fields: graphql.Fields{
-			"testField": &graphql.FieldConfig{
+			"testField": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -1235,7 +1235,7 @@ func TestIntrospection_ExposesDescriptionsOnTypesAndFields(t *testing.T) {
 	queryRoot := graphql.NewObject(graphql.ObjectConfig{
 		Name: "QueryRoot",
 		Fields: graphql.Fields{
-			"onlyField": &graphql.FieldConfig{
+			"onlyField": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -1301,7 +1301,7 @@ func TestIntrospection_ExposesDescriptionsOnEnums(t *testing.T) {
 	queryRoot := graphql.NewObject(graphql.ObjectConfig{
 		Name: "QueryRoot",
 		Fields: graphql.Fields{
-			"onlyField": &graphql.FieldConfig{
+			"onlyField": &graphql.Field{
 				Type: graphql.String,
 			},
 		},

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -768,7 +768,7 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 						Type: testInputObject,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					return p.Args["complex"]
 				},
 			},

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func g(t *testing.T, p graphql.Params) *graphql.Result {
-	return graphql.Graphql(p)
+	return graphql.Do(p)
 }
 
 func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {

--- a/lists_test.go
+++ b/lists_test.go
@@ -25,7 +25,7 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 	})
 	dataType.AddFieldConfig("nest", &graphql.Field{
 		Type: dataType,
-		Resolve: func(p graphql.GQLFRParams) interface{} {
+		Resolve: func(p graphql.ResolveParams) interface{} {
 			return data
 		},
 	})

--- a/lists_test.go
+++ b/lists_test.go
@@ -17,7 +17,7 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 
 	dataType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "DataType",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"test": &graphql.FieldConfig{
 				Type: testType,
 			},

--- a/lists_test.go
+++ b/lists_test.go
@@ -18,12 +18,12 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 	dataType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "DataType",
 		Fields: graphql.Fields{
-			"test": &graphql.FieldConfig{
+			"test": &graphql.Field{
 				Type: testType,
 			},
 		},
 	})
-	dataType.AddFieldConfig("nest", &graphql.FieldConfig{
+	dataType.AddFieldConfig("nest", &graphql.Field{
 		Type: dataType,
 		Resolve: func(p graphql.GQLFRParams) interface{} {
 			return data

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -41,7 +41,7 @@ func (r *testRoot) PromiseAndFailToChangeTheNumber(newNumber int) *testNumberHol
 var numberHolderType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "NumberHolder",
 	Fields: graphql.Fields{
-		"theNumber": &graphql.FieldConfig{
+		"theNumber": &graphql.Field{
 			Type: graphql.Int,
 		},
 	},
@@ -51,7 +51,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 	Query: graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{
-			"numberHolder": &graphql.FieldConfig{
+			"numberHolder": &graphql.Field{
 				Type: numberHolderType,
 			},
 		},
@@ -59,7 +59,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 	Mutation: graphql.NewObject(graphql.ObjectConfig{
 		Name: "Mutation",
 		Fields: graphql.Fields{
-			"immediatelyChangeTheNumber": &graphql.FieldConfig{
+			"immediatelyChangeTheNumber": &graphql.Field{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{
 					"newNumber": &graphql.ArgumentConfig{
@@ -73,7 +73,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 					return obj.ImmediatelyChangeTheNumber(newNumber)
 				},
 			},
-			"promiseToChangeTheNumber": &graphql.FieldConfig{
+			"promiseToChangeTheNumber": &graphql.Field{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{
 					"newNumber": &graphql.ArgumentConfig{
@@ -87,7 +87,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 					return obj.PromiseToChangeTheNumber(newNumber)
 				},
 			},
-			"failToChangeTheNumber": &graphql.FieldConfig{
+			"failToChangeTheNumber": &graphql.Field{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{
 					"newNumber": &graphql.ArgumentConfig{
@@ -101,7 +101,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 					return obj.FailToChangeTheNumber(newNumber)
 				},
 			},
-			"promiseAndFailToChangeTheNumber": &graphql.FieldConfig{
+			"promiseAndFailToChangeTheNumber": &graphql.Field{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{
 					"newNumber": &graphql.ArgumentConfig{

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -40,7 +40,7 @@ func (r *testRoot) PromiseAndFailToChangeTheNumber(newNumber int) *testNumberHol
 // numberHolderType creates a mapping to testNumberHolder
 var numberHolderType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "NumberHolder",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"theNumber": &graphql.FieldConfig{
 			Type: graphql.Int,
 		},
@@ -50,7 +50,7 @@ var numberHolderType = graphql.NewObject(graphql.ObjectConfig{
 var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 	Query: graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"numberHolder": &graphql.FieldConfig{
 				Type: numberHolderType,
 			},
@@ -58,7 +58,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 	}),
 	Mutation: graphql.NewObject(graphql.ObjectConfig{
 		Name: "Mutation",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"immediatelyChangeTheNumber": &graphql.FieldConfig{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -66,7 +66,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -80,7 +80,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -94,7 +94,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -108,7 +108,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -48,7 +48,7 @@ var nullingData = map[string]interface{}{
 
 var dataType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "DataType",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"sync": &graphql.FieldConfig{
 			Type: graphql.String,
 		},

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -49,16 +49,16 @@ var nullingData = map[string]interface{}{
 var dataType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "DataType",
 	Fields: graphql.Fields{
-		"sync": &graphql.FieldConfig{
+		"sync": &graphql.Field{
 			Type: graphql.String,
 		},
-		"nonNullSync": &graphql.FieldConfig{
+		"nonNullSync": &graphql.Field{
 			Type: graphql.NewNonNull(graphql.String),
 		},
-		"promise": &graphql.FieldConfig{
+		"promise": &graphql.Field{
 			Type: graphql.String,
 		},
-		"nonNullPromise": &graphql.FieldConfig{
+		"nonNullPromise": &graphql.Field{
 			Type: graphql.NewNonNull(graphql.String),
 		},
 	},
@@ -95,16 +95,16 @@ func init() {
 		return nullingData
 	}
 
-	dataType.AddFieldConfig("nest", &graphql.FieldConfig{
+	dataType.AddFieldConfig("nest", &graphql.Field{
 		Type: dataType,
 	})
-	dataType.AddFieldConfig("nonNullNest", &graphql.FieldConfig{
+	dataType.AddFieldConfig("nonNullNest", &graphql.Field{
 		Type: graphql.NewNonNull(dataType),
 	})
-	dataType.AddFieldConfig("promiseNest", &graphql.FieldConfig{
+	dataType.AddFieldConfig("promiseNest", &graphql.Field{
 		Type: dataType,
 	})
-	dataType.AddFieldConfig("nonNullPromiseNest", &graphql.FieldConfig{
+	dataType.AddFieldConfig("nonNullPromiseNest", &graphql.Field{
 		Type: graphql.NewNonNull(dataType),
 	})
 }

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -494,8 +494,8 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	sort.Sort(gqlerrors.GQLFormattedErrorSlice(expected.Errors))
-	sort.Sort(gqlerrors.GQLFormattedErrorSlice(result.Errors))
+	sort.Sort(gqlerrors.FormattedErrors(expected.Errors))
+	sort.Sort(gqlerrors.FormattedErrors(result.Errors))
 	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -599,8 +599,8 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	sort.Sort(gqlerrors.GQLFormattedErrorSlice(expected.Errors))
-	sort.Sort(gqlerrors.GQLFormattedErrorSlice(result.Errors))
+	sort.Sort(gqlerrors.FormattedErrors(expected.Errors))
+	sort.Sort(gqlerrors.FormattedErrors(result.Errors))
 	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -997,8 +997,8 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	sort.Sort(gqlerrors.GQLFormattedErrorSlice(expected.Errors))
-	sort.Sort(gqlerrors.GQLFormattedErrorSlice(result.Errors))
+	sort.Sort(gqlerrors.FormattedErrors(expected.Errors))
+	sort.Sort(gqlerrors.FormattedErrors(result.Errors))
 	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}

--- a/schema.go
+++ b/schema.go
@@ -277,10 +277,10 @@ func assertObjectImplementsInterface(object *Object, iface *Interface) error {
 
 		// Assert each interface field arg is implemented.
 		for _, ifaceArg := range ifaceField.Args {
-			argName := ifaceArg.name
+			argName := ifaceArg.PrivateName
 			var objectArg *Argument
 			for _, arg := range objectField.Args {
-				if arg.name == argName {
+				if arg.PrivateName == argName {
 					objectArg = arg
 					break
 				}
@@ -314,10 +314,10 @@ func assertObjectImplementsInterface(object *Object, iface *Interface) error {
 		}
 		// Assert argument set invariance.
 		for _, objectArg := range objectField.Args {
-			argName := objectArg.name
+			argName := objectArg.PrivateName
 			var ifaceArg *Argument
 			for _, arg := range ifaceField.Args {
-				if arg.name == argName {
+				if arg.PrivateName == argName {
 					ifaceArg = arg
 					break
 				}

--- a/schema.go
+++ b/schema.go
@@ -52,8 +52,8 @@ func NewSchema(config SchemaConfig) (Schema, error) {
 	// Build type map now to detect any errors within this schema.
 	typeMap := TypeMap{}
 	objectTypes := []*Object{
-		schema.GetQueryType(),
-		schema.GetMutationType(),
+		schema.QueryType(),
+		schema.MutationType(),
 		__Type,
 		__Schema,
 	}
@@ -74,7 +74,7 @@ func NewSchema(config SchemaConfig) (Schema, error) {
 	for _, ttype := range typeMap {
 		switch ttype := ttype.(type) {
 		case *Object:
-			for _, iface := range ttype.GetInterfaces() {
+			for _, iface := range ttype.Interfaces() {
 				err := assertObjectImplementsInterface(ttype, iface)
 				if err != nil {
 					return schema, err
@@ -86,15 +86,15 @@ func NewSchema(config SchemaConfig) (Schema, error) {
 	return schema, nil
 }
 
-func (gq *Schema) GetQueryType() *Object {
+func (gq *Schema) QueryType() *Object {
 	return gq.schemaConfig.Query
 }
 
-func (gq *Schema) GetMutationType() *Object {
+func (gq *Schema) MutationType() *Object {
 	return gq.schemaConfig.Mutation
 }
 
-func (gq *Schema) GetDirectives() []*Directive {
+func (gq *Schema) Directives() []*Directive {
 	if len(gq.directives) == 0 {
 		gq.directives = []*Directive{
 			IncludeDirective,
@@ -104,17 +104,17 @@ func (gq *Schema) GetDirectives() []*Directive {
 	return gq.directives
 }
 
-func (gq *Schema) GetTypeMap() TypeMap {
+func (gq *Schema) TypeMap() TypeMap {
 	return gq.typeMap
 }
 
-func (gq *Schema) GetType(name string) Type {
-	return gq.GetTypeMap()[name]
+func (gq *Schema) Type(name string) Type {
+	return gq.TypeMap()[name]
 }
 
 func typeMapReducer(typeMap TypeMap, objectType Type) (TypeMap, error) {
 	var err error
-	if objectType == nil || objectType.GetName() == "" {
+	if objectType == nil || objectType.Name() == "" {
 		return typeMap, nil
 	}
 
@@ -133,25 +133,25 @@ func typeMapReducer(typeMap TypeMap, objectType Type) (TypeMap, error) {
 		}
 	}
 
-	if mappedObjectType, ok := typeMap[objectType.GetName()]; ok {
+	if mappedObjectType, ok := typeMap[objectType.Name()]; ok {
 		err := invariant(
 			mappedObjectType == objectType,
-			fmt.Sprintf(`Schema must contain unique named types but contains multiple types named "%v".`, objectType.GetName()),
+			fmt.Sprintf(`Schema must contain unique named types but contains multiple types named "%v".`, objectType.Name()),
 		)
 		if err != nil {
 			return typeMap, err
 		}
 		return typeMap, err
 	}
-	if objectType.GetName() == "" {
+	if objectType.Name() == "" {
 		return typeMap, nil
 	}
 
-	typeMap[objectType.GetName()] = objectType
+	typeMap[objectType.Name()] = objectType
 
 	switch objectType := objectType.(type) {
 	case *Union:
-		types := objectType.GetPossibleTypes()
+		types := objectType.PossibleTypes()
 		if objectType.err != nil {
 			return typeMap, objectType.err
 		}
@@ -165,7 +165,7 @@ func typeMapReducer(typeMap TypeMap, objectType Type) (TypeMap, error) {
 			}
 		}
 	case *Interface:
-		types := objectType.GetPossibleTypes()
+		types := objectType.PossibleTypes()
 		if objectType.err != nil {
 			return typeMap, objectType.err
 		}
@@ -179,7 +179,7 @@ func typeMapReducer(typeMap TypeMap, objectType Type) (TypeMap, error) {
 			}
 		}
 	case *Object:
-		interfaces := objectType.GetInterfaces()
+		interfaces := objectType.Interfaces()
 		if objectType.err != nil {
 			return typeMap, objectType.err
 		}
@@ -196,7 +196,7 @@ func typeMapReducer(typeMap TypeMap, objectType Type) (TypeMap, error) {
 
 	switch objectType := objectType.(type) {
 	case *Object:
-		fieldMap := objectType.GetFields()
+		fieldMap := objectType.Fields()
 		if objectType.err != nil {
 			return typeMap, objectType.err
 		}
@@ -213,7 +213,7 @@ func typeMapReducer(typeMap TypeMap, objectType Type) (TypeMap, error) {
 			}
 		}
 	case *Interface:
-		fieldMap := objectType.GetFields()
+		fieldMap := objectType.Fields()
 		if objectType.err != nil {
 			return typeMap, objectType.err
 		}
@@ -230,7 +230,7 @@ func typeMapReducer(typeMap TypeMap, objectType Type) (TypeMap, error) {
 			}
 		}
 	case *InputObject:
-		fieldMap := objectType.GetFields()
+		fieldMap := objectType.Fields()
 		if objectType.err != nil {
 			return typeMap, objectType.err
 		}
@@ -245,8 +245,8 @@ func typeMapReducer(typeMap TypeMap, objectType Type) (TypeMap, error) {
 }
 
 func assertObjectImplementsInterface(object *Object, iface *Interface) error {
-	objectFieldMap := object.GetFields()
-	ifaceFieldMap := iface.GetFields()
+	objectFieldMap := object.Fields()
+	ifaceFieldMap := iface.Fields()
 
 	// Assert each interface field is implemented.
 	for fieldName, _ := range ifaceFieldMap {
@@ -277,10 +277,10 @@ func assertObjectImplementsInterface(object *Object, iface *Interface) error {
 
 		// Assert each interface field arg is implemented.
 		for _, ifaceArg := range ifaceField.Args {
-			argName := ifaceArg.Name
+			argName := ifaceArg.name
 			var objectArg *Argument
 			for _, arg := range objectField.Args {
-				if arg.Name == argName {
+				if arg.name == argName {
 					objectArg = arg
 					break
 				}
@@ -314,10 +314,10 @@ func assertObjectImplementsInterface(object *Object, iface *Interface) error {
 		}
 		// Assert argument set invariance.
 		for _, objectArg := range objectField.Args {
-			argName := objectArg.Name
+			argName := objectArg.name
 			var ifaceArg *Argument
 			for _, arg := range ifaceField.Args {
-				if arg.Name == argName {
+				if arg.name == argName {
 					ifaceArg = arg
 					break
 				}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -120,15 +120,15 @@ func init() {
 		Name:        "Character",
 		Description: "A character in the Star Wars Trilogy",
 		Fields: graphql.Fields{
-			"id": &graphql.FieldConfig{
+			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the character.",
 			},
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the character.",
 			},
-			"appearsIn": &graphql.FieldConfig{
+			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
 			},
@@ -144,7 +144,7 @@ func init() {
 			return droidType
 		},
 	})
-	characterInterface.AddFieldConfig("friends", &graphql.FieldConfig{
+	characterInterface.AddFieldConfig("friends", &graphql.Field{
 		Type:        graphql.NewList(characterInterface),
 		Description: "The friends of the character, or an empty list if they have none.",
 	})
@@ -153,7 +153,7 @@ func init() {
 		Name:        "Human",
 		Description: "A humanoid creature in the Star Wars universe.",
 		Fields: graphql.Fields{
-			"id": &graphql.FieldConfig{
+			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the human.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -163,7 +163,7 @@ func init() {
 					return nil
 				},
 			},
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the human.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -173,7 +173,7 @@ func init() {
 					return nil
 				},
 			},
-			"friends": &graphql.FieldConfig{
+			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the human, or an empty list if they have none.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -183,7 +183,7 @@ func init() {
 					return []interface{}{}
 				},
 			},
-			"appearsIn": &graphql.FieldConfig{
+			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -193,7 +193,7 @@ func init() {
 					return nil
 				},
 			},
-			"homePlanet": &graphql.FieldConfig{
+			"homePlanet": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The home planet of the human, or null if unknown.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -212,7 +212,7 @@ func init() {
 		Name:        "Droid",
 		Description: "A mechanical creature in the Star Wars universe.",
 		Fields: graphql.Fields{
-			"id": &graphql.FieldConfig{
+			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the droid.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -222,7 +222,7 @@ func init() {
 					return nil
 				},
 			},
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the droid.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -232,7 +232,7 @@ func init() {
 					return nil
 				},
 			},
-			"friends": &graphql.FieldConfig{
+			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the droid, or an empty list if they have none.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -249,7 +249,7 @@ func init() {
 					return []interface{}{}
 				},
 			},
-			"appearsIn": &graphql.FieldConfig{
+			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -259,7 +259,7 @@ func init() {
 					return nil
 				},
 			},
-			"primaryFunction": &graphql.FieldConfig{
+			"primaryFunction": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The primary function of the droid.",
 				Resolve: func(p graphql.GQLFRParams) interface{} {
@@ -278,7 +278,7 @@ func init() {
 	queryType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{
-			"hero": &graphql.FieldConfig{
+			"hero": &graphql.Field{
 				Type: characterInterface,
 				Args: graphql.FieldConfigArgument{
 					"episode": &graphql.ArgumentConfig{
@@ -291,7 +291,7 @@ func init() {
 					return GetHero(p.Args["episode"])
 				},
 			},
-			"human": &graphql.FieldConfig{
+			"human": &graphql.Field{
 				Type: humanType,
 				Args: graphql.FieldConfigArgument{
 					"id": &graphql.ArgumentConfig{
@@ -303,7 +303,7 @@ func init() {
 					return GetHuman(p.Args["id"].(int))
 				},
 			},
-			"droid": &graphql.FieldConfig{
+			"droid": &graphql.Field{
 				Type: droidType,
 				Args: graphql.FieldConfigArgument{
 					"id": &graphql.ArgumentConfig{

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -119,7 +119,7 @@ func init() {
 	characterInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name:        "Character",
 		Description: "A character in the Star Wars Trilogy",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"id": &graphql.FieldConfig{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the character.",
@@ -152,7 +152,7 @@ func init() {
 	humanType = graphql.NewObject(graphql.ObjectConfig{
 		Name:        "Human",
 		Description: "A humanoid creature in the Star Wars universe.",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"id": &graphql.FieldConfig{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the human.",
@@ -211,7 +211,7 @@ func init() {
 	droidType = graphql.NewObject(graphql.ObjectConfig{
 		Name:        "Droid",
 		Description: "A mechanical creature in the Star Wars universe.",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"id": &graphql.FieldConfig{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the droid.",
@@ -277,7 +277,7 @@ func init() {
 
 	queryType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"hero": &graphql.FieldConfig{
 				Type: characterInterface,
 				Args: graphql.FieldConfigArgument{

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -156,7 +156,7 @@ func init() {
 			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the human.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Id
 					}
@@ -166,7 +166,7 @@ func init() {
 			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the human.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Name
 					}
@@ -176,7 +176,7 @@ func init() {
 			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the human, or an empty list if they have none.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Friends
 					}
@@ -186,7 +186,7 @@ func init() {
 			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.AppearsIn
 					}
@@ -196,7 +196,7 @@ func init() {
 			"homePlanet": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The home planet of the human, or null if unknown.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.HomePlanet
 					}
@@ -215,7 +215,7 @@ func init() {
 			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the droid.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.Id
 					}
@@ -225,7 +225,7 @@ func init() {
 			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the droid.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.Name
 					}
@@ -235,7 +235,7 @@ func init() {
 			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the droid, or an empty list if they have none.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						friends := []map[string]interface{}{}
 						for _, friend := range droid.Friends {
@@ -252,7 +252,7 @@ func init() {
 			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.AppearsIn
 					}
@@ -262,7 +262,7 @@ func init() {
 			"primaryFunction": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The primary function of the droid.",
-				Resolve: func(p graphql.GQLFRParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.PrimaryFunction
 					}
@@ -287,7 +287,7 @@ func init() {
 						Type: episodeEnum,
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) (r interface{}) {
+				Resolve: func(p graphql.ResolveParams) (r interface{}) {
 					return GetHero(p.Args["episode"])
 				},
 			},
@@ -299,7 +299,7 @@ func init() {
 						Type:        graphql.NewNonNull(graphql.String),
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) (r interface{}) {
+				Resolve: func(p graphql.ResolveParams) (r interface{}) {
 					return GetHuman(p.Args["id"].(int))
 				},
 			},
@@ -311,7 +311,7 @@ func init() {
 						Type:        graphql.NewNonNull(graphql.String),
 					},
 				},
-				Resolve: func(p graphql.GQLFRParams) (r interface{}) {
+				Resolve: func(p graphql.ResolveParams) (r interface{}) {
 					return GetDroid(p.Args["id"].(int))
 				},
 			},

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -31,7 +31,7 @@ type testPerson struct {
 var namedType = graphql.NewInterface(graphql.InterfaceConfig{
 	Name: "Named",
 	Fields: graphql.Fields{
-		"name": &graphql.FieldConfig{
+		"name": &graphql.Field{
 			Type: graphql.String,
 		},
 	},
@@ -42,10 +42,10 @@ var dogType = graphql.NewObject(graphql.ObjectConfig{
 		namedType,
 	},
 	Fields: graphql.Fields{
-		"name": &graphql.FieldConfig{
+		"name": &graphql.Field{
 			Type: graphql.String,
 		},
-		"barks": &graphql.FieldConfig{
+		"barks": &graphql.Field{
 			Type: graphql.Boolean,
 		},
 	},
@@ -60,10 +60,10 @@ var catType = graphql.NewObject(graphql.ObjectConfig{
 		namedType,
 	},
 	Fields: graphql.Fields{
-		"name": &graphql.FieldConfig{
+		"name": &graphql.Field{
 			Type: graphql.String,
 		},
-		"meows": &graphql.FieldConfig{
+		"meows": &graphql.Field{
 			Type: graphql.Boolean,
 		},
 	},
@@ -93,13 +93,13 @@ var personType = graphql.NewObject(graphql.ObjectConfig{
 		namedType,
 	},
 	Fields: graphql.Fields{
-		"name": &graphql.FieldConfig{
+		"name": &graphql.Field{
 			Type: graphql.String,
 		},
-		"pets": &graphql.FieldConfig{
+		"pets": &graphql.Field{
 			Type: graphql.NewList(petType),
 		},
-		"friends": &graphql.FieldConfig{
+		"friends": &graphql.Field{
 			Type: graphql.NewList(namedType),
 		},
 	},
@@ -505,7 +505,7 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 	namedType2 := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "Named",
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -522,10 +522,10 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 			namedType2,
 		},
 		Fields: graphql.Fields{
-			"name": &graphql.FieldConfig{
+			"name": &graphql.Field{
 				Type: graphql.String,
 			},
-			"friends": &graphql.FieldConfig{
+			"friends": &graphql.Field{
 				Type: graphql.NewList(namedType2),
 			},
 		},

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -497,8 +497,8 @@ func TestUnionIntersectionTypes_AllowsFragmentConditionsToBeAbstractTypes(t *tes
 }
 func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 
-	var encounteredSchema *graphql.Schema
-	var encounteredRootValue interface{}
+	//var encounteredSchema *graphql.Schema
+	//var encounteredRootValue interface{}
 
 	var personType2 *graphql.Object
 
@@ -510,8 +510,8 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 			},
 		},
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
-			encounteredSchema = &info.Schema
-			encounteredRootValue = info.RootValue
+			//encounteredSchema = &info.Schema
+			//encounteredRootValue = info.RootValue
 			return personType2
 		},
 	})

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -30,7 +30,7 @@ type testPerson struct {
 
 var namedType = graphql.NewInterface(graphql.InterfaceConfig{
 	Name: "Named",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"name": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -41,7 +41,7 @@ var dogType = graphql.NewObject(graphql.ObjectConfig{
 	Interfaces: []*graphql.Interface{
 		namedType,
 	},
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"name": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -59,7 +59,7 @@ var catType = graphql.NewObject(graphql.ObjectConfig{
 	Interfaces: []*graphql.Interface{
 		namedType,
 	},
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"name": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -92,7 +92,7 @@ var personType = graphql.NewObject(graphql.ObjectConfig{
 	Interfaces: []*graphql.Interface{
 		namedType,
 	},
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"name": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -504,7 +504,7 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 
 	namedType2 := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "Named",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -521,7 +521,7 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 		Interfaces: []*graphql.Interface{
 			namedType2,
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"name": &graphql.FieldConfig{
 				Type: graphql.String,
 			},

--- a/validation_test.go
+++ b/validation_test.go
@@ -21,7 +21,7 @@ var someScalarType = graphql.NewScalar(graphql.ScalarConfig{
 })
 var someObjectType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "SomeObject",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"f": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -32,7 +32,7 @@ var objectWithIsTypeOf = graphql.NewObject(graphql.ObjectConfig{
 	IsTypeOf: func(value interface{}, info graphql.ResolveInfo) bool {
 		return true
 	},
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"f": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -52,7 +52,7 @@ var someInterfaceType = graphql.NewInterface(graphql.InterfaceConfig{
 	ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 		return nil
 	},
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"f": &graphql.FieldConfig{
 			Type: graphql.String,
 		},
@@ -107,7 +107,7 @@ func schemaWithFieldType(ttype graphql.Output) (graphql.Schema, error) {
 	return graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"f": &graphql.FieldConfig{
 					Type: ttype,
 				},
@@ -119,7 +119,7 @@ func schemaWithInputObject(ttype graphql.Input) (graphql.Schema, error) {
 	return graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"f": &graphql.FieldConfig{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
@@ -136,7 +136,7 @@ func schemaWithObjectFieldOfType(fieldType graphql.Input) (graphql.Schema, error
 
 	badObjectType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "BadObject",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"badField": &graphql.FieldConfig{
 				Type: fieldType,
 			},
@@ -145,7 +145,7 @@ func schemaWithObjectFieldOfType(fieldType graphql.Input) (graphql.Schema, error
 	return graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"f": &graphql.FieldConfig{
 					Type: badObjectType,
 				},
@@ -158,7 +158,7 @@ func schemaWithObjectImplementingType(implementedType *graphql.Interface) (graph
 	badObjectType := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "BadObject",
 		Interfaces: []*graphql.Interface{implementedType},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -167,7 +167,7 @@ func schemaWithObjectImplementingType(implementedType *graphql.Interface) (graph
 	return graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"f": &graphql.FieldConfig{
 					Type: badObjectType,
 				},
@@ -187,7 +187,7 @@ func schemaWithUnionOfType(ttype *graphql.Object) (graphql.Schema, error) {
 	return graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"f": &graphql.FieldConfig{
 					Type: badObjectType,
 				},
@@ -199,7 +199,7 @@ func schemaWithInterfaceFieldOfType(ttype graphql.Type) (graphql.Schema, error) 
 
 	badInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "BadInterface",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"badField": &graphql.FieldConfig{
 				Type: ttype,
 			},
@@ -208,7 +208,7 @@ func schemaWithInterfaceFieldOfType(ttype graphql.Type) (graphql.Schema, error) 
 	return graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"f": &graphql.FieldConfig{
 					Type: badInterfaceType,
 				},
@@ -220,7 +220,7 @@ func schemaWithArgOfType(ttype graphql.Type) (graphql.Schema, error) {
 
 	badObject := graphql.NewObject(graphql.ObjectConfig{
 		Name: "BadObject",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"badField": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -234,7 +234,7 @@ func schemaWithArgOfType(ttype graphql.Type) (graphql.Schema, error) {
 	return graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"f": &graphql.FieldConfig{
 					Type: badObject,
 				},
@@ -255,7 +255,7 @@ func schemaWithInputFieldOfType(ttype graphql.Type) (graphql.Schema, error) {
 	return graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
-			Fields: graphql.FieldConfigMap{
+			Fields: graphql.Fields{
 				"f": &graphql.FieldConfig{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
@@ -280,7 +280,7 @@ func TestTypeSystem_SchemaMustHaveObjectRootTypes_AcceptsASchemaWhoseQueryTypeIs
 func TestTypeSystem_SchemaMustHaveObjectRootTypes_AcceptsASchemaWhoseQueryAndMutationTypesAreObjectType(t *testing.T) {
 	mutationObject := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Mutation",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"edit": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -312,7 +312,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichRedef
 	})
 	queryType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"normal": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -333,7 +333,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichDefin
 
 	a := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SameName",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -341,7 +341,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichDefin
 	})
 	b := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SameName",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -349,7 +349,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichDefin
 	})
 	queryType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"a": &graphql.FieldConfig{
 				Type: a,
 			},
@@ -373,7 +373,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -384,7 +384,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 		Interfaces: []*graphql.Interface{
 			anotherInterface,
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -395,7 +395,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 		Interfaces: []*graphql.Interface{
 			anotherInterface,
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -403,7 +403,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 	})
 	queryType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"iface": &graphql.FieldConfig{
 				Type: anotherInterface,
 			},
@@ -421,7 +421,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 func TestTypeSystem_ObjectsMustHaveFields_AcceptsAnObjectTypeWithFieldsObject(t *testing.T) {
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -444,7 +444,7 @@ func TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithMissingFields(t
 func TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithIncorrectlyNamedFields(t *testing.T) {
 	badObject := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"bad-name-with-dashes": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -459,7 +459,7 @@ func TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithIncorrectlyName
 func TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithEmptyFields(t *testing.T) {
 	badObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:   "SomeObject",
-		Fields: graphql.FieldConfigMap{},
+		Fields: graphql.Fields{},
 	})
 	_, err := schemaWithFieldType(badObject)
 	expectedError := `SomeObject fields must be an object with field names as keys or a function which return such an object.`
@@ -471,7 +471,7 @@ func TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithEmptyFields(t *
 func TestTypeSystem_FieldsArgsMustBeProperlyNamed_AcceptsFieldArgsWithValidNames(t *testing.T) {
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"goodField": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -489,7 +489,7 @@ func TestTypeSystem_FieldsArgsMustBeProperlyNamed_AcceptsFieldArgsWithValidNames
 func TestTypeSystem_FieldsArgsMustBeProperlyNamed_RejectsFieldArgWithInvalidNames(t *testing.T) {
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"badField": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -509,7 +509,7 @@ func TestTypeSystem_FieldsArgsMustBeProperlyNamed_RejectsFieldArgWithInvalidName
 func TestTypeSystem_FieldsArgsMustBeObjects_AcceptsAnObjectTypeWithFieldArgs(t *testing.T) {
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"goodField": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -531,7 +531,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithArrayInte
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -542,7 +542,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithArrayInte
 		Interfaces: (graphql.InterfacesThunk)(func() []*graphql.Interface {
 			return []*graphql.Interface{anotherInterfaceType}
 		}),
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -559,7 +559,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithInterface
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -568,7 +568,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithInterface
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name:       "SomeObject",
 		Interfaces: []*graphql.Interface{anotherInterfaceType},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -675,7 +675,7 @@ func TestTypeSystem_ObjectTypesMustBeAssertable_AcceptsAnObjectTypeWithAnIsTypeO
 		IsTypeOf: func(value interface{}, info graphql.ResolveInfo) bool {
 			return true
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -693,7 +693,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -702,7 +702,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name:       "SomeObject",
 		Interfaces: []*graphql.Interface{anotherInterfaceType},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -716,7 +716,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceWithImpleme
 
 	anotherInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -728,7 +728,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceWithImpleme
 		IsTypeOf: func(value interface{}, info graphql.ResolveInfo) bool {
 			return true
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -746,7 +746,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -758,7 +758,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 		IsTypeOf: func(value interface{}, info graphql.ResolveInfo) bool {
 			return true
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -968,7 +968,7 @@ func TestTypeSystem_ObjectsCanOnlyImplementInterfaces_AcceptsAnObjectImplementin
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"f": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -1106,7 +1106,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1120,7 +1120,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1142,7 +1142,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1156,7 +1156,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1181,7 +1181,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWhi
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1195,7 +1195,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWhi
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1221,7 +1221,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1235,7 +1235,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"anotherfield": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -1253,7 +1253,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1267,7 +1267,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: someScalarType,
 				Args: graphql.FieldConfigArgument{
@@ -1290,7 +1290,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1304,7 +1304,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -1322,7 +1322,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1336,7 +1336,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
@@ -1359,7 +1359,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.NewNonNull(graphql.NewList(graphql.String)),
 			},
@@ -1368,7 +1368,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.NewNonNull(graphql.NewList(graphql.String)),
 			},
@@ -1385,7 +1385,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 		ResolveType: func(value interface{}, info graphql.ResolveInfo) *graphql.Object {
 			return nil
 		},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.String,
 			},
@@ -1394,7 +1394,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 	anotherObject := graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: graphql.FieldConfigMap{
+		Fields: graphql.Fields{
 			"field": &graphql.FieldConfig{
 				Type: graphql.NewNonNull(graphql.String),
 			},

--- a/validation_test.go
+++ b/validation_test.go
@@ -1060,16 +1060,16 @@ func TestTypeSystem_ListMustAcceptGraphQLTypes_AcceptsAnTypeAsItemTypeOfList(t *
 	})
 	for _, ttype := range testTypes {
 		result := graphql.NewList(ttype)
-		if result.GetError() != nil {
-			t.Fatalf(`unexpected error: %v for type "%v"`, result.GetError(), ttype)
+		if result.Error() != nil {
+			t.Fatalf(`unexpected error: %v for type "%v"`, result.Error(), ttype)
 		}
 	}
 }
 func TestTypeSystem_ListMustAcceptGraphQLTypes_RejectsANilTypeAsItemTypeOfList(t *testing.T) {
 	result := graphql.NewList(nil)
 	expectedError := `Can only create List of a Type but got: <nil>.`
-	if result.GetError() == nil || result.GetError().Error() != expectedError {
-		t.Fatalf("Expected error: %v, got %v", expectedError, result.GetError())
+	if result.Error() == nil || result.Error().Error() != expectedError {
+		t.Fatalf("Expected error: %v, got %v", expectedError, result.Error())
 	}
 }
 
@@ -1087,16 +1087,16 @@ func TestTypeSystem_NonNullMustAcceptGraphQLTypes_AcceptsAnTypeAsNullableTypeOfN
 	}
 	for _, ttype := range nullableTypes {
 		result := graphql.NewNonNull(ttype)
-		if result.GetError() != nil {
-			t.Fatalf(`unexpected error: %v for type "%v"`, result.GetError(), ttype)
+		if result.Error() != nil {
+			t.Fatalf(`unexpected error: %v for type "%v"`, result.Error(), ttype)
 		}
 	}
 }
 func TestTypeSystem_NonNullMustAcceptGraphQLTypes_RejectsNilAsNonNullableType(t *testing.T) {
 	result := graphql.NewNonNull(nil)
 	expectedError := `Can only create NonNull of a Nullable Type but got: <nil>.`
-	if result.GetError() == nil || result.GetError().Error() != expectedError {
-		t.Fatalf("Expected error: %v, got %v", expectedError, result.GetError())
+	if result.Error() == nil || result.Error().Error() != expectedError {
+		t.Fatalf("Expected error: %v, got %v", expectedError, result.Error())
 	}
 }
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -22,7 +22,7 @@ var someScalarType = graphql.NewScalar(graphql.ScalarConfig{
 var someObjectType = graphql.NewObject(graphql.ObjectConfig{
 	Name: "SomeObject",
 	Fields: graphql.Fields{
-		"f": &graphql.FieldConfig{
+		"f": &graphql.Field{
 			Type: graphql.String,
 		},
 	},
@@ -33,7 +33,7 @@ var objectWithIsTypeOf = graphql.NewObject(graphql.ObjectConfig{
 		return true
 	},
 	Fields: graphql.Fields{
-		"f": &graphql.FieldConfig{
+		"f": &graphql.Field{
 			Type: graphql.String,
 		},
 	},
@@ -53,7 +53,7 @@ var someInterfaceType = graphql.NewInterface(graphql.InterfaceConfig{
 		return nil
 	},
 	Fields: graphql.Fields{
-		"f": &graphql.FieldConfig{
+		"f": &graphql.Field{
 			Type: graphql.String,
 		},
 	},
@@ -108,7 +108,7 @@ func schemaWithFieldType(ttype graphql.Output) (graphql.Schema, error) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"f": &graphql.FieldConfig{
+				"f": &graphql.Field{
 					Type: ttype,
 				},
 			},
@@ -120,7 +120,7 @@ func schemaWithInputObject(ttype graphql.Input) (graphql.Schema, error) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"f": &graphql.FieldConfig{
+				"f": &graphql.Field{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
 						"args": &graphql.ArgumentConfig{
@@ -137,7 +137,7 @@ func schemaWithObjectFieldOfType(fieldType graphql.Input) (graphql.Schema, error
 	badObjectType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "BadObject",
 		Fields: graphql.Fields{
-			"badField": &graphql.FieldConfig{
+			"badField": &graphql.Field{
 				Type: fieldType,
 			},
 		},
@@ -146,7 +146,7 @@ func schemaWithObjectFieldOfType(fieldType graphql.Input) (graphql.Schema, error
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"f": &graphql.FieldConfig{
+				"f": &graphql.Field{
 					Type: badObjectType,
 				},
 			},
@@ -159,7 +159,7 @@ func schemaWithObjectImplementingType(implementedType *graphql.Interface) (graph
 		Name:       "BadObject",
 		Interfaces: []*graphql.Interface{implementedType},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -168,7 +168,7 @@ func schemaWithObjectImplementingType(implementedType *graphql.Interface) (graph
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"f": &graphql.FieldConfig{
+				"f": &graphql.Field{
 					Type: badObjectType,
 				},
 			},
@@ -188,7 +188,7 @@ func schemaWithUnionOfType(ttype *graphql.Object) (graphql.Schema, error) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"f": &graphql.FieldConfig{
+				"f": &graphql.Field{
 					Type: badObjectType,
 				},
 			},
@@ -200,7 +200,7 @@ func schemaWithInterfaceFieldOfType(ttype graphql.Type) (graphql.Schema, error) 
 	badInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "BadInterface",
 		Fields: graphql.Fields{
-			"badField": &graphql.FieldConfig{
+			"badField": &graphql.Field{
 				Type: ttype,
 			},
 		},
@@ -209,7 +209,7 @@ func schemaWithInterfaceFieldOfType(ttype graphql.Type) (graphql.Schema, error) 
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"f": &graphql.FieldConfig{
+				"f": &graphql.Field{
 					Type: badInterfaceType,
 				},
 			},
@@ -221,7 +221,7 @@ func schemaWithArgOfType(ttype graphql.Type) (graphql.Schema, error) {
 	badObject := graphql.NewObject(graphql.ObjectConfig{
 		Name: "BadObject",
 		Fields: graphql.Fields{
-			"badField": &graphql.FieldConfig{
+			"badField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"badArg": &graphql.ArgumentConfig{
@@ -235,7 +235,7 @@ func schemaWithArgOfType(ttype graphql.Type) (graphql.Schema, error) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"f": &graphql.FieldConfig{
+				"f": &graphql.Field{
 					Type: badObject,
 				},
 			},
@@ -256,7 +256,7 @@ func schemaWithInputFieldOfType(ttype graphql.Type) (graphql.Schema, error) {
 		Query: graphql.NewObject(graphql.ObjectConfig{
 			Name: "Query",
 			Fields: graphql.Fields{
-				"f": &graphql.FieldConfig{
+				"f": &graphql.Field{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
 						"badArg": &graphql.ArgumentConfig{
@@ -281,7 +281,7 @@ func TestTypeSystem_SchemaMustHaveObjectRootTypes_AcceptsASchemaWhoseQueryAndMut
 	mutationObject := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Mutation",
 		Fields: graphql.Fields{
-			"edit": &graphql.FieldConfig{
+			"edit": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -313,10 +313,10 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichRedef
 	queryType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{
-			"normal": &graphql.FieldConfig{
+			"normal": &graphql.Field{
 				Type: graphql.String,
 			},
-			"fake": &graphql.FieldConfig{
+			"fake": &graphql.Field{
 				Type: fakeString,
 			},
 		},
@@ -334,7 +334,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichDefin
 	a := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SameName",
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -342,7 +342,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichDefin
 	b := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SameName",
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -350,10 +350,10 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichDefin
 	queryType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{
-			"a": &graphql.FieldConfig{
+			"a": &graphql.Field{
 				Type: a,
 			},
-			"b": &graphql.FieldConfig{
+			"b": &graphql.Field{
 				Type: b,
 			},
 		},
@@ -374,7 +374,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 			return nil
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -385,7 +385,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 			anotherInterface,
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -396,7 +396,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 			anotherInterface,
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -404,7 +404,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveS
 	queryType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{
-			"iface": &graphql.FieldConfig{
+			"iface": &graphql.Field{
 				Type: anotherInterface,
 			},
 		},
@@ -422,7 +422,7 @@ func TestTypeSystem_ObjectsMustHaveFields_AcceptsAnObjectTypeWithFieldsObject(t 
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -445,7 +445,7 @@ func TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithIncorrectlyName
 	badObject := graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
 		Fields: graphql.Fields{
-			"bad-name-with-dashes": &graphql.FieldConfig{
+			"bad-name-with-dashes": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -472,7 +472,7 @@ func TestTypeSystem_FieldsArgsMustBeProperlyNamed_AcceptsFieldArgsWithValidNames
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
 		Fields: graphql.Fields{
-			"goodField": &graphql.FieldConfig{
+			"goodField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"goodArgs": &graphql.ArgumentConfig{
@@ -490,7 +490,7 @@ func TestTypeSystem_FieldsArgsMustBeProperlyNamed_RejectsFieldArgWithInvalidName
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
 		Fields: graphql.Fields{
-			"badField": &graphql.FieldConfig{
+			"badField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"bad-name-with-dashes": &graphql.ArgumentConfig{
@@ -510,7 +510,7 @@ func TestTypeSystem_FieldsArgsMustBeObjects_AcceptsAnObjectTypeWithFieldArgs(t *
 	_, err := schemaWithFieldType(graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
 		Fields: graphql.Fields{
-			"goodField": &graphql.FieldConfig{
+			"goodField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"goodArgs": &graphql.ArgumentConfig{
@@ -532,7 +532,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithArrayInte
 			return nil
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -543,7 +543,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithArrayInte
 			return []*graphql.Interface{anotherInterfaceType}
 		}),
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -560,7 +560,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithInterface
 			return nil
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -569,7 +569,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithInterface
 		Name:       "SomeObject",
 		Interfaces: []*graphql.Interface{anotherInterfaceType},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -676,7 +676,7 @@ func TestTypeSystem_ObjectTypesMustBeAssertable_AcceptsAnObjectTypeWithAnIsTypeO
 			return true
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -694,7 +694,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 			return nil
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -703,7 +703,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 		Name:       "SomeObject",
 		Interfaces: []*graphql.Interface{anotherInterfaceType},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -717,7 +717,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceWithImpleme
 	anotherInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -729,7 +729,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceWithImpleme
 			return true
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -747,7 +747,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 			return nil
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -759,7 +759,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 			return true
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -969,7 +969,7 @@ func TestTypeSystem_ObjectsCanOnlyImplementInterfaces_AcceptsAnObjectImplementin
 			return nil
 		},
 		Fields: graphql.Fields{
-			"f": &graphql.FieldConfig{
+			"f": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -1107,7 +1107,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1121,7 +1121,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1143,7 +1143,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1157,7 +1157,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1165,7 +1165,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 					},
 				},
 			},
-			"anotherfield": &graphql.FieldConfig{
+			"anotherfield": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -1182,7 +1182,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWhi
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1196,7 +1196,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWhi
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1222,7 +1222,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1236,7 +1236,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"anotherfield": &graphql.FieldConfig{
+			"anotherfield": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -1254,7 +1254,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1268,7 +1268,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: someScalarType,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1291,7 +1291,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1305,7 +1305,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -1323,7 +1323,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1337,7 +1337,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
 					"input": &graphql.ArgumentConfig{
@@ -1360,7 +1360,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.NewNonNull(graphql.NewList(graphql.String)),
 			},
 		},
@@ -1369,7 +1369,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.NewNonNull(graphql.NewList(graphql.String)),
 			},
 		},
@@ -1386,7 +1386,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 			return nil
 		},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.String,
 			},
 		},
@@ -1395,7 +1395,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
 		Fields: graphql.Fields{
-			"field": &graphql.FieldConfig{
+			"field": &graphql.Field{
 				Type: graphql.NewNonNull(graphql.String),
 			},
 		},

--- a/values.go
+++ b/values.go
@@ -44,7 +44,7 @@ func getArgumentValues(argDefs []*Argument, argASTs []*ast.Argument, variableVar
 	results := map[string]interface{}{}
 	for _, argDef := range argDefs {
 
-		name := argDef.Name
+		name := argDef.name
 		var valueAST ast.Value
 		if argAST, ok := argASTMap[name]; ok {
 			valueAST = argAST.Value
@@ -147,7 +147,7 @@ func coerceValue(ttype Input, value interface{}) interface{} {
 		}
 
 		obj := map[string]interface{}{}
-		for fieldName, field := range ttype.GetFields() {
+		for fieldName, field := range ttype.Fields() {
 			value, _ := valueMap[fieldName]
 			fieldValue := coerceValue(field.Type, value)
 			if isNullish(fieldValue) {
@@ -197,7 +197,7 @@ func typeFromAST(schema Schema, inputTypeAST ast.Type) (Type, error) {
 		if inputTypeAST.Name != nil {
 			nameValue = inputTypeAST.Name.Value
 		}
-		ttype := schema.GetType(nameValue)
+		ttype := schema.Type(nameValue)
 		return ttype, nil
 	default:
 		return nil, invariant(inputTypeAST.GetKind() == kinds.Named, "Must be a named type.")
@@ -243,7 +243,7 @@ func isValidInputValue(value interface{}, ttype Input) bool {
 		if !ok {
 			return false
 		}
-		fields := ttype.GetFields()
+		fields := ttype.Fields()
 
 		// Ensure every provided field is defined.
 		for fieldName, _ := range valueMap {
@@ -362,7 +362,7 @@ func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]interfac
 
 		}
 		obj := map[string]interface{}{}
-		for fieldName, field := range ttype.GetFields() {
+		for fieldName, field := range ttype.Fields() {
 			fieldAST, ok := fieldASTs[fieldName]
 			if !ok || fieldAST == nil {
 				continue

--- a/values.go
+++ b/values.go
@@ -44,7 +44,7 @@ func getArgumentValues(argDefs []*Argument, argASTs []*ast.Argument, variableVar
 	results := map[string]interface{}{}
 	for _, argDef := range argDefs {
 
-		name := argDef.name
+		name := argDef.PrivateName
 		var valueAST ast.Value
 		if argAST, ok := argASTMap[name]; ok {
 			valueAST = argAST.Value

--- a/variables_test.go
+++ b/variables_test.go
@@ -68,7 +68,7 @@ func inputResolved(p graphql.GQLFRParams) interface{} {
 var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 	Name: "TestType",
 	Fields: graphql.Fields{
-		"fieldWithObjectInput": &graphql.FieldConfig{
+		"fieldWithObjectInput": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"input": &graphql.ArgumentConfig{
@@ -77,7 +77,7 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 			},
 			Resolve: inputResolved,
 		},
-		"fieldWithNullableStringInput": &graphql.FieldConfig{
+		"fieldWithNullableStringInput": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"input": &graphql.ArgumentConfig{
@@ -86,7 +86,7 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 			},
 			Resolve: inputResolved,
 		},
-		"fieldWithNonNullableStringInput": &graphql.FieldConfig{
+		"fieldWithNonNullableStringInput": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"input": &graphql.ArgumentConfig{
@@ -95,7 +95,7 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 			},
 			Resolve: inputResolved,
 		},
-		"fieldWithDefaultArgumentValue": &graphql.FieldConfig{
+		"fieldWithDefaultArgumentValue": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"input": &graphql.ArgumentConfig{
@@ -105,7 +105,7 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 			},
 			Resolve: inputResolved,
 		},
-		"list": &graphql.FieldConfig{
+		"list": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"input": &graphql.ArgumentConfig{
@@ -114,7 +114,7 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 			},
 			Resolve: inputResolved,
 		},
-		"nnList": &graphql.FieldConfig{
+		"nnList": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"input": &graphql.ArgumentConfig{
@@ -123,7 +123,7 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 			},
 			Resolve: inputResolved,
 		},
-		"listNN": &graphql.FieldConfig{
+		"listNN": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"input": &graphql.ArgumentConfig{
@@ -132,7 +132,7 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 			},
 			Resolve: inputResolved,
 		},
-		"nnListNN": &graphql.FieldConfig{
+		"nnListNN": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
 				"input": &graphql.ArgumentConfig{

--- a/variables_test.go
+++ b/variables_test.go
@@ -53,7 +53,7 @@ var testInputObject *graphql.InputObject = graphql.NewInputObject(graphql.InputO
 	},
 })
 
-func inputResolved(p graphql.GQLFRParams) interface{} {
+func inputResolved(p graphql.ResolveParams) interface{} {
 	input, ok := p.Args["input"]
 	if !ok {
 		return nil

--- a/variables_test.go
+++ b/variables_test.go
@@ -67,7 +67,7 @@ func inputResolved(p graphql.GQLFRParams) interface{} {
 
 var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 	Name: "TestType",
-	Fields: graphql.FieldConfigMap{
+	Fields: graphql.Fields{
 		"fieldWithObjectInput": &graphql.FieldConfig{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{


### PR DESCRIPTION
As discussed in #20 and #44, this renames a bunch of structs and methods. I simply used [`gorename`](https://godoc.org/golang.org/x/tools/cmd/gorename) to do this, there are no actual code changes.

`Graphql` -> `Do`
`FieldConfigMap` -> `Fields`
`FieldConfig` -> `Field`
`GQLFRParams` -> `ResolveParams`
`GQLFormattedErrorSlice` -> `FormattedErrors`
`Name` -> `PrivateName`
`Description` -> `PrivateDescription`
`GetName` -> `Name`
`GetDescription` -> `Description`
`GetError` -> `Error`
`GetValues` -> `Values`
`GetFields` -> `Fields`
`GetObjectType` -> `ObjectType`
`GetPossibleTypes` -> `PossibleTypes`
`GetInterfaces` -> `Interfaces`
`GetDirectives` -> `Directives`
`GetMutationType` -> `MutationType`
`GetQueryType` -> `QueryType`
`GetType` -> `Type`
`GetTypeMap` -> `TypeMap`

I couldn't use `name` and `description` due to `encoding/json` only working on exported fields.