### PR TITLE
README: Adds Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A *work-in-progress* implementation of GraphQL for Go.
 
+### Documentation
+
+- godoc: https://godoc.org/github.com/graphql-go/graphql
+
 ### Getting Started
 
 To install the library, run:


### PR DESCRIPTION
#### Overview
- Closes: https://github.com/graphql-go/graphql/issues/160
- [x] Adds `Documentation` section with `README`.