### PR TITLE
Fix hang in parser with bad tokens

### DIFF
--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/graphql-go/graphql/language/source"
 )
 
+func TestBadToken(t *testing.T) {
+	_, err := Parse(ParseParams{
+		Source: &source.Source{
+			Body: "query _ {\n  me {\n    id`\n  }\n}",
+			Name: "GraphQL",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected a parse error")
+	}
+}
+
 func TestAcceptsOptionToNotIncludeSource(t *testing.T) {
 	opts := ParseOptions{
 		NoSource: true,


### PR DESCRIPTION
Error from `advance` were not being handled which led to an infinite
loop in the parser. The included test would hang (timing out) before the change.