### PR TITLE
Enable cyclic types in ObjectType and InputObjectType

### DIFF
--- a/definition_test.go
+++ b/definition_test.go
@@ -533,3 +533,25 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 	}
 
 }
+
+func TestTypeSystem_DefinitionExampe_AllowsCyclicFieldTypes(t *testing.T) {
+	personType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Person",
+		Fields: (graphql.ObjectFieldMapThunk)(func() graphql.FieldConfigMap {
+			return graphql.FieldConfigMap{
+				"name": &graphql.FieldConfig{
+					Type: graphql.String,
+				},
+				"bestFriend": &graphql.FieldConfig{
+					Type: personType,
+				},
+			}
+		}),
+	})
+
+	fieldMap := personType.GetFields()
+	if !reflect.DeepEqual(fieldMap["name"].Type, graphql.String) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(fieldMap["bestFriend"].Type, personType))
+	}
+
+}


### PR DESCRIPTION
I've implemented the ability to allow the definition of cyclic field configuration. However I'm not too sure about the implementation style since the code seems to implement it in different ways for object, interface and input object. I've also added a simple test cases for the cyclic type in object field configurations. Let me know if there is something else I need to do.
