### PR TITLE
language/parser: Fix infinite loop on unexpected character

### DIFF
--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1429,7 +1429,7 @@ func any(parser *Parser, openKind int, parseFn parseFn, closeKind int) ([]interf
 	var nodes []interface{}
 	_, err := expect(parser, openKind)
 	if err != nil {
-		return nodes, nil
+		return nodes, err
 	}
 	for {
 		if skp, err := skip(parser, closeKind); err != nil {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -576,6 +576,16 @@ func TestParseCreatesAst(t *testing.T) {
 
 }
 
+func TestParseUnexpectedCharacter(t *testing.T) {
+	_, err := Parse(ParseParams{Source: "{t(d:[[~"})
+	expectedError := &gqlerrors.Error{
+		Message:   "Syntax Error GraphQL (1:8) Unexpected character \"~\".\n\n1: {t(d:[[~\n          ^\n",
+		Positions: []int{7},
+		Locations: []location.SourceLocation{{1, 8}},
+	}
+	checkError(t, err, expectedError)
+}
+
 type errorMessageTest struct {
 	source          interface{}
 	expectedMessage string


### PR DESCRIPTION
Ensure errors returned by the lexer are returned by `any()`.

Hang found by go-fuzz.