### PR TITLE
Adds Context support.

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/graphql-go/graphql/language/ast"
+	"golang.org/x/net/context"
 )
 
 // These are all of the possible kinds of
@@ -552,6 +553,11 @@ type ResolveInfo struct {
 	RootValue      interface{}
 	Operation      ast.Definition
 	VariableValues map[string]interface{}
+
+	// Context is passed through to resolve functions from either Params.Context
+	// or ExecuteParams.Context.  This can be used to provide per-request state
+	// from the application.
+	Context context.Context
 }
 
 type Fields map[string]*Field

--- a/definition.go
+++ b/definition.go
@@ -538,6 +538,9 @@ type ResolveParams struct {
 	Args   map[string]interface{}
 	Info   ResolveInfo
 	Schema Schema
+	//This can be used to provide per-request state
+	//from the application.
+	Context context.Context
 }
 
 // TODO: relook at FieldResolveFn params
@@ -553,11 +556,6 @@ type ResolveInfo struct {
 	RootValue      interface{}
 	Operation      ast.Definition
 	VariableValues map[string]interface{}
-
-	// Context is passed through to resolve functions from either Params.Context
-	// or ExecuteParams.Context.  This can be used to provide per-request state
-	// from the application.
-	Context context.Context
 }
 
 type Fields map[string]*Field

