### PR TITLE
Respect Context Deadline

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -31,7 +31,6 @@ func Execute(p ExecuteParams) (result *Result) {
 	}
 
 	resultChannel := make(chan *Result)
-	doneChannel := make(chan struct{})
 
 	go func(out chan<- *Result, done <-chan struct{}) {
 		result := &Result{}
@@ -81,7 +80,7 @@ func Execute(p ExecuteParams) (result *Result) {
 		case <-done:
 		}
 
-	}(resultChannel, doneChannel)
+	}(resultChannel, ctx.Done())
 
 	select {
 	case <-ctx.Done():
@@ -90,7 +89,6 @@ func Execute(p ExecuteParams) (result *Result) {
 	case r := <-resultChannel:
 		result = r
 	}
-	close(doneChannel)
 	return
 }
 

--- a/executor.go
+++ b/executor.go
@@ -24,40 +24,74 @@ type ExecuteParams struct {
 }
 
 func Execute(p ExecuteParams) (result *Result) {
-	result = &Result{}
-
-	exeContext, err := buildExecutionContext(BuildExecutionCtxParams{
-		Schema:        p.Schema,
-		Root:          p.Root,
-		AST:           p.AST,
-		OperationName: p.OperationName,
-		Args:          p.Args,
-		Errors:        nil,
-		Result:        result,
-		Context:       p.Context,
-	})
-
-	if err != nil {
-		result.Errors = append(result.Errors, gqlerrors.FormatError(err))
-		return
+	// Use background context if no context was provided
+	ctx := p.Context
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			var err error
-			if r, ok := r.(error); ok {
-				err = gqlerrors.FormatError(r)
-			}
-			exeContext.Errors = append(exeContext.Errors, gqlerrors.FormatError(err))
-			result.Errors = exeContext.Errors
-		}
-	}()
+	resultChannel := make(chan *Result)
+	doneChannel := make(chan struct{})
 
-	return executeOperation(ExecuteOperationParams{
-		ExecutionContext: exeContext,
-		Root:             p.Root,
-		Operation:        exeContext.Operation,
-	})
+	go func(out chan<- *Result, done <-chan struct{}) {
+		result := &Result{}
+
+		exeContext, err := buildExecutionContext(BuildExecutionCtxParams{
+			Schema:        p.Schema,
+			Root:          p.Root,
+			AST:           p.AST,
+			OperationName: p.OperationName,
+			Args:          p.Args,
+			Errors:        nil,
+			Result:        result,
+			Context:       p.Context,
+		})
+
+		if err != nil {
+			result.Errors = append(result.Errors, gqlerrors.FormatError(err))
+			select {
+			case out <- result:
+			case <-done:
+			}
+			return
+		}
+
+		defer func() {
+			if r := recover(); r != nil {
+				var err error
+				if r, ok := r.(error); ok {
+					err = gqlerrors.FormatError(r)
+				}
+				exeContext.Errors = append(exeContext.Errors, gqlerrors.FormatError(err))
+				result.Errors = exeContext.Errors
+				select {
+				case out <- result:
+				case <-done:
+				}
+			}
+		}()
+
+		result = executeOperation(ExecuteOperationParams{
+			ExecutionContext: exeContext,
+			Root:             p.Root,
+			Operation:        exeContext.Operation,
+		})
+		select {
+		case out <- result:
+		case <-done:
+		}
+
+	}(resultChannel, doneChannel)
+
+	select {
+	case <-ctx.Done():
+		result = &Result{}
+		result.Errors = append(result.Errors, gqlerrors.FormatError(ctx.Err()))
+	case r := <-resultChannel:
+		result = r
+	}
+	close(doneChannel)
+	return
 }
 
 type BuildExecutionCtxParams struct {


### PR DESCRIPTION
Have added context timeout to graphql.Execute, this seemed the most appropriate place to put it. A couple of concerns I have;

* Nested resolve functions could still be started after a context has already been cancelled
* Not sure of the performance implications of these changes - doesn't look too bad to me but I hasn't been benchmarked
* The go func inside of Execute's pretty messy now, the same select is repeated three times
* The tests run slower after this change as they need to wait for the context timeout. I've kept this to 100ms for now, so not a massive deal - but it might be better to kick off this test in parallel.

Feedback very much appreciated!

Closes https://github.com/graphql-go/graphql/issues/184