### PR TITLE
resolve field function can return an error

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -48,20 +48,20 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if dog, ok := p.Source.(*testDog); ok {
-						return dog.Name
+						return dog.Name, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if dog, ok := p.Source.(*testDog); ok {
-						return dog.Woofs
+						return dog.Woofs, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},
@@ -79,20 +79,20 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if cat, ok := p.Source.(*testCat); ok {
-						return cat.Name
+						return cat.Name, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if cat, ok := p.Source.(*testCat); ok {
-						return cat.Meows
+						return cat.Meows, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},
@@ -103,11 +103,11 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
-						}
+						}, nil
 					},
 				},
 			},
@@ -202,11 +202,11 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
-						}
+						}, nil
 					},
 				},
 			},
@@ -288,11 +288,11 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(*testHuman); ok {
-						return human.Name
+						return human.Name, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},
@@ -309,20 +309,20 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if dog, ok := p.Source.(*testDog); ok {
-						return dog.Name
+						return dog.Name, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if dog, ok := p.Source.(*testDog); ok {
-						return dog.Woofs
+						return dog.Woofs, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},
@@ -339,20 +339,20 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if cat, ok := p.Source.(*testCat); ok {
-						return cat.Name
+						return cat.Name, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if cat, ok := p.Source.(*testCat); ok {
-						return cat.Meows
+						return cat.Meows, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},
@@ -363,12 +363,12 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
 							&testHuman{"Jon"},
-						}
+						}, nil
 					},
 				},
 			},
@@ -480,12 +480,12 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
 							&testHuman{"Jon"},
-						}
+						}, nil
 					},
 				},
 			},

--- a/definition.go
+++ b/definition.go
@@ -540,7 +540,7 @@ type ResolveParams struct {
 }
 
 // TODO: relook at FieldResolveFn params
-type FieldResolveFn func(p ResolveParams) interface{}
+type FieldResolveFn func(p ResolveParams) (interface{}, error)
 
 type ResolveInfo struct {
 	FieldName      string

--- a/definition_test.go
+++ b/definition_test.go
@@ -1,7 +1,6 @@
 package graphql_test
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -68,9 +67,6 @@ var blogArticle = graphql.NewObject(graphql.ObjectConfig{
 	},
 })
 
-var ErrArticleQuery = errors.New("ErrArticleQuery")
-var ErrArticleMutation = errors.New("ErrArticleMutation")
-
 var blogQuery = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Query",
 	Fields: graphql.Fields{
@@ -80,9 +76,6 @@ var blogQuery = graphql.NewObject(graphql.ObjectConfig{
 				"id": &graphql.ArgumentConfig{
 					Type: graphql.String,
 				},
-			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-				return nil, ErrArticleQuery
 			},
 		},
 		"feed": &graphql.Field{
@@ -100,9 +93,6 @@ var blogMutation = graphql.NewObject(graphql.ObjectConfig{
 				"title": &graphql.ArgumentConfig{
 					Type: graphql.String,
 				},
-			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-				return nil, ErrArticleMutation
 			},
 		},
 	},
@@ -548,46 +538,4 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedInputFields, fields))
 	}
 