--- a/executor.go
+++ b/executor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/ast"
+	"golang.org/x/net/context"
 )
 
 type ExecuteParams struct {
@@ -16,6 +17,10 @@ type ExecuteParams struct {
 	AST           *ast.Document
 	OperationName string
 	Args          map[string]interface{}
+
+	// Context may be provided to pass application-specific per-request
+	// information to resolve functions.
+	Context context.Context
 }
 
 func Execute(p ExecuteParams) (result *Result) {
@@ -29,6 +34,7 @@ func Execute(p ExecuteParams) (result *Result) {
 		Args:          p.Args,
 		Errors:        nil,
 		Result:        result,
+		Context:       p.Context,
 	})
 
 	if err != nil {
@@ -62,6 +68,7 @@ type BuildExecutionCtxParams struct {
 	Args          map[string]interface{}
 	Errors        []gqlerrors.FormattedError
 	Result        *Result
+	Context       context.Context
 }
 type ExecutionContext struct {
 	Schema         Schema
@@ -70,6 +77,7 @@ type ExecutionContext struct {
 	Operation      ast.Definition
 	VariableValues map[string]interface{}
 	Errors         []gqlerrors.FormattedError
+	Context        context.Context
 }
 
 func buildExecutionContext(p BuildExecutionCtxParams) (*ExecutionContext, error) {
@@ -124,6 +132,7 @@ func buildExecutionContext(p BuildExecutionCtxParams) (*ExecutionContext, error)
 	eCtx.Operation = operation
 	eCtx.VariableValues = variableValues
 	eCtx.Errors = p.Errors
+	eCtx.Context = p.Context
 	return eCtx, nil
 }
 
@@ -492,6 +501,7 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 		RootValue:      eCtx.Root,
 		Operation:      eCtx.Operation,
 		VariableValues: eCtx.VariableValues,
+		Context:        eCtx.Context,
 	}
 
 	// TODO: If an error occurs while calling the field `resolve` function, ensure that

--- a/executor.go
+++ b/executor.go
@@ -501,7 +501,6 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 		RootValue:      eCtx.Root,
 		Operation:      eCtx.Operation,
 		VariableValues: eCtx.VariableValues,
-		Context:        eCtx.Context,
 	}
 
 	// TODO: If an error occurs while calling the field `resolve` function, ensure that
@@ -511,9 +510,10 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 	var resolveFnError error
 
 	result, resolveFnError = resolveFn(ResolveParams{
-		Source: source,
-		Args:   args,
-		Info:   info,
+		Source:  source,
+		Args:    args,
+		Info:    info,
+		Context: eCtx.Context,
 	})
 
 	if resolveFnError != nil {

--- a/executor_test.go
+++ b/executor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
+	"golang.org/x/net/context"
 )
 
 func TestExecutesArbitraryCode(t *testing.T) {
@@ -295,17 +296,17 @@ func TestMergesParallelFragments(t *testing.T) {
 	}
 }
 
-func TestThreadsContextCorrectly(t *testing.T) {
+func TestThreadsSourceCorrectly(t *testing.T) {
 
 	query := `
       query Example { a }
     `
 
 	data := map[string]interface{}{
-		"contextThing": "thing",
+		"key": "value",
 	}
 
-	var resolvedContext map[string]interface{}
+	var resolvedSource map[string]interface{}
 
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
 		Query: graphql.NewObject(graphql.ObjectConfig{
@@ -314,8 +315,8 @@ func TestThreadsContextCorrectly(t *testing.T) {
 				"a": &graphql.Field{
 					Type: graphql.String,
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						resolvedContext = p.Source.(map[string]interface{})
-						return resolvedContext, nil
+						resolvedSource = p.Source.(map[string]interface{})
+						return resolvedSource, nil
 					},
 				},
 			},
@@ -339,9 +340,9 @@ func TestThreadsContextCorrectly(t *testing.T) {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
 
-	expected := "thing"
-	if resolvedContext["contextThing"] != expected {
-		t.Fatalf("Expected context.contextThing to equal %v, got %v", expected, resolvedContext["contextThing"])
+	expected := "value"
+	if resolvedSource["key"] != expected {
+		t.Fatalf("Expected context.key to equal %v, got %v", expected, resolvedSource["key"])
 	}
 }
 
@@ -401,6 +402,53 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 	}
 	if resolvedArgs["stringArg"] != expectedString {
 		t.Fatalf("Expected args.stringArg to equal `%v`, got `%v`", expectedNum, resolvedArgs["stringArg"])
+	}
+}
+
+func TestThreadsContextCorrectly(t *testing.T) {
+
+	query := `
+      query Example { a }
+    `
+
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: graphql.NewObject(graphql.ObjectConfig{
+			Name: "Type",
+			Fields: graphql.Fields{
+				"a": &graphql.Field{
+					Type: graphql.String,
+					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+						return p.Info.Context.Value("foo"), nil
+					},
+				},
+			},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Error in schema %v", err.Error())
+	}
+
+	// parse query
+	ast := testutil.TestParse(t, query)
+
+	// execute
+	ep := graphql.ExecuteParams{
+		Schema:  schema,
+		AST:     ast,
+		Context: context.WithValue(context.Background(), "foo", "bar"),
+	}
+	result := testutil.TestExecute(t, ep)
+	if len(result.Errors) > 0 {
+		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
+	}
+
+	expected := &graphql.Result{
+		Data: map[string]interface{}{
+			"a": "bar",
+		},
+	}
+	if !reflect.DeepEqual(expected, result) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
 

--- a/executor_test.go
+++ b/executor_test.go
@@ -418,7 +418,7 @@ func TestThreadsContextCorrectly(t *testing.T) {
 				"a": &graphql.Field{
 					Type: graphql.String,
 					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						return p.Info.Context.Value("foo"), nil
+						return p.Context.Value("foo"), nil
 					},
 				},
 			},

--- a/graphql.go
+++ b/graphql.go
@@ -4,6 +4,7 @@ import (
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/parser"
 	"github.com/graphql-go/graphql/language/source"
+	"golang.org/x/net/context"
 )
 
 type Params struct {
@@ -12,6 +13,10 @@ type Params struct {
 	RootObject     map[string]interface{}
 	VariableValues map[string]interface{}
 	OperationName  string
+
+	// Context may be provided to pass application-specific per-request
+	// information to resolve functions.
+	Context context.Context
 }
 
 func Do(p Params) *Result {
@@ -39,5 +44,6 @@ func Do(p Params) *Result {
 		AST:           AST,
 		OperationName: p.OperationName,
 		Args:          p.VariableValues,
+		Context:       p.Context,
 	})
 }

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -135,7 +135,7 @@ func TestBasicGraphQLExample(t *testing.T) {
 
 func TestThreadsContextFromParamsThrough(t *testing.T) {
 	extractFieldFromContextFn := func(p graphql.ResolveParams) (interface{}, error) {
-		return p.Info.Context.Value(p.Args["key"]), nil
+		return p.Context.Value(p.Args["key"]), nil
 	}
 
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
+	"golang.org/x/net/context"
 )
 
 type T struct {
@@ -126,6 +127,45 @@ func TestBasicGraphQLExample(t *testing.T) {
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
+	if !reflect.DeepEqual(result.Data, expected) {
+		t.Fatalf("wrong result, query: %v, graphql result diff: %v", query, testutil.Diff(expected, result))
+	}
+
+}
+
+func TestThreadsContextFromParamsThrough(t *testing.T) {
+	extractFieldFromContextFn := func(p graphql.ResolveParams) (interface{}, error) {
+		return p.Info.Context.Value(p.Args["key"]), nil
+	}
+
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: graphql.NewObject(graphql.ObjectConfig{
+			Name: "Query",
+			Fields: graphql.Fields{
+				"value": &graphql.Field{
+					Type: graphql.String,
+					Args: graphql.FieldConfigArgument{
+						"key": &graphql.ArgumentConfig{Type: graphql.String},
+					},
+					Resolve: extractFieldFromContextFn,
+				},
+			},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("wrong result, unexpected errors: %v", err.Error())
+	}
+	query := `{ value(key:"a") }`
+
+	result := graphql.Do(graphql.Params{
+		Schema:        schema,
+		RequestString: query,
+		Context:       context.WithValue(context.TODO(), "a", "xyz"),
+	})
+	if len(result.Errors) > 0 {
+		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
+	}
+	expected := map[string]interface{}{"value": "xyz"}
 	if !reflect.DeepEqual(result.Data, expected) {
 		t.Fatalf("wrong result, query: %v, graphql result diff: %v", query, testutil.Diff(expected, result))
 	}


### PR DESCRIPTION
#### Details

- [x] Adds support for `Context` available on each field's `Resolve` function, eg:
  ```go
  graphq.Do({
    // ...
    Context: context.WithValue(context.Background(), "currentUser", user)
  })
  // ...
  Resolve: func(p graphql.ResolveParams) {
    u := p.Context.Value("currentUser")
  }
  ```
  - On previous related pr's, `Context` was exposed:
    - A new param of  `Resolve` function - `func(ctx context.Context, p ResolveParams)`
    - Through `graphql.ResolveParams.Info.Context`

  - I think it's more concise to expose context as field of `graphql.ResolveParams.Context` like to example showed above, if any thoughts on this please do share :+1: 
 
- Thanks a lot to @tallstreet & @augustoroman who initially proposed and worked on this on #25 and #82.