### PR TITLE
Expose DefaultResolveFn to make it wrappable outside the library.

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -397,10 +397,10 @@ func doesFragmentConditionMatch(eCtx *ExecutionContext, fragment ast.Node, ttype
 		if conditionalType == ttype {
 			return true
 		}
-                if conditionalType.Name() == ttype.Name() {
+		if conditionalType.Name() == ttype.Name() {
 			return true
 		}
-		
+
 		if conditionalType, ok := conditionalType.(Abstract); ok {
 			return conditionalType.IsPossibleType(ttype)
 		}
@@ -484,7 +484,7 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 	returnType = fieldDef.Type
 	resolveFn := fieldDef.Resolve
 	if resolveFn == nil {
-		resolveFn = defaultResolveFn
+		resolveFn = DefaultResolveFn
 	}
 
 	// Build a map of arguments from the field.arguments AST, using the
@@ -685,7 +685,7 @@ func completeValue(eCtx *ExecutionContext, returnType Type, fieldASTs []*ast.Fie
 
 }
 
-func defaultResolveFn(p ResolveParams) (interface{}, error) {
+func DefaultResolveFn(p ResolveParams) (interface{}, error) {
 	// try to resolve p.Source as a struct first
 	sourceVal := reflect.ValueOf(p.Source)
 	if sourceVal.IsValid() && sourceVal.Type().Kind() == reflect.Ptr {


### PR DESCRIPTION
Hi!
I've started implementing ACL for my schema of data, and I want to be able to wrap the default resolve function for simple fields.
The wrapper is a function which checks rights for the particular field or object. If the access is not allowed, it returns an error.
Not sure if it is the right implementation. Probably, there's another way, and I would glad to hear alternatives.
Thanks!