-}
-
-func TestQuery_FieldResolveFn_AddsErrorsToGraphQLResult(t *testing.T) {
-	blogSchema, err := graphql.NewSchema(graphql.SchemaConfig{
-		Query:    blogQuery,
-		Mutation: blogMutation,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error, got: %v", err)
-	}
-	query := "{ article(id:\"1\") { id } }"
-	result := graphql.Do(graphql.Params{
-		Schema:        blogSchema,
-		RequestString: query,
-	})
-	if len(result.Errors) == 0 {
-		t.Fatal("wrong result, expected errors, got no errors")
-	}
-	if result.Errors[0].Error() != ErrArticleQuery.Error() {
-		t.Fatalf("wrong result, unexpected error, got: %v, expected: %v", result.Errors[0], ErrArticleQuery)
-	}
-}
-
-func TestMutation_FieldResolveFn_AddsErrorsToGraphQLResult(t *testing.T) {
-	blogSchema, err := graphql.NewSchema(graphql.SchemaConfig{
-		Query:    blogQuery,
-		Mutation: blogMutation,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error, got: %v", err)
-	}
-	query := "mutation _ { newArticle: writeArticle(title:\"article title\") { id  }  }"
-	result := graphql.Do(graphql.Params{
-		Schema:        blogSchema,
-		RequestString: query,
-	})
-	if len(result.Errors) == 0 {
-		t.Fatal("wrong result, expected errors, got no errors")
-	}
-	if result.Errors[0].Error() != ErrArticleMutation.Error() {
-		t.Fatalf("wrong result, unexpected error, got: %v, expected: %v", result.Errors[0], ErrArticleMutation)
-	}
 }

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -39,17 +39,17 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.String,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) interface{} {
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				if fromInt, ok := p.Args["fromInt"]; ok {
-					return fromInt
+					return fromInt, nil
 				}
 				if fromString, ok := p.Args["fromString"]; ok {
-					return fromString
+					return fromString, nil
 				}
 				if fromEnum, ok := p.Args["fromEnum"]; ok {
-					return fromEnum
+					return fromEnum, nil
 				}
-				return nil
+				return nil, nil
 			},
 		},
 		"colorInt": &graphql.Field{
@@ -62,14 +62,14 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.Int,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) interface{} {
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				if fromInt, ok := p.Args["fromInt"]; ok {
-					return fromInt
+					return fromInt, nil
 				}
 				if fromEnum, ok := p.Args["fromEnum"]; ok {
-					return fromEnum
+					return fromEnum, nil
 				}
-				return nil
+				return nil, nil
 			},
 		},
 	},
@@ -84,11 +84,11 @@ var enumTypeTestMutationType = graphql.NewObject(graphql.ObjectConfig{
 					Type: enumTypeTestColorType,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) interface{} {
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				if color, ok := p.Args["color"]; ok {
-					return color
+					return color, nil
 				}
-				return nil
+				return nil, nil
 			},
 		},
 	},

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -13,8 +13,8 @@ func main() {
 	fields := graphql.Fields{
 		"hello": &graphql.Field{
 			Type: graphql.String,
-			Resolve: func(p graphql.ResolveParams) interface{} {
-				return "world"
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				return "world", nil
 			},
 		},
 	}

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -56,12 +56,12 @@ var queryType = graphql.NewObject(
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					idQuery, isOK := p.Args["id"].(string)
 					if isOK {
-						return data[idQuery]
+						return data[idQuery], nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},

--- a/executor.go
+++ b/executor.go
@@ -498,11 +498,17 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 	// it is wrapped as a Error with locations. Log this error and return
 	// null if allowed, otherwise throw the error so the parent field can handle
 	// it.
-	result, _ = resolveFn(ResolveParams{
+	var resultError error
+
+	result, resultError = resolveFn(ResolveParams{
 		Source: source,
 		Args:   args,
 		Info:   info,
 	})
+
+	if resultError != nil {
+		panic(gqlerrors.FormatError(resultError))
+	}
 
 	completed := completeValueCatchingError(eCtx, returnType, fieldASTs, info, result)
 	return completed, resultState

--- a/executor.go
+++ b/executor.go
@@ -498,16 +498,16 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 	// it is wrapped as a Error with locations. Log this error and return
 	// null if allowed, otherwise throw the error so the parent field can handle
 	// it.
-	var resultError error
+	var resolveFnError error
 
-	result, resultError = resolveFn(ResolveParams{
+	result, resolveFnError = resolveFn(ResolveParams{
 		Source: source,
 		Args:   args,
 		Info:   info,
 	})
 
-	if resultError != nil {
-		panic(gqlerrors.FormatError(resultError))
+	if resolveFnError != nil {
+		panic(gqlerrors.FormatError(resolveFnError))
 	}
 
 	completed := completeValueCatchingError(eCtx, returnType, fieldASTs, info, result)

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -106,13 +106,13 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if author, ok := p.Source.(*testAuthor); ok {
 						width := fmt.Sprintf("%v", p.Args["width"])
 						height := fmt.Sprintf("%v", p.Args["height"])
-						return author.Pic(width, height)
+						return author.Pic(width, height), nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"recentArticle": &graphql.Field{},
@@ -156,14 +156,14 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						Type: graphql.ID,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					id := p.Args["id"]
-					return article(id)
+					return article(id), nil
 				},
 			},
 			"feed": &graphql.Field{
 				Type: graphql.NewList(blogArticle),
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					return []*testArticle{
 						article(1),
 						article(2),
@@ -175,7 +175,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						article(8),
 						article(9),
 						article(10),
-					}
+					}, nil
 				},
 			},
 		},

--- a/executor_test.go
+++ b/executor_test.go
@@ -1178,7 +1178,7 @@ func TestQuery_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 		RequestString: query,
 	})
 	if len(result.Errors) != 0 {
-		t.Fatal("wrong result, unexpected errors: %+v", result.Errors)
+		t.Fatalf("wrong result, unexpected errors: %+v", result.Errors)
 	}
 }
 
