### PR TITLE
Allow GraphQLFloat to be represented by `float64`

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -96,27 +96,27 @@ var Int = NewScalar(ScalarConfig{
 	},
 })
 
-func coerceFloat32(value interface{}) interface{} {
+func coerceFloat(value interface{}) interface{} {
 	switch value := value.(type) {
 	case bool:
 		if value == true {
-			return float32(1)
+			return 1.0
 		}
-		return float32(0)
+		return 0.0
 	case int:
-		return float32(value)
+		return float64(value)
 	case float32:
 		return value
 	case float64:
-		return float32(value)
+		return value
 	case string:
 		val, err := strconv.ParseFloat(value, 0)
 		if err != nil {
 			return nil
 		}
-		return coerceFloat32(val)
+		return val
 	}
-	return float32(0)
+	return 0.0
 }
 
 // Float is the GraphQL float type definition.
@@ -125,8 +125,8 @@ var Float = NewScalar(ScalarConfig{
 	Description: "The `Float` scalar type represents signed double-precision fractional " +
 		"values as specified by " +
 		"[IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
-	Serialize:  coerceFloat32,
-	ParseValue: coerceFloat32,
+	Serialize:  coerceFloat,
+	ParseValue: coerceFloat,
 	ParseLiteral: func(valueAST ast.Value) interface{} {
 		switch valueAST := valueAST.(type) {
 		case *ast.FloatValue:

--- a/scalars_serialization_test.go
+++ b/scalars_serialization_test.go
@@ -12,7 +12,7 @@ type intSerializationTest struct {
 	Value    interface{}
 	Expected interface{}
 }
-type float32SerializationTest struct {
+type float64SerializationTest struct {
 	Value    interface{}
 	Expected interface{}
 }
@@ -37,6 +37,12 @@ func TestTypeSystem_Scalar_SerializesOutputInt(t *testing.T) {
 		{float32(-1.1), -1},
 		{float32(1e5), 100000},
 		{float32(math.MaxFloat32), nil},
+		{float64(0.1), 0},
+		{float64(1.1), 1},
+		{float64(-1.1), -1},
+		{float64(1e5), 100000},
+		{float64(math.MaxFloat32), nil},
+		{float64(math.MaxFloat64), nil},
 		// Maybe a safe Go/Javascript `int`, but bigger than 2^32, so not
 		// representable as a GraphQL Int
 		{9876504321, nil},
@@ -71,34 +77,49 @@ func TestTypeSystem_Scalar_SerializesOutputInt(t *testing.T) {
 		{[]int{}, nil},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		val := graphql.Int.Serialize(test.Value)
 		if val != test.Expected {
-			reflectedValue := reflect.ValueOf(test.Value)
-			t.Fatalf("Failed Int.Serialize(%v(%v)), expected: %v, got %v", reflectedValue.Type(), test.Value, test.Expected, val)
+			reflectedTestValue := reflect.ValueOf(test.Value)
+			reflectedExpectedValue := reflect.ValueOf(test.Expected)
+			reflectedValue := reflect.ValueOf(val)
+			t.Fatalf("Failed test #%d - Int.Serialize(%v(%v)), expected: %v(%v), got %v(%v)",
+				i, reflectedTestValue.Type(), test.Value,
+				reflectedExpectedValue.Type(), test.Expected,
+				reflectedValue.Type(), val,
+			)
 		}
 	}
 }
 
 func TestTypeSystem_Scalar_SerializesOutputFloat(t *testing.T) {
-	tests := []float32SerializationTest{
-		{int(1), float32(1.0)},
-		{int(0), float32(0.0)},
-		{int(-1), float32(-1.0)},
+	tests := []float64SerializationTest{
+		{int(1), 1.0},
+		{int(0), 0.0},
+		{int(-1), -1.0},
 		{float32(0.1), float32(0.1)},
 		{float32(1.1), float32(1.1)},
 		{float32(-1.1), float32(-1.1)},
-		{"-1.1", float32(-1.1)},
+		{float64(0.1), float64(0.1)},
+		{float64(1.1), float64(1.1)},
+		{float64(-1.1), float64(-1.1)},
+		{"-1.1", -1.1},
 		{"one", nil},
-		{false, float32(0.0)},
-		{true, float32(1.0)},
+		{false, 0.0},
+		{true, 1.0},
 	}
 
 	for i, test := range tests {
 		val := graphql.Float.Serialize(test.Value)
 		if val != test.Expected {
-			reflectedValue := reflect.ValueOf(test.Value)
-			t.Fatalf("Failed test #%d - Float.Serialize(%v(%v)), expected: %v, got %v", i, reflectedValue.Type(), test.Value, test.Expected, val)
+			reflectedTestValue := reflect.ValueOf(test.Value)
+			reflectedExpectedValue := reflect.ValueOf(test.Expected)
+			reflectedValue := reflect.ValueOf(val)
+			t.Fatalf("Failed test #%d - Float.Serialize(%v(%v)), expected: %v(%v), got %v(%v)",
+				i, reflectedTestValue.Type(), test.Value,
+				reflectedExpectedValue.Type(), test.Expected,
+				reflectedValue.Type(), val,
+			)
 		}
 	}
 }
@@ -108,6 +129,7 @@ func TestTypeSystem_Scalar_SerializesOutputStrings(t *testing.T) {
 		{"string", "string"},
 		{int(1), "1"},
 		{float32(-1.1), "-1.1"},
+		{float64(-1.1), "-1.1"},
 		{true, "true"},
 		{false, "false"},
 	}


### PR DESCRIPTION
This PR addresses #130 and depends on PR #123 

**Relevant commit changeset:**
https://github.com/graphql-go/graphql/commit/c7fc4935d154c7e250f0ec48aa787c996f28e353 Updated `graphql.Float` coercion

- if value type is explicitly `float32`, return `float32`
- if value type is explicitly `float64`, return `float64`
- if value type is `int`, return `float64`
- if value type is `string`, use `strconv.ParseFloat()` to return `float64`
- for everything else, use system-default

