### PR TITLE
Experimental/Need feedback: Implement pluggable batching/dedup/concurrent fetch like facebook/dataloader

### DIFF
--- a/examples/dataloader/example.go
+++ b/examples/dataloader/example.go
@@ -1,0 +1,194 @@
+package dataloaderexample
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/bigdrum/godataloader"
+	"github.com/graphql-go/graphql"
+)
+
+var postDB = map[string]*post{
+	"1": &post{
+		ID:       "1",
+		Content:  "Hello 1",
+		AuthorID: "1",
+	},
+	"2": &post{
+		ID:       "2",
+		Content:  "Hello 2",
+		AuthorID: "1",
+	},
+	"3": &post{
+		ID:       "3",
+		Content:  "Hello 3",
+		AuthorID: "2",
+	},
+	"4": &post{
+		ID:       "4",
+		Content:  "Hello 4",
+		AuthorID: "2",
+	},
+}
+
+var userDB = map[string]*user{
+	"1": &user{
+		ID:   "1",
+		Name: "Mike",
+	},
+	"2": &user{
+		ID:   "2",
+		Name: "John",
+	},
+}
+
+var loaderKey = struct{}{}
+
+type loader struct {
+	postLoader *dataloader.DataLoader
+	userLoader *dataloader.DataLoader
+}
+
+func newLoader(sch *dataloader.Scheduler) *loader {
+	return &loader{
+		postLoader: dataloader.New(sch, dataloader.Parallel(func(key interface{}) dataloader.Value {
+			// In practice, we will make remote request (e.g. SQL) to fetch post.
+			// Here we just fake it.
+			log.Print("Load post ", key)
+			time.Sleep(time.Second)
+			id := key.(string)
+			return dataloader.NewValue(postDB[id], nil)
+		})),
+		userLoader: dataloader.New(sch, dataloader.Parallel(func(key interface{}) dataloader.Value {
+			// In practice, we will make remote request (e.g. SQL) to fetch post.
+			// Here we just fake it.
+			log.Print("Load user ", key)
+			time.Sleep(time.Second)
+			id := key.(string)
+			return dataloader.NewValue(userDB[id], nil)
+		})),
+	}
+}
+
+type post struct {
+	ID       string `json:"id"`
+	Content  string `json:"content"`
+	AuthorID string `json:"author_id"`
+}
+
+type user struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func attachNewDataLoader(parent context.Context, sch *dataloader.Scheduler) context.Context {
+	dl := newLoader(sch)
+	return context.WithValue(parent, loaderKey, dl)
+}
+
+func getDataLoader(ctx context.Context) *loader {
+	return ctx.Value(loaderKey).(*loader)
+}
+
+func CreateSchema() graphql.Schema {
+	userType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "User",
+		Fields: graphql.Fields{
+			"id": &graphql.Field{
+				Type: graphql.String,
+			},
+			"name": &graphql.Field{
+				Type: graphql.String,
+			},
+		},
+	})
+
+	postType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Post",
+		Fields: graphql.Fields{
+			"id": &graphql.Field{
+				Type: graphql.String,
+			},
+			"content": &graphql.Field{
+				Type: graphql.String,
+			},
+			"author": &graphql.Field{
+				Type: userType,
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					post := p.Source.(*post)
+					id := post.AuthorID
+					dl := getDataLoader(p.Context)
+					return dl.userLoader.Load(id).Unbox()
+				},
+			},
+		},
+	})
+
+	rootQuery := graphql.NewObject(graphql.ObjectConfig{
+		Name: "RootQuery",
+		Fields: graphql.Fields{
+			"post": &graphql.Field{
+				Type: postType,
+				Args: graphql.FieldConfigArgument{
+					"id": &graphql.ArgumentConfig{
+						Type: graphql.String,
+					},
+				},
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					id, ok := p.Args["id"].(string)
+					if !ok {
+						return nil, nil
+					}
+					dl := getDataLoader(p.Context)
+					return dl.postLoader.Load(id).Unbox()
+				},
+			},
+		}})
+
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: rootQuery,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return schema
+}
+
+type dataloaderExecutor struct {
+	sch *dataloader.Scheduler
+}
+
+func (e *dataloaderExecutor) RunMany(fs []func()) {
+	wg := dataloader.NewWaitGroup(e.sch)
+	for i := range fs {
+		f := fs[i]
+		wg.Add(1)
+		e.sch.Spawn(func() {
+			defer wg.Done()
+			f()
+		})
+	}
+	wg.Wait()
+}
+
+func RunQuery(query string, schema graphql.Schema) *graphql.Result {
+	var result *graphql.Result
+	dataloader.RunWithScheduler(func(sch *dataloader.Scheduler) {
+		executor := dataloaderExecutor{sch}
+		ctx := attachNewDataLoader(context.Background(), sch)
+		result = graphql.Do(graphql.Params{
+			Schema:        schema,
+			RequestString: query,
+			Context:       ctx,
+			Executor:      &executor,
+		})
+		if len(result.Errors) > 0 {
+			fmt.Printf("wrong result, unexpected errors: %v", result.Errors)
+		}
+	})
+
+	return result
+}

