### PR TITLE
Fix `lexer` tests (follow up to #137)

### DIFF
--- a/gqlerrors/syntax.go
+++ b/gqlerrors/syntax.go
@@ -3,7 +3,6 @@ package gqlerrors
 import (
 	"fmt"
 	"regexp"
-
 	"strings"
 
 	"github.com/graphql-go/graphql/language/ast"

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -13,10 +13,57 @@ type Test struct {
 }
 
 func createSource(body string) *source.Source {
-	return source.NewSource(&source.Source{Body: body})
+	return source.NewSource(&source.Source{Body: []byte(body)})
 }
 
-func TestDisallowsUncommonControlCharacters(t *testing.T) {
+func TestLexer_GetTokenDesc(t *testing.T) {
+	expected := `Name "foo"`
+	tokenDescription := GetTokenDesc(Token{
+		Kind:  TokenKind[NAME],
+		Start: 2,
+		End:   5,
+		Value: "foo",
+	})
+	if expected != tokenDescription {
+		t.Errorf("Expected %v, got %v", expected, tokenDescription)
+	}
+
+	expected = `Name`
+	tokenDescription = GetTokenDesc(Token{
+		Kind:  TokenKind[NAME],
+		Start: 0,
+		End:   0,
+		Value: "",
+	})
+	if expected != tokenDescription {
+		t.Errorf("Expected %v, got %v", expected, tokenDescription)
+	}
+
+	expected = `String "foo"`
+	tokenDescription = GetTokenDesc(Token{
+		Kind:  TokenKind[STRING],
+		Start: 2,
+		End:   5,
+		Value: "foo",
+	})
+	if expected != tokenDescription {
+		t.Errorf("Expected %v, got %v", expected, tokenDescription)
+	}
+
+	expected = `String`
+	tokenDescription = GetTokenDesc(Token{
+		Kind:  TokenKind[STRING],
+		Start: 0,
+		End:   0,
+		Value: "",
+	})
+	if expected != tokenDescription {
+		t.Errorf("Expected %v, got %v", expected, tokenDescription)
+	}
+
+}
+
+func TestLexer_DisallowsUncommonControlCharacters(t *testing.T) {
 	tests := []Test{
 		{
 			Body: "\u0007",
@@ -30,15 +77,15 @@ func TestDisallowsUncommonControlCharacters(t *testing.T) {
 	for _, test := range tests {
 		_, err := Lex(createSource(test.Body))(0)
 		if err == nil {
-			t.Fatalf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
+			t.Errorf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
 		}
 		if err.Error() != test.Expected {
-			t.Fatalf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", test.Expected, err.Error())
+			t.Errorf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", test.Expected, err.Error())
 		}
 	}
 }
 
-func TestAcceptsBOMHeader(t *testing.T) {
+func TestLexer_AcceptsBOMHeader(t *testing.T) {
 	tests := []Test{
 		{
 			Body: "\uFEFF foo",
@@ -51,17 +98,17 @@ func TestAcceptsBOMHeader(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		token, err := Lex(&source.Source{Body: test.Body})(0)
+		token, err := Lex(&source.Source{Body: []byte(test.Body)})(0)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		if !reflect.DeepEqual(token, test.Expected) {
-			t.Fatalf("unexpected token, expected: %v, got: %v", test.Expected, token)
+			t.Errorf("unexpected token, expected: %v, got: %v", test.Expected, token)
 		}
 	}
 }
 
-func TestSkipsWhiteSpace(t *testing.T) {
+func TestLexer_SkipsWhiteSpace(t *testing.T) {
 	tests := []Test{
 		{
 			Body: `
@@ -97,19 +144,28 @@ func TestSkipsWhiteSpace(t *testing.T) {
 				Value: "foo",
 			},
 		},
+		{
+			Body: ``,
+			Expected: Token{
+				Kind:  TokenKind[EOF],
+				Start: 0,
+				End:   0,
+				Value: "",
+			},
+		},
 	}
 	for _, test := range tests {
-		token, err := Lex(&source.Source{Body: test.Body})(0)
+		token, err := Lex(&source.Source{Body: []byte(test.Body)})(0)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		if !reflect.DeepEqual(token, test.Expected) {
-			t.Fatalf("unexpected token, expected: %v, got: %v, body: %s", test.Expected, token, test.Body)
+			t.Errorf("unexpected token, expected: %v, got: %v, body: %s", test.Expected, token, test.Body)
 		}
 	}
 }
 
-func TestErrorsRespectWhitespace(t *testing.T) {
+func TestLexer_ErrorsRespectWhitespace(t *testing.T) {
 	body := `
 
     ?
@@ -125,7 +181,39 @@ func TestErrorsRespectWhitespace(t *testing.T) {
 	}
 }
 
-func TestLexesStrings(t *testing.T) {
+func TestLexer_LexesNames(t *testing.T) {
+	tests := []Test{
+		{
+			Body: "simple",
+			Expected: Token{
+				Kind:  TokenKind[NAME],
+				Start: 0,
+				End:   6,
+				Value: "simple",
+			},
+		},
+		{
+			Body: "Capital",
+			Expected: Token{
+				Kind:  TokenKind[NAME],
+				Start: 0,
+				End:   7,
+				Value: "Capital",
+			},
+		},
+	}
+	for _, test := range tests {
+		token, err := Lex(&source.Source{Body: []byte(test.Body)})(0)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(token, test.Expected) {
+			t.Errorf("unexpected token, expected: %v, got: %v", test.Expected, token)
+		}
+	}
+}
+
+func TestLexer_LexesStrings(t *testing.T) {
 	tests := []Test{
 		{
 			Body: "\"simple\"",
@@ -169,7 +257,7 @@ func TestLexesStrings(t *testing.T) {
 				Kind:  TokenKind[STRING],
 				Start: 0,
 				End:   15,
-				Value: "slashes \\ \\/",
+				Value: "slashes \\ /",
 			},
 		},
 		{
@@ -181,19 +269,46 @@ func TestLexesStrings(t *testing.T) {
 				Value: "unicode \u1234\u5678\u90AB\uCDEF",
 			},
 		},
+		{
+			Body: "\"unicode фы世界\"",
+			Expected: Token{
+				Kind:  TokenKind[STRING],
+				Start: 0,
+				End:   20,
+				Value: "unicode фы世界",
+			},
+		},
+		{
+			Body: "\"фы世界\"",
+			Expected: Token{
+				Kind:  TokenKind[STRING],
+				Start: 0,
+				End:   12,
+				Value: "фы世界",
+			},
+		},
+		{
+			Body: "\"Has a фы世界 multi-byte character.\"",
+			Expected: Token{
+				Kind:  TokenKind[STRING],
+				Start: 0,
+				End:   40,
+				Value: "Has a фы世界 multi-byte character.",
+			},
+		},
 	}
 	for _, test := range tests {
-		token, err := Lex(&source.Source{Body: test.Body})(0)
+		token, err := Lex(&source.Source{Body: []byte(test.Body)})(0)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 		if !reflect.DeepEqual(token, test.Expected) {
-			t.Fatalf("unexpected token, expected: %v, got: %v", test.Expected, token)
+			t.Errorf("unexpected token, expected: %v, got: %v", test.Expected, token)
 		}
 	}
 }
 
-func TestLexReportsUsefulStringErrors(t *testing.T) {
+func TestLexer_ReportsUsefulStringErrors(t *testing.T) {
 	tests := []Test{
 		{
 			Body: "\"",
@@ -301,19 +416,38 @@ func TestLexReportsUsefulStringErrors(t *testing.T) {
          ^
 `,
 		},
+		{
+			Body: "\"bad \\u123",
+			Expected: `Syntax Error GraphQL (1:7) Invalid character escape sequence: \u123
+
+1: "bad \u123
+         ^
+`,
+		},
+		{
+			// some unicode chars take more than one column of text
+			// current implementation does not handle this
+			Body: "\"bфы世ыы𠱸d \\uXXXF esc\"",
+			Expected: `Syntax Error GraphQL (1:12) Invalid character escape sequence: \uXXXF
+
+1: "bфы世ыы𠱸d \uXXXF esc"
+              ^
+`,
+		},
 	}
 	for _, test := range tests {
 		_, err := Lex(createSource(test.Body))(0)
 		if err == nil {
-			t.Fatalf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
+			t.Errorf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
 		}
+
 		if err.Error() != test.Expected {
-			t.Fatalf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", test.Expected, err.Error())
+			t.Errorf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", test.Expected, err.Error())
 		}
 	}
 }
 
-func TestLexesNumbers(t *testing.T) {
+func TestLexer_LexesNumbers(t *testing.T) {
 	tests := []Test{
 		{
 			Body: "4",
@@ -463,15 +597,15 @@ func TestLexesNumbers(t *testing.T) {
 	for _, test := range tests {
 		token, err := Lex(createSource(test.Body))(0)
 		if err != nil {
-			t.Fatalf("unexpected error: %v, test: %s", err, test)
+			t.Errorf("unexpected error: %v, test: %s", err, test)
 		}
 		if !reflect.DeepEqual(token, test.Expected) {
-			t.Fatalf("unexpected token, expected: %v, got: %v, test: %v", test.Expected, token, test)
+			t.Errorf("unexpected token, expected: %v, got: %v, test: %v", test.Expected, token, test)
 		}
 	}
 }
 
-func TestLexReportsUsefulNumbeErrors(t *testing.T) {
+func TestLexer_ReportsUsefulNumberErrors(t *testing.T) {
 	tests := []Test{
 		{
 			Body: "00",
@@ -542,15 +676,15 @@ func TestLexReportsUsefulNumbeErrors(t *testing.T) {
 	for _, test := range tests {
 		_, err := Lex(createSource(test.Body))(0)
 		if err == nil {
-			t.Fatalf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
+			t.Errorf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
 		}
 		if err.Error() != test.Expected {
-			t.Fatalf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", test.Expected, err.Error())
+			t.Errorf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", test.Expected, err.Error())
 		}
 	}
 }
 
-func TestLexesPunctuation(t *testing.T) {
+func TestLexer_LexesPunctuation(t *testing.T) {
 	tests := []Test{
 		{
 			Body: "!",
@@ -673,15 +807,15 @@ func TestLexesPunctuation(t *testing.T) {
 	for _, test := range tests {
 		token, err := Lex(createSource(test.Body))(0)
 		if err != nil {
-			t.Fatalf("unexpected error :%v, test: %v", err, test)
+			t.Errorf("unexpected error :%v, test: %v", err, test)
 		}
 		if !reflect.DeepEqual(token, test.Expected) {
-			t.Fatalf("unexpected token, expected: %v, got: %v, test: %v", test.Expected, token, test)
+			t.Errorf("unexpected token, expected: %v, got: %v, test: %v", test.Expected, token, test)
 		}
 	}
 }
 
-func TestLexReportsUsefulUnknownCharacterError(t *testing.T) {
+func TestLexer_ReportsUsefulUnknownCharacterError(t *testing.T) {
 	tests := []Test{
 		{
 			Body: "..",
@@ -715,19 +849,27 @@ func TestLexReportsUsefulUnknownCharacterError(t *testing.T) {
    ^
 `,
 		},
+		{
+			Body: "ф",
+			Expected: `Syntax Error GraphQL (1:1) Unexpected character "\\u0444".
+
+1: ф
+   ^
+`,
+		},
 	}
 	for _, test := range tests {
 		_, err := Lex(createSource(test.Body))(0)
 		if err == nil {
-			t.Fatalf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
+			t.Errorf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
 		}
 		if err.Error() != test.Expected {
-			t.Fatalf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", test.Expected, err.Error())
+			t.Errorf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", test.Expected, err.Error())
 		}
 	}
 }
 
-func TestLexRerportsUsefulInformationForDashesInNames(t *testing.T) {
+func TestLexer_ReportsUsefulInformationForDashesInNames(t *testing.T) {
 	q := "a-b"
 	lexer := Lex(createSource(q))
 	firstToken, err := lexer(0)

--- a/language/parser/schema_parser_test.go
+++ b/language/parser/schema_parser_test.go
@@ -739,10 +739,10 @@ input Hello {
 `,
 		Nodes: []ast.Node{},
 		Source: &source.Source{
-			Body: `
+			Body: []byte(`
 input Hello {
   world(foo: Int): String
-}`,
+}`),
 			Name: "GraphQL",
 		},
 		Positions: []int{22},


### PR DESCRIPTION
Follow up to PR #137, thanks to @Matthias247
Previous discussion over at https://github.com/Matthias247/graphql/pull/2

- Increased coverage for `lexer` package to 100%
- Added more tests to cover parsing unicode strings (#135) as well.
- Fixed invalid test for `lexer` properly escaping slashes for TokenString type
