### PR TITLE
Add BindFields function tool

### DIFF
--- a/util.go
+++ b/util.go
@@ -76,21 +76,22 @@ func getGraphType(tipe reflect.Type) Output {
 }
 
 func getGraphList(tipe reflect.Type) *List {
-	switch tipe {
-	case reflect.TypeOf([]int{}):
-	case reflect.TypeOf([]int8{}):
-	case reflect.TypeOf([]int32{}):
-	case reflect.TypeOf([]int64{}):
-		return NewList(Int)
-	case reflect.TypeOf([]bool{}):
-		return NewList(Boolean)
-	case reflect.TypeOf([]float32{}):
-	case reflect.TypeOf([]float64{}):
-		return NewList(Float)
-	case reflect.TypeOf([]string{}):
-		return NewList(String)
+	if tipe.Kind() == reflect.Slice {
+		switch tipe.Elem().Kind() {
+		case reflect.Int:
+		case reflect.Int8:
+		case reflect.Int32:
+		case reflect.Int64:
+			return NewList(Int)
+		case reflect.Bool:
+			return NewList(Boolean)
+		case reflect.Float32:
+		case reflect.Float64:
+			return NewList(Float)
+		case reflect.String:
+			return NewList(String)
+		}
 	}
-
 	// finaly bind object
 	t := reflect.New(tipe.Elem())
 	name := strings.Replace(fmt.Sprint(tipe.Elem()), ".", "_", -1)

--- a/util.go
+++ b/util.go
@@ -1,0 +1,143 @@
+package graphql
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/graphql-go/graphql"
+	"reflect"
+)
+
+const TAG = "json"
+
+func BindFields(obj interface{}) Fields {
+	v := reflect.ValueOf(obj)
+	fields := make(map[string]*Field)
+
+	for i := 0; i < v.NumField(); i++ {
+		typeField := v.Type().Field(i)
+
+		tag := typeField.Tag.Get(TAG)
+		if typeField.Type.Kind() == reflect.Struct && tag == "" {
+			structFields := BindFields(v.Field(i).Interface())
+
+			fields = appendFields(fields, structFields)
+			continue
+		}
+
+		if tag == "" {
+			continue
+		}
+
+		graphType := getGraphType(typeField.Type)
+		fields[tag] = &Field{
+			Type: graphType,
+			Resolve: func(p ResolveParams) (interface{}, error) {
+				return extractValue(tag, p.Source), nil
+			},
+		}
+	}
+	return fields
+}
+
+func getGraphType(tipe reflect.Type) Output {
+	kind := tipe.Kind()
+	switch kind {
+	case reflect.String:
+		return String
+	case reflect.Int:
+		return Int
+	case reflect.Float32:
+	case reflect.Float64:
+		return Float
+	case reflect.Bool:
+		return Boolean
+	case reflect.Slice:
+		return getGraphList(tipe)
+	}
+	return String
+}
+
+func getGraphList(tipe reflect.Type) *List {
+	switch tipe {
+	case reflect.TypeOf([]int{}):
+	case reflect.TypeOf([]int8{}):
+	case reflect.TypeOf([]int32{}):
+	case reflect.TypeOf([]int64{}):
+		return NewList(Int)
+	case reflect.TypeOf([]bool{}):
+		return NewList(Boolean)
+	case reflect.TypeOf([]float32{}):
+	case reflect.TypeOf([]float64{}):
+		return NewList(Float)
+	}
+	return NewList(String)
+}
+
+func appendFields(dest, origin Fields) Fields {
+	for key, value := range origin {
+		dest[key] = value
+	}
+	return dest
+}
+
+func extractValue(originTag string, obj interface{}) interface{} {
+	val := reflect.ValueOf(obj)
+
+	for j := 0; j < val.NumField(); j++ {
+		typeField := val.Type().Field(j)
+		if typeField.Type.Kind() == reflect.Struct {
+			res := extractValue(originTag, val.Field(j).Interface())
+			if res != nil {
+				return res
+			}
+		}
+		curTag := typeField.Tag
+		if originTag == curTag.Get(TAG) {
+			return val.Field(j).Interface()
+		}
+	}
+	return nil
+}
+
+// lazy way of binding args
+func BindArg(obj interface{}, tags ...string) FieldConfigArgument {
+	v := reflect.ValueOf(obj)
+	var config = make(FieldConfigArgument)
+	for i := 0; i < v.NumField(); i++ {
+		typeField := v.Type().Field(i)
+
+		mytag := typeField.Tag.Get(TAG)
+		if inArray(tags, mytag) {
+			config[mytag] = &ArgumentConfig{
+				Type: getGraphType(typeField.Type),
+			}
+		}
+	}
+	return config
+}
+
+func UnmarshalArgs(args map[string]interface{}, pointer interface{}) error {
+	js, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("ini error 1 %v", err)
+	}
+	err = json.Unmarshal(js, pointer)
+	if err != nil {
+		return fmt.Errorf("ini error 2 %v", err)
+	}
+	return nil
+}
+
+func inArray(slice interface{}, item interface{}) bool {
+	s := reflect.ValueOf(slice)
+	if s.Kind() != reflect.Slice {
+		panic("inArray() given a non-slice type")
+	}
+
+	for i := 0; i < s.Len(); i++ {
+		if reflect.DeepEqual(item, s.Index(i).Interface()) {
+			return true
+		}
+	}
+	return false
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,1 @@
+package graphql

--- a/util_test.go
+++ b/util_test.go
@@ -14,6 +14,7 @@ type Person struct {
 	Human
 	Name    string   `json:"name"`
 	Home    Address  `json:"home"`
+	Hobbies []string `json:"hobbies"`
 	Friends []Friend `json:"friends"`
 }
 
@@ -45,6 +46,7 @@ var personSource = Person{
 		City:   "Jakarta",
 	},
 	Friends: friendSource,
+	Hobbies:[]string{"eat","sleep","code"},
 }
 
 var friendSource = []Friend{
@@ -83,7 +85,8 @@ func TestBindFields(t *testing.T) {
 				friends{name,address},
 				age,
 				weight,
-				alive
+				alive,
+				hobbies
 			}
 		}
 	`

--- a/util_test.go
+++ b/util_test.go
@@ -1,1 +1,92 @@
 package graphql
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"testing"
+)
+
+type Human struct {
+	Alive  bool    `json:"alive"`
+	Age    int     `json:"age"`
+	Weight float64 `json:"weight"`
+}
+
+type person struct {
+	Human
+	Name    string   `json:"name"`
+	Home    Address  `json:"home"`
+	Friends []Friend `json:"friends"`
+}
+
+type Friend struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+}
+
+type Address struct {
+	Street string `json:"street"`
+	City   string `json:"city"`
+}
+
+var personSource = person{
+	Human: Human{
+		Age:    24,
+		Weight: 70.1,
+		Alive:  true,
+	},
+	Name: "John Doe",
+	Home: myaddress,
+	Friends: []Friend{
+		{"Arief", "palembang"},
+		{"Al", "semarang"},
+	},
+}
+
+var myaddress = Address{
+	Street: "Jl. G1",
+	City:   "Jakarta",
+}
+
+func TestBindFields(t *testing.T) {
+	personObj := NewObject(ObjectConfig{
+		Name:   "Person",
+		Fields: BindFields(person{}),
+	})
+	fields := Fields{
+		"person": &Field{
+			Type: personObj,
+			Resolve: func(p ResolveParams) (interface{}, error) {
+				return personSource, nil
+			},
+		},
+	}
+	rootQuery := ObjectConfig{Name: "RootQuery", Fields: fields}
+	schemaConfig := SchemaConfig{Query: NewObject(rootQuery)}
+	schema, err := NewSchema(schemaConfig)
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Query
+	query := `
+		{
+			person{
+				name,
+				home{street},
+				friends{name,address},
+				age,
+				weight,
+				alive
+			}
+		}
+	`
+	params := Params{Schema: schema, RequestString: query}
+	r := Do(params)
+	if len(r.Errors) > 0 {
+		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
+	}
+	rJSON, _ := json.Marshal(r)
+	fmt.Printf("%s \n", rJSON)
+}

--- a/util_test.go
+++ b/util_test.go
@@ -2,24 +2,25 @@ package graphql_test
 
 import (
 	"encoding/json"
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
 	"log"
 	"reflect"
 	"testing"
-)
 
-type Human struct {
-	Alive  bool    `json:"alive"`
-	Age    int     `json:"age"`
-	Weight float64 `json:"weight"`
-}
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/testutil"
+)
 
 type Person struct {
 	Human
 	Name    string   `json:"name"`
 	Home    Address  `json:"home"`
 	Friends []Friend `json:"friends"`
+}
+
+type Human struct {
+	Alive  bool    `json:"alive"`
+	Age    int     `json:"age"`
+	Weight float64 `json:"weight"`
 }
 
 type Friend struct {
@@ -38,29 +39,29 @@ var personSource = Person{
 		Weight: 70.1,
 		Alive:  true,
 	},
-	Name:    "John Doe",
-	Home:    myaddress,
+	Name: "John Doe",
+	Home: Address{
+		Street: "Jl. G1",
+		City:   "Jakarta",
+	},
 	Friends: friendSource,
 }
 
 var friendSource = []Friend{
-	{"Arief", "palembang"},
-	{"Al", "semarang"},
-}
-
-var myaddress = Address{
-	Street: "Jl. G1",
-	City:   "Jakarta",
+	{Name: "Arief", Address: "palembang"},
+	{Name: "Al", Address: "semarang"},
 }
 
 func TestBindFields(t *testing.T) {
-	personObj := graphql.NewObject(graphql.ObjectConfig{
-		Name:   "Person",
+	// create person type based on Person struct
+	personType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Person",
+		// pass empty Person struct to bind all of it's fields
 		Fields: graphql.BindFields(Person{}),
 	})
 	fields := graphql.Fields{
 		"person": &graphql.Field{
-			Type: personObj,
+			Type: personType,
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				return personSource, nil
 			},
@@ -118,6 +119,7 @@ func TestBindArg(t *testing.T) {
 	fields := graphql.Fields{
 		"friend": &graphql.Field{
 			Type: friendObj,
+			//it can be added more than one since it's a slice
 			Args: graphql.BindArg(Friend{}, "name"),
 			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 				if name, ok := p.Args["name"].(string); ok {


### PR DESCRIPTION
I've been working with graphql-go lately and realize I'm pretty lazy to create object type for every struct I had. So I made a binder/wrapper function to easily bind all fields in my struct into graphql object.

So if you have this struct 
```go
type Person struct {
    Name    string  `graph:"name"`
    Address string  `graph:"address"`
}
```
you can create person type with 
```go
personType := graphql.NewObject(graphql.ObjectConfig{
        Name:   "Person",
        Fields: BindFields(Person{}),
    })
```

in file `util_test.go` I made an example with Person struct that looked like this:
```go
type Person struct {
	Human //embedded Fields
	Name    string   `json:"name"` // standard scalar type
	Home    Address  `json:"home"` // struct type
	Hobbies []string `json:"hobbies"` // slice of scalar type 
	Friends []Friend `json:"friends"` // slice of struct type
}

type Human struct {
	Alive  bool    `json:"alive"`
	Age    int     `json:"age"`
	Weight float64 `json:"weight"`
}

type Friend struct {
	Name    string `json:"name"`
	Address string `json:"address"`
}

type Address struct {
	Street string `json:"street"`
	City   string `json:"city"`
}
```

because this function will scan through empty struct so this function cannot accept recursive type. that would make a stack-overflow error. And one more utility function which is `BindArgs` that can bind the args depending on provided params.
