### PR TITLE
Adds Fieldsthunk to ObjectConfig.

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -412,10 +412,6 @@ func (gt *Object) Fields() FieldDefinitionMap {
 		configureFields = gt.typeConfig.Fields.(Fields)
 	case FieldsThunk:
 		configureFields = gt.typeConfig.Fields.(FieldsThunk)()
-	case nil:
-	default:
-		gt.err = errors.New(fmt.Sprintf("Unknown Object.Fields type: %v", reflect.TypeOf(gt.typeConfig.Fields)))
-		return nil
 	}
 	fields, err := defineFieldMap(gt, configureFields)
 	gt.err = err

--- a/definition.go
+++ b/definition.go
@@ -345,10 +345,11 @@ type InterfacesThunk func() []*Interface
 type ObjectConfig struct {
 	Name        string      `json:"description"`
 	Interfaces  interface{} `json:"interfaces"`
-	Fields      Fields      `json:"fields"`
+	Fields      interface{} `json:"fields"`
 	IsTypeOf    IsTypeOfFn  `json:"isTypeOf"`
 	Description string      `json:"description"`
 }
+type FieldsThunk func() Fields
 
 func NewObject(config ObjectConfig) *Object {
 	objectType := &Object{}
@@ -390,8 +391,10 @@ func (gt *Object) AddFieldConfig(fieldName string, fieldConfig *Field) {
 	if fieldName == "" || fieldConfig == nil {
 		return
 	}
-	gt.typeConfig.Fields[fieldName] = fieldConfig
-
+	switch gt.typeConfig.Fields.(type) {
+	case Fields:
+		gt.typeConfig.Fields.(Fields)[fieldName] = fieldConfig
+	}
 }
 func (gt *Object) Name() string {
 	return gt.PrivateName
@@ -403,11 +406,23 @@ func (gt *Object) String() string {
 	return gt.PrivateName
 }
 func (gt *Object) Fields() FieldDefinitionMap {
-	fields, err := defineFieldMap(gt, gt.typeConfig.Fields)
+	var configureFields Fields
+	switch gt.typeConfig.Fields.(type) {
+	case Fields:
+		configureFields = gt.typeConfig.Fields.(Fields)
+	case FieldsThunk:
+		configureFields = gt.typeConfig.Fields.(FieldsThunk)()
+	case nil:
+	default:
+		gt.err = errors.New(fmt.Sprintf("Unknown Object.Fields type: %v", reflect.TypeOf(gt.typeConfig.Fields)))
+		return nil
+	}
+	fields, err := defineFieldMap(gt, configureFields)
 	gt.err = err
 	gt.fields = fields
 	return gt.fields
 }
+
 func (gt *Object) Interfaces() []*Interface {
 	var configInterfaces []*Interface
 	switch gt.typeConfig.Interfaces.(type) {

--- a/definition_test.go
+++ b/definition_test.go
@@ -537,5 +537,25 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 	if !reflect.DeepEqual(inputFields, expectedInputFields) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedInputFields, fields))
 	}
+}
 
+func TestTypeSystem_DefinitionExample_IncludesFieldsThunk(t *testing.T) {
+	var someObject *graphql.Object
+	someObject = graphql.NewObject(graphql.ObjectConfig{
+		Name: "SomeObject",
+		Fields: (graphql.FieldsThunk)(func() graphql.Fields {
+			return graphql.Fields{
+				"f": &graphql.Field{
+					Type: graphql.Int,
+				},
+				"s": &graphql.Field{
+					Type: someObject,
+				},
+			}
+		}),
+	})
+	fieldMap := someObject.Fields()
+	if !reflect.DeepEqual(fieldMap["s"].Type, someObject) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(fieldMap["s"].Type, someObject))
+	}
 }

--- a/executor.go
+++ b/executor.go
@@ -397,7 +397,10 @@ func doesFragmentConditionMatch(eCtx *ExecutionContext, fragment ast.Node, ttype
 		if conditionalType == ttype {
 			return true
 		}
-
+                if conditionalType.GetName() == ttype.GetName() {
+			return true
+		}
+		
 		if conditionalType, ok := conditionalType.(Abstract); ok {
 			return conditionalType.IsPossibleType(ttype)
 		}

--- a/executor.go
+++ b/executor.go
@@ -397,7 +397,7 @@ func doesFragmentConditionMatch(eCtx *ExecutionContext, fragment ast.Node, ttype
 		if conditionalType == ttype {
 			return true
 		}
-                if conditionalType.GetName() == ttype.GetName() {
+                if conditionalType.Name() == ttype.Name() {
 			return true
 		}
 		

--- a/introspection.go
+++ b/introspection.go
@@ -266,6 +266,14 @@ mutation operations.`,
 					return nil, nil
 				},
 			},
+			"subscriptionType": &Field{
+				Description: `If this server support subscription, the type that ' +
+                   'subscription operations will be rooted at.`,
+				Type: __Type,
+				Resolve: func(p ResolveParams) (interface{}, error) {
+					return nil, nil
+				},
+			},
 			"directives": &Field{
 				Description: `A list of all directives supported by this server.`,
 				Type: NewNonNull(NewList(


### PR DESCRIPTION
#### Details.

- [x] Updates `ObjectConfig.Fields` to be an interface, so now possibles can be:
  - `graphql.Fields` & `graphql.FieldsThunk`

- Built in top of great work from @pyros2097 on #96  :+1:

Note: 
I've removed extra code within `Object.Fields()` since `graphql.defineFieldMap()` does handle it and is being covered with:
`TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithMissingFields`

cc/ @pyros2097 