### PR TITLE
Minor fix to stop `go vet` from complaining

### DIFF
--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -97,7 +97,7 @@ func TestParseProvidesUsefulErrors(t *testing.T) {
     ^
 `,
 		Positions: []int{1},
-		Locations: []location.SourceLocation{{1, 2}},
+		Locations: []location.SourceLocation{{Line: 1, Column: 2}},
 	}
 	checkError(t, err, expectedError)
 


### PR DESCRIPTION
Fixes the following `go vet` violation:

```
language/parser/parser_test.go:100: github.com/graphql-go/graphql/language/location.SourceLocation composite literal uses unkeyed fields
exit status 1
```

cc @sogko @chris-ramon 
