### PR TITLE
Fix default values of input objects.

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -1230,6 +1230,56 @@ func TestQuery_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 	}
 }
 
+func TestQuery_InputObjectUsesFieldDefaultValueFn(t *testing.T) {
+	inputType := graphql.NewInputObject(graphql.InputObjectConfig{
+		Name: "Input",
+		Fields: graphql.InputObjectConfigFieldMap{
+			"default": &graphql.InputObjectFieldConfig{
+				Type:         graphql.String,
+				DefaultValue: "bar",
+			},
+		},
+	})
+	q := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"a": &graphql.Field{
+				Type: graphql.String,
+				Args: graphql.FieldConfigArgument{
+					"foo": &graphql.ArgumentConfig{
+						Type: graphql.NewNonNull(inputType),
+					},
+				},
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					val := p.Args["foo"].(map[string]interface{})
+					def, ok := val["default"]
+					if !ok || def == nil {
+						return nil, errors.New("queryError: No 'default' param")
+					}
+					if def.(string) != "bar" {
+						return nil, errors.New("queryError: 'default' param has wrong value")
+					}
+					return "ok", nil
+				},
+			},
+		},
+	})
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: q,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error, got: %v", err)
+	}
+	query := `{ a(foo: {}) }`
+	result := graphql.Do(graphql.Params{
+		Schema:        schema,
+		RequestString: query,
+	})
+	if len(result.Errors) != 0 {
+		t.Fatalf("wrong result, unexpected errors: %+v", result.Errors)
+	}
+}
+
 func TestMutation_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 	mError := errors.New("mutationError")
 	q := graphql.NewObject(graphql.ObjectConfig{

--- a/values.go
+++ b/values.go
@@ -364,10 +364,14 @@ func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]interfac
 		obj := map[string]interface{}{}
 		for fieldName, field := range ttype.Fields() {
 			fieldAST, ok := fieldASTs[fieldName]
+			fieldValue := field.DefaultValue
 			if !ok || fieldAST == nil {
-				continue
+				if fieldValue == nil {
+					continue
+				}
+			} else {
+				fieldValue = valueFromAST(fieldAST.Value, field.Type, variables)
 			}
-			fieldValue := valueFromAST(fieldAST.Value, field.Type, variables)
 			if isNullish(fieldValue) {
 				fieldValue = field.DefaultValue
 			}


### PR DESCRIPTION
This pull request fixes an issue where the default value of an input object's field was ignored. The issue is triggered under the following conditions:
1. An object's field contains arguments which are input objects.
2. The input objects contain fields for which a default value is specified.
3. The query does not provide an input object's field for which a default value is specified.
In this situation, the input object's field should be set to the default value, but was not.

Any comments on this pull request are welcome.

Best regards
Sven Schneider
