### PR TITLE
Improve performance for schemas with many fields

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -266,20 +266,20 @@ func NewScalar(config ScalarConfig) *Scalar {
 	st.PrivateName = config.Name
 	st.PrivateDescription = config.Description
 
-	err = invariant(
+	err = invariantf(
 		config.Serialize != nil,
-		fmt.Sprintf(`%v must provide "serialize" function. If this custom Scalar is `+
+		`%v must provide "serialize" function. If this custom Scalar is `+
 			`also used as an input type, ensure "parseValue" and "parseLiteral" `+
-			`functions are also provided.`, st),
+			`functions are also provided.`, st,
 	)
 	if err != nil {
 		st.err = err
 		return st
 	}
 	if config.ParseValue != nil || config.ParseLiteral != nil {
-		err = invariant(
+		err = invariantf(
 			config.ParseValue != nil && config.ParseLiteral != nil,
-			fmt.Sprintf(`%v must provide both "parseValue" and "parseLiteral" functions.`, st),
+			`%v must provide both "parseValue" and "parseLiteral" functions.`, st,
 		)
 		if err != nil {
 			st.err = err
@@ -478,20 +478,20 @@ func defineInterfaces(ttype *Object, interfaces []*Interface) ([]*Interface, err
 		return ifaces, nil
 	}
 	for _, iface := range interfaces {
-		err := invariant(
+		err := invariantf(
 			iface != nil,
-			fmt.Sprintf(`%v may only implement Interface types, it cannot implement: %v.`, ttype, iface),
+			`%v may only implement Interface types, it cannot implement: %v.`, ttype, iface,
 		)
 		if err != nil {
 			return ifaces, err
 		}
 		if iface.ResolveType != nil {
-			err = invariant(
+			err = invariantf(
 				iface.ResolveType != nil,
-				fmt.Sprintf(`Interface Type %v does not provide a "resolveType" function `+
+				`Interface Type %v does not provide a "resolveType" function `+
 					`and implementing Type %v does not provide a "isTypeOf" `+
 					`function. There is no way to resolve this implementing type `+
-					`during execution.`, iface, ttype),
+					`during execution.`, iface, ttype,
 			)
 			if err != nil {
 				return ifaces, err
@@ -507,9 +507,9 @@ func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 
 	resultFieldMap := FieldDefinitionMap{}
 
-	err := invariant(
+	err := invariantf(
 		len(fields) > 0,
-		fmt.Sprintf(`%v fields must be an object with field names as keys or a function which return such an object.`, ttype),
+		`%v fields must be an object with field names as keys or a function which return such an object.`, ttype,
 	)
 	if err != nil {
 		return resultFieldMap, err
@@ -519,9 +519,9 @@ func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 		if field == nil {
 			continue
 		}
-		err = invariant(
+		err = invariantf(
 			field.Type != nil,
-			fmt.Sprintf(`%v.%v field type must be Output Type but got: %v.`, ttype, fieldName, field.Type),
+			`%v.%v field type must be Output Type but got: %v.`, ttype, fieldName, field.Type,
 		)
 		if err != nil {
 			return resultFieldMap, err
@@ -547,16 +547,16 @@ func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 			if err != nil {
 				return resultFieldMap, err
 			}
-			err = invariant(
+			err = invariantf(
 				arg != nil,
-				fmt.Sprintf(`%v.%v args must be an object with argument names as keys.`, ttype, fieldName),
+				`%v.%v args must be an object with argument names as keys.`, ttype, fieldName,
 			)
 			if err != nil {
 				return resultFieldMap, err
 			}
-			err = invariant(
+			err = invariantf(
 				arg.Type != nil,
-				fmt.Sprintf(`%v.%v(%v:) argument type must be Input Type but got: %v.`, ttype, fieldName, argName, arg.Type),
+				`%v.%v(%v:) argument type must be Input Type but got: %v.`, ttype, fieldName, argName, arg.Type,
 			)
 			if err != nil {
 				return resultFieldMap, err
@@ -823,30 +823,30 @@ func NewUnion(config UnionConfig) *Union {
 	objectType.PrivateDescription = config.Description
 	objectType.ResolveType = config.ResolveType
 
-	err = invariant(
+	err = invariantf(
 		len(config.Types) > 0,
-		fmt.Sprintf(`Must provide Array of types for Union %v.`, config.Name),
+		`Must provide Array of types for Union %v.`, config.Name,
 	)
 	if err != nil {
 		objectType.err = err
 		return objectType
 	}
 	for _, ttype := range config.Types {
-		err := invariant(
+		err := invariantf(
 			ttype != nil,
-			fmt.Sprintf(`%v may only contain Object types, it cannot contain: %v.`, objectType, ttype),
+			`%v may only contain Object types, it cannot contain: %v.`, objectType, ttype,
 		)
 		if err != nil {
 			objectType.err = err
 			return objectType
 		}
 		if objectType.ResolveType == nil {
-			err = invariant(
+			err = invariantf(
 				ttype.IsTypeOf != nil,
-				fmt.Sprintf(`Union Type %v does not provide a "resolveType" function `+
+				`Union Type %v does not provide a "resolveType" function `+
 					`and possible Type %v does not provide a "isTypeOf" `+
 					`function. There is no way to resolve this possible type `+
-					`during execution.`, objectType, ttype),
+					`during execution.`, objectType, ttype,
 			)
 			if err != nil {
 				objectType.err = err
@@ -947,19 +947,19 @@ func NewEnum(config EnumConfig) *Enum {
 func (gt *Enum) defineEnumValues(valueMap EnumValueConfigMap) ([]*EnumValueDefinition, error) {
 	values := []*EnumValueDefinition{}
 
-	err := invariant(
+	err := invariantf(
 		len(valueMap) > 0,
-		fmt.Sprintf(`%v values must be an object with value names as keys.`, gt),
+		`%v values must be an object with value names as keys.`, gt,
 	)
 	if err != nil {
 		return values, err
 	}
 
 	for valueName, valueConfig := range valueMap {
-		err := invariant(
+		err := invariantf(
 			valueConfig != nil,
-			fmt.Sprintf(`%v.%v must refer to an object with a "value" key `+
-				`representing an internal value but got: %v.`, gt, valueName, valueConfig),
+			`%v.%v must refer to an object with a "value" key `+
+				`representing an internal value but got: %v.`, gt, valueName, valueConfig,
 		)
 		if err != nil {
 			return values, err
@@ -1130,9 +1130,9 @@ func (gt *InputObject) defineFieldMap() InputObjectFieldMap {
 	}
 	resultFieldMap := InputObjectFieldMap{}
 
-	err := invariant(
+	err := invariantf(
 		len(fieldMap) > 0,
-		fmt.Sprintf(`%v fields must be an object with field names as keys or a function which return such an object.`, gt),
+		`%v fields must be an object with field names as keys or a function which return such an object.`, gt,
 	)
 	if err != nil {
 		gt.err = err
@@ -1147,9 +1147,9 @@ func (gt *InputObject) defineFieldMap() InputObjectFieldMap {
 		if err != nil {
 			continue
 		}
-		err = invariant(
+		err = invariantf(
 			fieldConfig.Type != nil,
-			fmt.Sprintf(`%v.%v field type must be Input Type but got: %v.`, gt, fieldName, fieldConfig.Type),
+			`%v.%v field type must be Input Type but got: %v.`, gt, fieldName, fieldConfig.Type,
 		)
 		if err != nil {
 			gt.err = err
@@ -1205,7 +1205,7 @@ type List struct {
 func NewList(ofType Type) *List {
 	gl := &List{}
 
-	err := invariant(ofType != nil, fmt.Sprintf(`Can only create List of a Type but got: %v.`, ofType))
+	err := invariantf(ofType != nil, `Can only create List of a Type but got: %v.`, ofType)
 	if err != nil {
 		gl.err = err
 		return gl
@@ -1259,7 +1259,7 @@ func NewNonNull(ofType Type) *NonNull {
 	gl := &NonNull{}
 
 	_, isOfTypeNonNull := ofType.(*NonNull)
-	err := invariant(ofType != nil && !isOfTypeNonNull, fmt.Sprintf(`Can only create NonNull of a Nullable Type but got: %v.`, ofType))
+	err := invariantf(ofType != nil && !isOfTypeNonNull, `Can only create NonNull of a Nullable Type but got: %v.`, ofType)
 	if err != nil {
 		gl.err = err
 		return gl
@@ -1286,8 +1286,8 @@ func (gl *NonNull) Error() error {
 var NameRegExp, _ = regexp.Compile("^[_a-zA-Z][_a-zA-Z0-9]*$")
 
 func assertValidName(name string) error {
-	return invariant(
+	return invariantf(
 		NameRegExp.MatchString(name),
-		fmt.Sprintf(`Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "%v" does not.`, name),
+		`Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "%v" does not.`, name,
 	)
 }

--- a/definition.go
+++ b/definition.go
@@ -473,7 +473,7 @@ func (gt *Object) Error() error {
 }
 
 func defineInterfaces(ttype *Object, interfaces []*Interface) ([]*Interface, error) {
-	ifaces := []*Interface{}
+	ifaces := make([]*Interface, 0, len(interfaces))
 
 	if len(interfaces) == 0 {
 		return ifaces, nil
@@ -542,7 +542,7 @@ func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 			DeprecationReason: field.DeprecationReason,
 		}
 
-		fieldDef.Args = []*Argument{}
+		fieldDef.Args = make([]*Argument, 0, len(field.Args))
 		for argName, arg := range field.Args {
 			err := assertValidName(argName)
 			if err != nil {
@@ -946,7 +946,7 @@ func NewEnum(config EnumConfig) *Enum {
 	return gt
 }
 func (gt *Enum) defineEnumValues(valueMap EnumValueConfigMap) ([]*EnumValueDefinition, error) {
-	values := []*EnumValueDefinition{}
+	values := make([]*EnumValueDefinition, 0, len(valueMap))
 
 	err := invariantf(
 		len(valueMap) > 0,

--- a/executor.go
+++ b/executor.go
@@ -635,9 +635,7 @@ func completeValue(eCtx *ExecutionContext, returnType Type, fieldASTs []*ast.Fie
 	}
 
 	// Not reachable. All possible output types have been considered.
-	err := invariant(false,
-		fmt.Sprintf(`Cannot complete value of unexpected type "%v."`, returnType),
-	)
+	err := invariantf(false, `Cannot complete value of unexpected type "%v."`, returnType)
 	if err != nil {
 		panic(gqlerrors.FormatError(err))
 	}
@@ -663,8 +661,9 @@ func completeAbstractValue(eCtx *ExecutionContext, returnType Abstract, fieldAST
 		runtimeType = defaultResolveTypeFn(resolveTypeParams, returnType)
 	}
 
-	err := invariant(runtimeType != nil,
-		fmt.Sprintf(`Could not determine runtime type of value "%v" for field %v.%v.`, result, info.ParentType, info.FieldName),
+	err := invariantf(runtimeType != nil,
+		`Could not determine runtime type of value "%v" for field %v.%v.`,
+		result, info.ParentType, info.FieldName,
 	)
 	if err != nil {
 		panic(err)
@@ -746,10 +745,10 @@ func completeListValue(eCtx *ExecutionContext, returnType *List, fieldASTs []*as
 	if info.ParentType != nil {
 		parentTypeName = info.ParentType.Name()
 	}
-	err := invariant(
+	err := invariantf(
 		resultVal.IsValid() && resultVal.Type().Kind() == reflect.Slice,
-		fmt.Sprintf("User Error: expected iterable, but did not find one "+
-			"for field %v.%v.", parentTypeName, info.FieldName),
+		"User Error: expected iterable, but did not find one "+
+			"for field %v.%v.", parentTypeName, info.FieldName,
 	)
 	if err != nil {
 		panic(gqlerrors.FormatError(err))

--- a/executor.go
+++ b/executor.go
@@ -293,9 +293,6 @@ func collectFields(p CollectFieldsParams) map[string][]*ast.Field {
 				continue
 			}
 			name := getFieldEntryKey(selection)
-			if _, ok := fields[name]; !ok {
-				fields[name] = []*ast.Field{}
-			}
 			fields[name] = append(fields[name], selection)
 		case *ast.InlineFragment:
 
@@ -755,7 +752,7 @@ func completeListValue(eCtx *ExecutionContext, returnType *List, fieldASTs []*as
 	}
 
 	itemType := returnType.OfType
-	completedResults := []interface{}{}
+	completedResults := make([]interface{}, 0, resultVal.Len())
 	for i := 0; i < resultVal.Len(); i++ {
 		val := resultVal.Index(i).Interface()
 		completedItem := completeValueCatchingError(eCtx, itemType, fieldASTs, info, val)

--- a/schema.go
+++ b/schema.go
@@ -1,9 +1,5 @@
 package graphql
 
-import (
-	"fmt"
-)
-
 type SchemaConfig struct {
 	Query        *Object
 	Mutation     *Object
@@ -224,9 +220,9 @@ func typeMapReducer(schema *Schema, typeMap TypeMap, objectType Type) (TypeMap, 
 	}
 
 	if mappedObjectType, ok := typeMap[objectType.Name()]; ok {
-		err := invariant(
+		err := invariantf(
 			mappedObjectType == objectType,
-			fmt.Sprintf(`Schema must contain unique named types but contains multiple types named "%v".`, objectType.Name()),
+			`Schema must contain unique named types but contains multiple types named "%v".`, objectType.Name(),
 		)
 		if err != nil {
 			return typeMap, err
@@ -344,10 +340,10 @@ func assertObjectImplementsInterface(schema *Schema, object *Object, iface *Inte
 		ifaceField := ifaceFieldMap[fieldName]
 
 		// Assert interface field exists on object.
-		err := invariant(
+		err := invariantf(
 			objectField != nil,
-			fmt.Sprintf(`"%v" expects field "%v" but "%v" does not `+
-				`provide it.`, iface, fieldName, object),
+			`"%v" expects field "%v" but "%v" does not `+
+				`provide it.`, iface, fieldName, object,
 		)
 		if err != nil {
 			return err
@@ -355,12 +351,12 @@ func assertObjectImplementsInterface(schema *Schema, object *Object, iface *Inte
 
 		// Assert interface field type is satisfied by object field type, by being
 		// a valid subtype. (covariant)
-		err = invariant(
+		err = invariantf(
 			isTypeSubTypeOf(schema, objectField.Type, ifaceField.Type),
-			fmt.Sprintf(`%v.%v expects type "%v" but `+
+			`%v.%v expects type "%v" but `+
 				`%v.%v provides type "%v".`,
-				iface, fieldName, ifaceField.Type,
-				object, fieldName, objectField.Type),
+			iface, fieldName, ifaceField.Type,
+			object, fieldName, objectField.Type,
 		)
 		if err != nil {
 			return err
@@ -377,12 +373,12 @@ func assertObjectImplementsInterface(schema *Schema, object *Object, iface *Inte
 				}
 			}
 			// Assert interface field arg exists on object field.
-			err = invariant(
+			err = invariantf(
 				objectArg != nil,
-				fmt.Sprintf(`%v.%v expects argument "%v" but `+
+				`%v.%v expects argument "%v" but `+
 					`%v.%v does not provide it.`,
-					iface, fieldName, argName,
-					object, fieldName),
+				iface, fieldName, argName,
+				object, fieldName,
 			)
 			if err != nil {
 				return err
@@ -390,14 +386,13 @@ func assertObjectImplementsInterface(schema *Schema, object *Object, iface *Inte
 
 			// Assert interface field arg type matches object field arg type.
 			// (invariant)
-			err = invariant(
+			err = invariantf(
 				isEqualType(ifaceArg.Type, objectArg.Type),
-				fmt.Sprintf(
-					`%v.%v(%v:) expects type "%v" `+
-						`but %v.%v(%v:) provides `+
-						`type "%v".`,
-					iface, fieldName, argName, ifaceArg.Type,
-					object, fieldName, argName, objectArg.Type),
+				`%v.%v(%v:) expects type "%v" `+
+					`but %v.%v(%v:) provides `+
+					`type "%v".`,
+				iface, fieldName, argName, ifaceArg.Type,
+				object, fieldName, argName, objectArg.Type,
 			)
 			if err != nil {
 				return err
@@ -416,12 +411,12 @@ func assertObjectImplementsInterface(schema *Schema, object *Object, iface *Inte
 
 			if ifaceArg == nil {
 				_, ok := objectArg.Type.(*NonNull)
-				err = invariant(
+				err = invariantf(
 					!ok,
-					fmt.Sprintf(`%v.%v(%v:) is of required type `+
+					`%v.%v(%v:) is of required type `+
 						`"%v" but is not also provided by the interface %v.%v.`,
-						object, fieldName, argName,
-						objectArg.Type, iface, fieldName),
+					object, fieldName, argName,
+					objectArg.Type, iface, fieldName,
 				)
 				if err != nil {
 					return err

--- a/values.go
+++ b/values.go
@@ -7,11 +7,12 @@ import (
 	"reflect"
 	"strings"
 
+	"sort"
+
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/kinds"
 	"github.com/graphql-go/graphql/language/printer"
-	"sort"
 )
 
 // Prepares an object map of variableValues of the correct type based on the
@@ -439,6 +440,13 @@ func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]interfac
 func invariant(condition bool, message string) error {
 	if !condition {
 		return gqlerrors.NewFormattedError(message)
+	}
+	return nil
+}
+
+func invariantf(condition bool, message string, args ...interface{}) error {
+	if !condition {
+		return gqlerrors.NewFormattedError(fmt.Sprintf(message, args...))
 	}
 	return nil
 }


### PR DESCRIPTION
I did some performance testing and noticed that there is some noticeable overhead once the schema grows.

Commit ccd7f68 introduces a `invariantf` function that formats the error message with fmt.Sprintf. This was done because in CPU profiles Printf regularily came up almost top.

```
(pprof) top10
1000ms of 2000ms total (50.00%)
Showing top 10 nodes out of 166 (cum >= 500ms)
      flat  flat%   sum%        cum   cum%
     200ms 10.00% 10.00%      460ms 23.00%  runtime.mallocgc
     180ms  9.00% 19.00%      710ms 35.50%  fmt.(*pp).doPrintf
```

I traced the source of the Printf's to defineFieldMap and started replacing there, but later extended to all occurances that I found. The change almost halved query processing time for a schema with 20 fields and also brought down allocations from ~2800 to ~1800.

In fdb793c I tried to eliminate the next biggest source of CPU usage, which was the regex in `assertValidName`. Suprisingly this only resulted in a ~26% decrease in query execution time.

```
(pprof) top10
640ms of 1360ms total (47.06%)
Showing top 10 nodes out of 145 (cum >= 40ms)
      flat  flat%   sum%        cum   cum%
     140ms 10.29% 10.29%      350ms 25.74%  runtime.mallocgc
      90ms  6.62% 16.91%       90ms  6.62%  regexp/syntax.(*Inst).MatchRunePos
```

58481fc only tries to avoid some slice reallocations in some places where the final slice length is known. This didn't really increase performance much (~1%) but seeing that the garbage collector is already the biggest source of CPU usage I left it in anyways.

I did some benchmarks comparing the changes to master with varying schema sizes.

schema with 1 field:

```
Before:
BenchmarkHelloQuery-4       5000            307082 ns/op           55207 B/op       1261 allocs/op

After:
BenchmarkHelloQuery-4       5000            250414 ns/op           49166 B/op       1103 allocs/op
```

schema with 20 fields:

```
Before:
BenchmarkHelloQuery-4       2000            736567 ns/op          116243 B/op       2867 allocs/op

After:
BenchmarkHelloQuery-4       5000            331042 ns/op           72469 B/op       1645 allocs/op
```

schema with 100 fields:

```
Before:
BenchmarkHelloQuery-4        500           2474401 ns/op          373010 B/op       9532 allocs/op


After:
BenchmarkHelloQuery-4       2000            609578 ns/op          169809 B/op       3885 allocs/op
```

The source for the benchmarks can be found at: https://gist.github.com/sfriedel/81793288bcc373988f6a000062d051ea

I did some testing with the changes and both the tests and my application run flawlessly with them, but  still it would be good if someone else takes a look.