@@ -1289,6 +1289,6 @@ func TestMutation_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 		RequestString: query,
 	})
 	if len(result.Errors) != 0 {
-		t.Fatal("wrong result, expected errors, got no errors")
+		t.Fatalf("wrong result, unexpected errors: %+v", result.Errors)
 	}
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -103,18 +103,18 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	}
 
 	// Schema Definitions
-	picResolverFn := func(p graphql.ResolveParams) interface{} {
+	picResolverFn := func(p graphql.ResolveParams) (interface{}, error) {
 		// get and type assert ResolveFn for this field
 		picResolver, ok := p.Source.(map[string]interface{})["pic"].(func(size int) string)
 		if !ok {
-			return nil
+			return nil, nil
 		}
 		// get and type assert argument
 		sizeArg, ok := p.Args["size"].(int)
 		if !ok {
-			return nil
+			return nil, nil
 		}
-		return picResolver(sizeArg)
+		return picResolver(sizeArg), nil
 	}
 	dataType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "DataType",
@@ -244,28 +244,28 @@ func TestMergesParallelFragments(t *testing.T) {
 		Fields: graphql.Fields{
 			"a": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return "Apple"
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return "Apple", nil
 				},
 			},
 			"b": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return "Banana"
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return "Banana", nil
 				},
 			},
 			"c": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return "Cherry"
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return "Cherry", nil
 				},
 			},
 		},
 	})
 	deepTypeFieldConfig := &graphql.Field{
 		Type: typeObjectType,
-		Resolve: func(p graphql.ResolveParams) interface{} {
-			return p.Source
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			return p.Source, nil
 		},
 	}
 	typeObjectType.AddFieldConfig("deep", deepTypeFieldConfig)
@@ -312,9 +312,9 @@ func TestThreadsContextCorrectly(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						resolvedContext = p.Source.(map[string]interface{})
-						return resolvedContext
+						return resolvedContext, nil
 					},
 				},
 			},
@@ -368,9 +368,9 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 						},
 					},
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						resolvedArgs = p.Args
-						return resolvedArgs
+						return resolvedArgs, nil
 					},
 				},
 			},
@@ -944,9 +944,9 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 							Type: graphql.Int,
 						},
 					},
-					Resolve: func(p graphql.ResolveParams) interface{} {
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 						args, _ := json.Marshal(p.Args)
-						return string(args)
+						return string(args), nil
 					},
 				},
 			},
@@ -1019,8 +1019,8 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		Fields: graphql.Fields{
 			"value": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return p.Source.(testSpecialType).Value
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return p.Source.(testSpecialType).Value, nil
 				},
 			},
 		},
@@ -1031,8 +1031,8 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 			Fields: graphql.Fields{
 				"specials": &graphql.Field{
 					Type: graphql.NewList(specialType),
-					Resolve: func(p graphql.ResolveParams) interface{} {
-						return p.Source.(map[string]interface{})["specials"]
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+						return p.Source.(map[string]interface{})["specials"], nil
 					},
 				},
 			},

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -94,8 +94,8 @@ func testGraphql(test T, p graphql.Params, t *testing.T) {
 func TestBasicGraphQLExample(t *testing.T) {
 	// taken from `graphql-js` README
 
-	helloFieldResolved := func(p graphql.ResolveParams) interface{} {
-		return "world"
+	helloFieldResolved := func(p graphql.ResolveParams) (interface{}, error) {
+		return "world", nil
 	}
 
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{

--- a/introspection.go
+++ b/introspection.go
@@ -105,7 +105,7 @@ func init() {
 					case *NonNull:
 						return TypeKindNonNull, nil
 					}
-					panic(fmt.Sprintf("Unknown kind of type: %v", p.Source))
+					return nil, fmt.Errorf("Unknown kind of type: %v", p.Source)
 				},
 			},
 			"name": &Field{

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -768,8 +768,8 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 						Type: testInputObject,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) interface{} {
-					return p.Args["complex"]
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return p.Args["complex"], nil
 				},
 			},
 		},

