### PR TITLE
Improve lexer performance by using a byte array as source

### DIFF
--- a/gqlerrors/syntax.go
+++ b/gqlerrors/syntax.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"regexp"
 
+	"strings"
+
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/language/source"
-	"strings"
 )
 
 func NewSyntaxError(s *source.Source, position int, description string) *Error {
@@ -44,7 +45,7 @@ func highlightSourceAtLocation(s *source.Source, l location.SourceLocation) stri
 	lineNum := fmt.Sprintf("%d", line)
 	nextLineNum := fmt.Sprintf("%d", (line + 1))
 	padLen := len(nextLineNum)
-	lines := regexp.MustCompile("\r\n|[\n\r]").Split(s.Body, -1)
+	lines := regexp.MustCompile("\r\n|[\n\r]").Split(string(s.Body), -1)
 	var highlight string
 	if line >= 2 {
 		highlight += fmt.Sprintf("%s: %s\n", lpad(padLen, prevLineNum), printLine(lines[line-2]))

--- a/graphql.go
+++ b/graphql.go
@@ -34,7 +34,7 @@ type Params struct {
 
 func Do(p Params) *Result {
 	source := source.NewSource(&source.Source{
-		Body: p.RequestString,
+		Body: []byte(p.RequestString),
 		Name: "GraphQL request",
 	})
 	AST, err := parser.Parse(parser.ParseParams{Source: source})

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -1,7 +1,9 @@
 package lexer
 
 import (
+	"bytes"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/source"
@@ -102,12 +104,6 @@ func Lex(s *source.Source) Lexer {
 	}
 }
 
-func runeStringValueAt(body string, start, end int) string {
-	// convert body string to runes, to handle unicode
-	bodyRunes := []rune(body)
-	return string(bodyRunes[start:end])
-}
-
 // Reads an alphanumeric + underscore name from the source.
 // [_A-Za-z][_0-9A-Za-z]*
 func readName(source *source.Source, position int) Token {
@@ -115,69 +111,69 @@ func readName(source *source.Source, position int) Token {
 	bodyLength := len(body)
 	end := position + 1
 	for {
-		code := charCodeAt(body, end)
-		if (end != bodyLength) && code != 0 &&
-			(code == 95 || // _
-				code >= 48 && code <= 57 || // 0-9
-				code >= 65 && code <= 90 || // A-Z
-				code >= 97 && code <= 122) { // a-z
-			end++
+		code, n := runeAt(body, end)
+		if (end != bodyLength) &&
+			(code == '_' || // _
+				code >= '0' && code <= '9' || // 0-9
+				code >= 'A' && code <= 'Z' || // A-Z
+				code >= 'a' && code <= 'z') { // a-z
+			end += n
 			continue
 		} else {
 			break
 		}
 	}
-	return makeToken(TokenKind[NAME], position, end, runeStringValueAt(body, position, end))
+	return makeToken(TokenKind[NAME], position, end, string(body[position:end]))
 }
 
 // Reads a number token from the source file, either a float
 // or an int depending on whether a decimal point appears.
 // Int:   -?(0|[1-9][0-9]*)
 // Float: -?(0|[1-9][0-9]*)(\.[0-9]+)?((E|e)(+|-)?[0-9]+)?
-func readNumber(s *source.Source, start int, firstCode rune) (Token, error) {
+func readNumber(s *source.Source, start int, firstCode rune, codeLength int) (Token, error) {
 	code := firstCode
 	body := s.Body
 	position := start
 	isFloat := false
-	if code == 45 { // -
-		position++
-		code = charCodeAt(body, position)
+	if code == '-' { // -
+		position += codeLength
+		code, codeLength = runeAt(body, position)
 	}
-	if code == 48 { // 0
-		position++
-		code = charCodeAt(body, position)
-		if code >= 48 && code <= 57 {
+	if code == '0' { // 0
+		position += codeLength
+		code, codeLength = runeAt(body, position)
+		if code >= '0' && code <= '9' {
 			description := fmt.Sprintf("Invalid number, unexpected digit after 0: %v.", printCharCode(code))
 			return Token{}, gqlerrors.NewSyntaxError(s, position, description)
 		}
 	} else {
-		p, err := readDigits(s, position, code)
+		p, err := readDigits(s, position, code, codeLength)
 		if err != nil {
 			return Token{}, err
 		}
 		position = p
-		code = charCodeAt(body, position)
+		code, codeLength = runeAt(body, position)
 	}
-	if code == 46 { // .
+	if code == '.' { // .
 		isFloat = true
-		position++
-		code = charCodeAt(body, position)
-		p, err := readDigits(s, position, code)
+		position += codeLength
+		code, codeLength = runeAt(body, position)
+		p, err := readDigits(s, position, code, codeLength)
 		if err != nil {
 			return Token{}, err
 		}
 		position = p
-		code = charCodeAt(body, position)
+		code, codeLength = runeAt(body, position)
 	}
-	if code == 69 || code == 101 { // E e
+	if code == 'E' || code == 'e' { // E e
 		isFloat = true
-		position++
-		code = charCodeAt(body, position)
-		if code == 43 || code == 45 { // + -
-			position++
-			code = charCodeAt(body, position)
+		position += codeLength
+		code, codeLength = runeAt(body, position)
+		if code == '+' || code == '-' { // + -
+			position += codeLength
+			code, codeLength = runeAt(body, position)
 		}
-		p, err := readDigits(s, position, code)
+		p, err := readDigits(s, position, code, codeLength)
 		if err != nil {
 			return Token{}, err
 		}
@@ -187,19 +183,20 @@ func readNumber(s *source.Source, start int, firstCode rune) (Token, error) {
 	if isFloat {
 		kind = TokenKind[FLOAT]
 	}
-	return makeToken(kind, start, position, runeStringValueAt(body, start, position)), nil
+
+	return makeToken(kind, start, position, string(body[start:position])), nil
 }
 
 // Returns the new position in the source after reading digits.
-func readDigits(s *source.Source, start int, firstCode rune) (int, error) {
+func readDigits(s *source.Source, start int, firstCode rune, codeLength int) (int, error) {
 	body := s.Body
 	position := start
 	code := firstCode
-	if code >= 48 && code <= 57 { // 0 - 9
+	if code >= '0' && code <= '9' { // 0 - 9
 		for {
-			if code >= 48 && code <= 57 { // 0 - 9
-				position++
-				code = charCodeAt(body, position)
+			if code >= '0' && code <= '9' { // 0 - 9
+				position += codeLength
+				code, codeLength = runeAt(body, position)
 				continue
 			} else {
 				break
@@ -217,68 +214,75 @@ func readString(s *source.Source, start int) (Token, error) {
 	position := start + 1
 	chunkStart := position
 	var code rune
-	var value string
+	var n int
+	var valueBuffer bytes.Buffer
 	for {
-		code = charCodeAt(body, position)
+		code, n = runeAt(body, position)
 		if position < len(body) &&
 			// not LineTerminator
 			code != 0x000A && code != 0x000D &&
 			// not Quote (")
-			code != 34 {
+			code != '"' {
 
 			// SourceCharacter
 			if code < 0x0020 && code != 0x0009 {
 				return Token{}, gqlerrors.NewSyntaxError(s, position, fmt.Sprintf(`Invalid character within String: %v.`, printCharCode(code)))
 			}
-			position++
-			if code == 92 { // \
-				value += body[chunkStart : position-1]
-				code = charCodeAt(body, position)
+			position += n
+			if code == '\\' { // \
+				valueBuffer.Write(body[chunkStart : position-1])
+				code, n = runeAt(body, position)
 				switch code {
-				case 34:
-					value += "\""
+				case '"':
+					valueBuffer.WriteRune('"')
 					break
-				case 47:
-					value += "\\/"
+				case '/':
+					valueBuffer.WriteRune('/')
 					break
-				case 92:
-					value += "\\"
+				case '\\':
+					valueBuffer.WriteRune('\\')
 					break
-				case 98:
-					value += "\b"
+				case 'b':
+					valueBuffer.WriteRune('\b')
 					break
-				case 102:
-					value += "\f"
+				case 'f':
+					valueBuffer.WriteRune('\f')
 					break
-				case 110:
-					value += "\n"
+				case 'n':
+					valueBuffer.WriteRune('\n')
 					break
-				case 114:
-					value += "\r"
+				case 'r':
+					valueBuffer.WriteRune('\r')
 					break
-				case 116:
-					value += "\t"
+				case 't':
+					valueBuffer.WriteRune('\t')
 					break
-				case 117: // u
+				case 'u':
+					// Check if there are at least 4 bytes available
+					if len(body) <= position+4 {
+						return Token{}, gqlerrors.NewSyntaxError(s, position,
+							fmt.Sprintf("Invalid character escape sequence: "+
+								"\\u%v", body[position+1:]))
+					}
 					charCode := uniCharCode(
-						charCodeAt(body, position+1),
-						charCodeAt(body, position+2),
-						charCodeAt(body, position+3),
-						charCodeAt(body, position+4),
+						rune(body[position+1]),
+						rune(body[position+2]),
+						rune(body[position+3]),
+						rune(body[position+4]),
 					)
 					if charCode < 0 {
 						return Token{}, gqlerrors.NewSyntaxError(s, position,
 							fmt.Sprintf("Invalid character escape sequence: "+
 								"\\u%v", body[position+1:position+5]))
 					}
-					value += fmt.Sprintf("%c", charCode)
+					valueBuffer.WriteRune(charCode)
 					position += 4
 					break
 				default:
 					return Token{}, gqlerrors.NewSyntaxError(s, position,
 						fmt.Sprintf(`Invalid character escape sequence: \\%c.`, code))
 				}
-				position++
+				position += n
 				chunkStart = position
 			}
 			continue
@@ -286,10 +290,12 @@ func readString(s *source.Source, start int) (Token, error) {
 			break
 		}
 	}
-	if code != 34 { // quote (")
+	if code != '"' { // quote (")
 		return Token{}, gqlerrors.NewSyntaxError(s, position, "Unterminated string.")
 	}
-	value += runeStringValueAt(body, chunkStart, position)
+	stringContent := body[chunkStart:position]
+	valueBuffer.Write(stringContent)
+	value := valueBuffer.String()
 	return makeToken(TokenKind[STRING], start, position+1, value), nil
 }
 
@@ -344,7 +350,7 @@ func readToken(s *source.Source, fromPosition int) (Token, error) {
 	if position >= bodyLength {
 		return makeToken(TokenKind[EOF], position, position, ""), nil
 	}
-	code := charCodeAt(body, position)
+	code, codeLength := runeAt(body, position)
 
 	// SourceCharacter
 	if code < 0x0020 && code != 0x0009 && code != 0x000A && code != 0x000D {
@@ -353,66 +359,68 @@ func readToken(s *source.Source, fromPosition int) (Token, error) {
 
 	switch code {
 	// !
-	case 33:
+	case '!':
 		return makeToken(TokenKind[BANG], position, position+1, ""), nil
 	// $
-	case 36:
+	case '$':
 		return makeToken(TokenKind[DOLLAR], position, position+1, ""), nil
 	// (
-	case 40:
+	case '(':
 		return makeToken(TokenKind[PAREN_L], position, position+1, ""), nil
 	// )
-	case 41:
+	case ')':
 		return makeToken(TokenKind[PAREN_R], position, position+1, ""), nil
 	// .
-	case 46:
-		if charCodeAt(body, position+1) == 46 && charCodeAt(body, position+2) == 46 {
+	case '.':
+		next1, _ := runeAt(body, position+1)
+		next2, _ := runeAt(body, position+2)
+		if next1 == '.' && next2 == '.' {
 			return makeToken(TokenKind[SPREAD], position, position+3, ""), nil
 		}
 		break
 	// :
-	case 58:
+	case ':':
 		return makeToken(TokenKind[COLON], position, position+1, ""), nil
 	// =
-	case 61:
+	case '=':
 		return makeToken(TokenKind[EQUALS], position, position+1, ""), nil
 	// @
-	case 64:
+	case '@':
 		return makeToken(TokenKind[AT], position, position+1, ""), nil
 	// [
-	case 91:
+	case '[':
 		return makeToken(TokenKind[BRACKET_L], position, position+1, ""), nil
 	// ]
-	case 93:
+	case ']':
 		return makeToken(TokenKind[BRACKET_R], position, position+1, ""), nil
 	// {
-	case 123:
+	case '{':
 		return makeToken(TokenKind[BRACE_L], position, position+1, ""), nil
 	// |
-	case 124:
+	case '|':
 		return makeToken(TokenKind[PIPE], position, position+1, ""), nil
 	// }
-	case 125:
+	case '}':
 		return makeToken(TokenKind[BRACE_R], position, position+1, ""), nil
 	// A-Z
-	case 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
-		82, 83, 84, 85, 86, 87, 88, 89, 90:
+	case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
+		'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z':
 		return readName(s, position), nil
 	// _
 	// a-z
-	case 95, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
-		111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122:
+	case '_', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+		'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z':
 		return readName(s, position), nil
 	// -
 	// 0-9
-	case 45, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57:
-		token, err := readNumber(s, position, code)
+	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		token, err := readNumber(s, position, code, codeLength)
 		if err != nil {
 			return token, err
 		}
 		return token, nil
 	// "
-	case 34:
+	case '"':
 		token, err := readString(s, position)
 		if err != nil {
 			return token, err
@@ -423,24 +431,29 @@ func readToken(s *source.Source, fromPosition int) (Token, error) {
 	return Token{}, gqlerrors.NewSyntaxError(s, position, description)
 }
 
-func charCodeAt(body string, position int) rune {
-	r := []rune(body)
-	if len(r) > position {
-		return r[position]
+func runeAt(body []byte, position int) (code rune, charWidth int) {
+	if len(body) <= position {
+		return 0, utf8.RuneError
 	}
-	return -1
 
+	c := body[position]
+	if c < utf8.RuneSelf {
+		return rune(c), 1
+	}
+
+	r, n := utf8.DecodeRune(body[position:])
+	return r, n
 }
 
 // Reads from body starting at startPosition until it finds a non-whitespace
 // or commented character, then returns the position of that character for lexing.
 // lexing.
-func positionAfterWhitespace(body string, startPosition int) int {
+func positionAfterWhitespace(body []byte, startPosition int) int {
 	bodyLength := len(body)
 	position := startPosition
 	for {
 		if position < bodyLength {
-			code := charCodeAt(body, position)
+			code, n := runeAt(body, position)
 
 			// Skip Ignored
 			if code == 0xFEFF || // BOM
@@ -452,16 +465,16 @@ func positionAfterWhitespace(body string, startPosition int) int {
 				code == 0x000D || // carriage return
 				// Comma
 				code == 0x002C {
-				position++
+				position += n
 			} else if code == 35 { // #
-				position++
+				position += n
 				for {
-					code := charCodeAt(body, position)
+					code, n := runeAt(body, position)
 					if position < bodyLength &&
 						code != 0 &&
 						// SourceCharacter but not LineTerminator
 						(code > 0x001F || code == 0x0009) && code != 0x000A && code != 0x000D {
-						position++
+						position += n
 						continue
 					} else {
 						break

--- a/language/location/location.go
+++ b/language/location/location.go
@@ -12,14 +12,14 @@ type SourceLocation struct {
 }
 
 func GetLocation(s *source.Source, position int) SourceLocation {
-	body := ""
+	body := []byte{}
 	if s != nil {
 		body = s.Body
 	}
 	line := 1
 	column := position + 1
 	lineRegexp := regexp.MustCompile("\r\n|[\n\r]")
-	matches := lineRegexp.FindAllStringIndex(body, -1)
+	matches := lineRegexp.FindAllIndex(body, -1)
 	for _, match := range matches {
 		matchIndex := match[0]
 		if matchIndex < position {

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -36,7 +36,7 @@ func Parse(p ParseParams) (*ast.Document, error) {
 		sourceObj = p.Source.(*source.Source)
 	default:
 		body, _ := p.Source.(string)
-		sourceObj = source.NewSource(&source.Source{Body: body})
+		sourceObj = source.NewSource(&source.Source{Body: []byte(body)})
 	}
 	parser, err := makeParser(sourceObj, p.Options)
 	if err != nil {
@@ -58,7 +58,7 @@ func parseValue(p ParseParams) (ast.Value, error) {
 		sourceObj = p.Source.(*source.Source)
 	default:
 		body, _ := p.Source.(string)
-		sourceObj = source.NewSource(&source.Source{Body: body})
+		sourceObj = source.NewSource(&source.Source{Body: []byte(body)})
 	}
 	parser, err := makeParser(sourceObj, p.Options)
 	if err != nil {

--- a/language/source/source.go
+++ b/language/source/source.go
@@ -5,7 +5,7 @@ const (
 )
 
 type Source struct {
-	Body string
+	Body []byte
 	Name string
 }
 

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -481,7 +481,7 @@ func init() {
 }
 func expectValidRule(t *testing.T, schema *graphql.Schema, rules []graphql.ValidationRuleFn, queryString string) {
 	source := source.NewSource(&source.Source{
-		Body: queryString,
+		Body: []byte(queryString),
 	})
 	AST, err := parser.Parse(parser.ParseParams{Source: source})
 	if err != nil {
@@ -498,7 +498,7 @@ func expectValidRule(t *testing.T, schema *graphql.Schema, rules []graphql.Valid
 }
 func expectInvalidRule(t *testing.T, schema *graphql.Schema, rules []graphql.ValidationRuleFn, queryString string, expectedErrors []gqlerrors.FormattedError) {
 	source := source.NewSource(&source.Source{
-		Body: queryString,
+		Body: []byte(queryString),
 	})
 	AST, err := parser.Parse(parser.ParseParams{Source: source})
 	if err != nil {

--- a/validator_test.go
+++ b/validator_test.go
@@ -15,7 +15,7 @@ import (
 
 func expectValid(t *testing.T, schema *graphql.Schema, queryString string) {
 	source := source.NewSource(&source.Source{
-		Body: queryString,
+		Body: []byte(queryString),
 		Name: "GraphQL request",
 	})
 	AST, err := parser.Parse(parser.ParseParams{Source: source})


### PR DESCRIPTION
I did some peformance testing for graphql-go and found out that it was superslow for my use-case (about 300ms for processing a simple query). After using the go profiling tools it was obvious that the Garbage Collector takes most of the time for it (> 250ms).

I have then viewed through the graphql related code and have seen that the Lexer produces an extreme amount of garbage. The reason is that the Lexer stores the request as a `string` type but converts it to ´[]rune` every time it wants to read a char. This will cause an allocation and copy for reading each character!

I have now made changes were the `Source` is directly storing a `[]byte` array, which can be indexed without performance penalty and which is never converted to a rune array. I changed some functions to read runes from the given offset and the source array and to be able to skip over them even if they are multibyte values.

This pull request improves performance for me by factor 30! This means I'm coming to 10ms for processing a request, which is still not stellar but more workable. In the new performance traces the lexer is no longer the most time consuming part.

The code was not heavily reviewed, so I suggest someone else also takes a look at it before merging. But tests are working and my application with it is working too.
