### PR TITLE
Add json tags to correct case for FromattedError

### DIFF
--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -7,8 +7,8 @@ import (
 )
 
 type FormattedError struct {
-	Message   string
-	Locations []location.SourceLocation
+	Message   string                    `json:"message"`
+	Locations []location.SourceLocation `json:"locations"`
 }
 
 func (g FormattedError) Error() string {

--- a/language/location/location.go
+++ b/language/location/location.go
@@ -7,8 +7,8 @@ import (
 )
 
 type SourceLocation struct {
-	Line   int
-	Column int
+	Line   int `json:"line"`
+	Column int `json:"column"`
 }
 
 func GetLocation(s *source.Source, position int) SourceLocation {


### PR DESCRIPTION
The GraphQL specification in section [7.2.2](https://facebook.github.io/graphql/#sec-Errors) says that the error response should contain entries with the keys: `message`, `locations`, `line` and `column`.

The spec also says in section [2.1.9](https://facebook.github.io/graphql/#sec-Names) the following:

> Names in GraphQL are case‐sensitive. That is to say `name`, `Name`, and `NAME` all refer to different names. Underscores are significant, which means other_name and othername are two different names.

As such, I have added tags to the relevant field declarations in the `FormattedError` type so that, when marshalled, the response will be case-correct.