--- a/lists_test.go
+++ b/lists_test.go
@@ -25,8 +25,8 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 	})
 	dataType.AddFieldConfig("nest", &graphql.Field{
 		Type: dataType,
-		Resolve: func(p graphql.ResolveParams) interface{} {
-			return data
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			return data, nil
 		},
 	})
 

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -66,11 +66,11 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
-					return obj.ImmediatelyChangeTheNumber(newNumber)
+					return obj.ImmediatelyChangeTheNumber(newNumber), nil
 				},
 			},
 			"promiseToChangeTheNumber": &graphql.Field{
@@ -80,11 +80,11 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
-					return obj.PromiseToChangeTheNumber(newNumber)
+					return obj.PromiseToChangeTheNumber(newNumber), nil
 				},
 			},
 			"failToChangeTheNumber": &graphql.Field{
@@ -94,11 +94,11 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
-					return obj.FailToChangeTheNumber(newNumber)
+					return obj.FailToChangeTheNumber(newNumber), nil
 				},
 			},
 			"promiseAndFailToChangeTheNumber": &graphql.Field{
@@ -108,11 +108,11 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
-					return obj.PromiseAndFailToChangeTheNumber(newNumber)
+					return obj.PromiseAndFailToChangeTheNumber(newNumber), nil
 				},
 			},
 		},

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -156,51 +156,51 @@ func init() {
 			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the human.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
-						return human.Id
+						return human.Id, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the human.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
-						return human.Name
+						return human.Name, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the human, or an empty list if they have none.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
-						return human.Friends
+						return human.Friends, nil
 					}
-					return []interface{}{}
+					return []interface{}{}, nil
 				},
 			},
 			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
-						return human.AppearsIn
+						return human.AppearsIn, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"homePlanet": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The home planet of the human, or null if unknown.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
-						return human.HomePlanet
+						return human.HomePlanet, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},
@@ -215,27 +215,27 @@ func init() {
 			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the droid.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
-						return droid.Id
+						return droid.Id, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the droid.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
-						return droid.Name
+						return droid.Name, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the droid, or an empty list if they have none.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						friends := []map[string]interface{}{}
 						for _, friend := range droid.Friends {
@@ -244,29 +244,29 @@ func init() {
 								"id":   friend.Id,
 							})
 						}
-						return droid.Friends
+						return droid.Friends, nil
 					}
-					return []interface{}{}
+					return []interface{}{}, nil
 				},
 			},
 			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
-						return droid.AppearsIn
+						return droid.AppearsIn, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 			"primaryFunction": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The primary function of the droid.",
-				Resolve: func(p graphql.ResolveParams) interface{} {
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
-						return droid.PrimaryFunction
+						return droid.PrimaryFunction, nil
 					}
-					return nil
+					return nil, nil
 				},
 			},
 		},
@@ -287,8 +287,8 @@ func init() {
 						Type: episodeEnum,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (r interface{}) {
-					return GetHero(p.Args["episode"])
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return GetHero(p.Args["episode"]), nil
 				},
 			},
 			"human": &graphql.Field{
@@ -299,8 +299,8 @@ func init() {
 						Type:        graphql.NewNonNull(graphql.String),
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (r interface{}) {
-					return GetHuman(p.Args["id"].(int))
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return GetHuman(p.Args["id"].(int)), nil
 				},
 			},
 			"droid": &graphql.Field{
@@ -311,8 +311,8 @@ func init() {
 						Type:        graphql.NewNonNull(graphql.String),
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (r interface{}) {
-					return GetDroid(p.Args["id"].(int))
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return GetDroid(p.Args["id"].(int)), nil
 				},
 			},
 		},

--- a/variables_test.go
+++ b/variables_test.go
@@ -53,16 +53,16 @@ var testInputObject *graphql.InputObject = graphql.NewInputObject(graphql.InputO
 	},
 })
 
-func inputResolved(p graphql.ResolveParams) interface{} {
+func inputResolved(p graphql.ResolveParams) (interface{}, error) {
 	input, ok := p.Args["input"]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	b, err := json.Marshal(input)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return string(b)
+	return string(b), nil
 }
 
 var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{


### PR DESCRIPTION
#### Details

- [x] Update `graphql.FieldResolveFn` return signature.
- [x] Update usage of `graphql.FieldResolveFn` to match new return signature.
- [x] Update `executor` to handle when any `graphql.FieldResolveFn` returns an error.
- [x] Write tests.