### PR TITLE
Add Pointer support to GraphQL

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -164,6 +164,7 @@ var _ Named = (*Interface)(nil)
 var _ Named = (*Union)(nil)
 var _ Named = (*Enum)(nil)
 var _ Named = (*InputObject)(nil)
+var _ Named = (*Pointer)(nil)
 
 func GetNamed(ttype Type) Named {
 	unmodifiedType := ttype
@@ -1302,6 +1303,58 @@ func (gl *NonNull) String() string {
 }
 func (gl *NonNull) Error() error {
 	return gl.err
+}
+
+// Pointer represents just that, a pointer to a value of another type. Pointers
+// are specific to langauges that support them, such as Go.
+type Pointer struct {
+	OfType Type `json:"ofType"`
+
+	err error
+}
+
+// NewPointer takes the given type and constructs a GraphQL pointer for that
+// type.
+func NewPointer(t Type) *Pointer {
+	p := &Pointer{}
+
+	err := invariant(t != nil, fmt.Sprintf("Can only create Pointer of a Type but got: %v.", t))
+	if err != nil {
+		p.err = err
+
+		return p
+	}
+
+	p.OfType = t
+
+	return p
+}
+
+// Name returns a GraphQL 'type name' that should represent what piece of data
+// is defined.
+func (p *Pointer) Name() string {
+	return fmt.Sprintf("*%v", p.OfType)
+}
+
+// Description is empty at the moment.
+func (p *Pointer) Description() string {
+	return ""
+}
+
+// String returns the Name of the pointer, also defined to fit *Pointer to
+// the fmt.Stringer interface.
+func (p *Pointer) String() string {
+	if p.OfType != nil {
+		return p.Name()
+	}
+
+	return ""
+}
+
+// Error returns an error value that may be attached to the Pointer value from
+// previous encounters.
+func (p *Pointer) Error() error {
+	return p.err
 }
 
 var NAME_REGEXP, _ = regexp.Compile("^[_a-zA-Z][_a-zA-Z0-9]*$")

--- a/definition_test.go
+++ b/definition_test.go
@@ -64,6 +64,21 @@ var blogArticle = graphql.NewObject(graphql.ObjectConfig{
 		"body": &graphql.Field{
 			Type: graphql.String,
 		},
+		"comments": &graphql.Field{
+			Type: graphql.NewPointer(graphql.NewList(blogComment)),
+		},
+	},
+})
+
+var blogComment = graphql.NewObject(graphql.ObjectConfig{
+	Name: "Comment",
+	Fields: graphql.Fields{
+		"id": &graphql.Field{
+			Type: graphql.NewPointer(graphql.String),
+		},
+		"body": &graphql.Field{
+			Type: graphql.NewPointer(graphql.String),
+		},
 	},
 })
 
@@ -202,6 +217,19 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 	}
 	if feedField.Name != "feed" {
 		t.Fatalf("feedField.Name expected to equal `feed`, got: %v", feedField.Name)
+	}
+
+	commentField := articleFieldTypeObject.Fields()["comments"]
+	commentFieldPtr, ok := commentField.Type.(*graphql.Pointer)
+	if !ok {
+		t.Fatalf("expected commentFieldPtr to be a Pointer, got: %v", commentField)
+	}
+	commentFieldPtrList, ok := commentFieldPtr.OfType.(*graphql.List)
+	if !ok {
+		t.Fatalf("expected commentFieldPtrList to be a List, got: %v", commentFieldPtrList)
+	}
+	if commentFieldPtrList.OfType != blogComment {
+		t.Fatalf("commentFieldPtrList.OfType expected to equal blogComment, got: %v", commentFieldPtrList.OfType)
 	}
 }
 func TestTypeSystem_DefinitionExample_DefinesAMutationScheme(t *testing.T) {
@@ -377,6 +405,9 @@ func TestTypeSystem_DefinitionExample_StringifiesSimpleTypes(t *testing.T) {
 		Test{graphql.NewNonNull(graphql.NewList(graphql.Int)), "[Int]!"},
 		Test{graphql.NewList(graphql.NewNonNull(graphql.Int)), "[Int!]"},
 		Test{graphql.NewList(graphql.NewList(graphql.Int)), "[[Int]]"},
+		Test{graphql.NewPointer(graphql.Int), "*Int"},
+		Test{graphql.NewPointer(graphql.NewList(graphql.Int)), "*[Int]"},
+		Test{graphql.NewNonNull(graphql.NewPointer(graphql.Int)), "*Int!"},
 	}
 	for _, test := range tests {
 		ttypeStr := fmt.Sprintf("%v", test.ttype)


### PR DESCRIPTION
This adds a new meta-type, `Pointer` to support pointer fields in structs. This allows easily converting a pattern like:

``` go
"ptr_field": &graphql.Field{
        Type: graphql.String,
        Resolve: func(params graphql.ResolveParams) (interface{}, error) {
                source := params.Source.(*SomeType)

                return *source.PtrField
        },
},
```

To simply:

``` go
"ptr_field": &graphql.Field{
        Type: graphql.NewPointer(graphql.String),
},
```

I realize that there is no spec for pointers but pointers aren't part of every language. I think it's important that we allow support for this due to significant amounts of boilerplate for simple pointer fields. I don't think there is really a better way to represent this outside of creating this new type, but I feel like it's an elegant solution.

This PR would close #101 