--- a/examples/dataloader/example.go
+++ b/examples/dataloader/example.go
@@ -186,6 +186,14 @@ type dataloaderExecutor struct {
 }
 
 func (e *dataloaderExecutor) RunMany(fs []func()) {
+	if len(fs) == 1 {
+		fs[0]()
+		return
+	}
+	if len(fs) == 0 {
+		return
+	}
+
 	wg := dataloader.NewWaitGroup(e.sch)
 	for i := range fs {
 		f := fs[i]

--- a/examples/dataloader/example_test.go
+++ b/examples/dataloader/example_test.go
@@ -1,0 +1,37 @@
+package dataloaderexample_test
+
+import (
+	"testing"
+
+	"github.com/graphql-go/graphql/examples/dataloader"
+)
+
+func TestQuery(t *testing.T) {
+	schema := dataloaderexample.CreateSchema()
+	r := dataloaderexample.RunQuery(`{
+        p1_0: post(id: "1") { id author { name }}
+        p1_1: post(id: "1") { id author { name }}
+        p1_2: post(id: "1") { id author { name }}
+        p1_3: post(id: "1") { id author { name }}
+        p1_4: post(id: "1") { id author { name }}
+        p1_5: post(id: "1") { id author { name }}
+        p2_1: post(id: "2") { id author { name }}
+        p2_2: post(id: "2") { id author { name }}
+        p2_3: post(id: "2") { id author { name }}
+        p3_1: post(id: "3") { id author { name }}
+        p3_2: post(id: "3") { id author { name }}
+        p3_3: post(id: "3") { id author { name }}
+    }`, schema)
+	if len(r.Errors) != 0 {
+		t.Error(r.Errors)
+	}
+	// The above query would produce log like this:
+	// 2016/07/23 23:28:05 Load post 1
+	// 2016/07/23 23:28:05 Load post 3
+	// 2016/07/23 23:28:05 Load post 2
+	// 2016/07/23 23:28:06 Load user 1
+	// 2016/07/23 23:28:06 Load user 2
+	// Notice the first level post loading is done concurrently without duplicate.
+	// And the second level user loading is also done in the same fashion.
+	// TODO: Make test actually verify that.
+}

--- a/examples/dataloader/example_test.go
+++ b/examples/dataloader/example_test.go
@@ -21,17 +21,22 @@ func TestQuery(t *testing.T) {
         p3_1: post(id: "3") { id author { name }}
         p3_2: post(id: "3") { id author { name }}
         p3_3: post(id: "3") { id author { name }}
+        u1_1: user(id: "1") { name }
+        u1_2: user(id: "1") { name }
+        u1_3: user(id: "1") { name }
+        u2_1: user(id: "3") { name }
+        u2_2: user(id: "3") { name }
+        u2_3: user(id: "3") { name }
     }`, schema)
 	if len(r.Errors) != 0 {
 		t.Error(r.Errors)
 	}
 	// The above query would produce log like this:
-	// 2016/07/23 23:28:05 Load post 1
-	// 2016/07/23 23:28:05 Load post 3
-	// 2016/07/23 23:28:05 Load post 2
-	// 2016/07/23 23:28:06 Load user 1
-	// 2016/07/23 23:28:06 Load user 2
+	// 2016/07/23 23:49:31 Load post 3
+	// 2016/07/23 23:49:31 Load post 1
+	// 2016/07/23 23:49:31 Load post 2
+	// 2016/07/23 23:49:32 Batch load users [3 1 2]
 	// Notice the first level post loading is done concurrently without duplicate.
-	// And the second level user loading is also done in the same fashion.
+	// And the second level user loading is also done in the same fashion, but batched fetch is used instead.
 	// TODO: Make test actually verify that.
 }

--- a/executor.go
+++ b/executor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/ast"
@@ -271,26 +272,21 @@ func executeFields(p ExecuteFieldsParams) *Result {
 
 	finalResults := map[string]interface{}{}
 	fs := make([]func(), 0, len(p.Fields))
-	var undefinedKeys []string
+	var resultsMu sync.Mutex
 	for responseName, fieldASTs := range p.Fields {
 		responseName := responseName
 		fieldASTs := fieldASTs
-		finalResults[responseName] = nil // This is to avoid using lock.
 		fs = append(fs, func() {
 			resolved, state := resolveField(p.ExecutionContext, p.ParentType, p.Source, fieldASTs)
 			if state.hasNoFieldDefs {
-				undefinedKeys = append(undefinedKeys, responseName)
 				return
 			}
+			resultsMu.Lock()
 			finalResults[responseName] = resolved
+			resultsMu.Unlock()
 		})
 	}
 	p.ExecutionContext.Executor.RunMany(fs)
-
-	// Remove undefined keys.
-	for _, key := range undefinedKeys {
-		delete(finalResults, key)
-	}
 	return &Result{
 		Data:   finalResults,
 		Errors: p.ExecutionContext.Errors,

--- a/graphql.go
+++ b/graphql.go
@@ -30,6 +30,10 @@ type Params struct {
 	// Context may be provided to pass application-specific per-request
 	// information to resolve functions.
 	Context context.Context
+
+	// Executor allows to control the behavior of how to perform resolving function that
+	// can be run concurrently. If not given, they will be executed serially.
+	Executor Executor
 }
 
 func Do(p Params) *Result {
@@ -58,5 +62,6 @@ func Do(p Params) *Result {
 		OperationName: p.OperationName,
 		Args:          p.VariableValues,
 		Context:       p.Context,
+		Executor:      p.Executor,
 	})
 }


### PR DESCRIPTION
I have been considering how to implement the idea of facebook/dataloader with graphql in go (which address issues like #106, #132), and this PR shows the progress so far.

This PR is mainly a demonstration on how it could work. And so far I'm happy with the idea.

This requires some minimum changes to the graphql package (just to inject a executor with a simple interface). The real concurrency feature is implemented in the godataloader library that I wrote separately, which can be plugged into graphql.

examples/dataloader contains an actual example, which demonstrate the following features:
- Opt-in.
- Concurrently loading multiple data.
- Load duplicate requests once.
- Batching multiple requests.
- No unnecessary goroutines are spawn unless concurrency actually happen.
- Synchronous programming style (without Promise-like object).

The test might best demonstrate the behavior.

``` go
func TestQuery(t *testing.T) {
    schema := dataloaderexample.CreateSchema()
    r := dataloaderexample.RunQuery(`{
        p1_0: post(id: "1") { id author { name }}
        p1_1: post(id: "1") { id author { name }}
        p1_2: post(id: "1") { id author { name }}
        p1_3: post(id: "1") { id author { name }}
        p1_4: post(id: "1") { id author { name }}
        p1_5: post(id: "1") { id author { name }}
        p2_1: post(id: "2") { id author { name }}
        p2_2: post(id: "2") { id author { name }}
        p2_3: post(id: "2") { id author { name }}
        p3_1: post(id: "3") { id author { name }}
        p3_2: post(id: "3") { id author { name }}
        p3_3: post(id: "3") { id author { name }}
        u1_1: user(id: "1") { name }
        u1_2: user(id: "1") { name }
        u1_3: user(id: "1") { name }
        u2_1: user(id: "3") { name }
        u2_2: user(id: "3") { name }
        u2_3: user(id: "3") { name }
    }`, schema)
    if len(r.Errors) != 0 {
        t.Error(r.Errors)
    }
    t.Error(r)
    // The above query would produce log like this:
    // 2016/07/23 23:49:31 Load post 3
    // 2016/07/23 23:49:31 Load post 1
    // 2016/07/23 23:49:31 Load post 2
    // 2016/07/23 23:49:32 Batch load users [3 1 2]
    // Notice the first level post loading is done concurrently without duplicate.
    // The user loading is also done in the same fashion, but batched fetch is used instead.
    // TODO: Make test actually verify the logged behavior.
}
```

This PR is not meant to be merged yet (at least the example probably doesn't fit to be part of this project because of its external dependency, unless the godataloader library is moved).

The godataloader library is probably a little bit more complicated than one would expect. And I'm happy to explain it if anyone finds this idea interesting.
