### PR TITLE
fixed issue with pointer to scalar values

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -25,52 +25,78 @@ func coerceInt(value interface{}) interface{} {
 			return nil
 		}
 		return value
+	case *int:
+		return coerceInt(*value)
 	case int8:
 		return int(value)
+	case *int8:
+		return int(*value)
 	case int16:
 		return int(value)
+	case *int16:
+		return int(*value)
 	case int32:
 		return int(value)
+	case *int32:
+		return int(*value)
 	case int64:
 		if value < int64(math.MinInt32) || value > int64(math.MaxInt32) {
 			return nil
 		}
 		return int(value)
+	case *int64:
+		return coerceInt(*value)
 	case uint:
 		if value > math.MaxInt32 {
 			return nil
 		}
 		return int(value)
+	case *uint:
+		return coerceInt(*value)
 	case uint8:
 		return int(value)
+	case *uint8:
+		return int(*value)
 	case uint16:
 		return int(value)
+	case *uint16:
+		return int(*value)
 	case uint32:
 		if value > uint32(math.MaxInt32) {
 			return nil
 		}
 		return int(value)
+	case *uint32:
+		return coerceInt(*value)
 	case uint64:
 		if value > uint64(math.MaxInt32) {
 			return nil
 		}
 		return int(value)
+	case *uint64:
+		return coerceInt(*value)
 	case float32:
 		if value < float32(math.MinInt32) || value > float32(math.MaxInt32) {
 			return nil
 		}
 		return int(value)
+	case *float32:
+		return coerceInt(*value)
 	case float64:
 		if value < float64(math.MinInt32) || value > float64(math.MaxInt32) {
 			return nil
 		}
 		return int(value)
+	case *float64:
+		return coerceInt(*value)
 	case string:
 		val, err := strconv.ParseFloat(value, 0)
 		if err != nil {
 			return nil
 		}
 		return coerceInt(val)
+	case *string:
+		return coerceInt(*value)
 	}
 
 	// If the value cannot be transformed into an int, return nil instead of '0'
@@ -103,18 +129,28 @@ func coerceFloat(value interface{}) interface{} {
 			return 1.0
 		}
 		return 0.0
+	case *bool:
+		return coerceFloat(*value)
 	case int:
 		return float64(value)
+	case *int32:
+		return coerceFloat(*value)
 	case float32:
 		return value
+	case *float32:
+		return coerceFloat(*value)
 	case float64:
 		return value
+	case *float64:
+		return coerceFloat(*value)
 	case string:
 		val, err := strconv.ParseFloat(value, 0)
 		if err != nil {
 			return nil
 		}
 		return val
+	case *string:
+		return coerceFloat(*value)
 	}
 	return 0.0
 }
@@ -143,6 +179,9 @@ var Float = NewScalar(ScalarConfig{
 })
 
 func coerceString(value interface{}) interface{} {
+	if v, ok := value.(*string); ok {
+		return *v
+	}
 	return fmt.Sprintf("%v", value)
 }
 
@@ -167,27 +206,37 @@ func coerceBool(value interface{}) interface{} {
 	switch value := value.(type) {
 	case bool:
 		return value
+	case *bool:
+		return *value
 	case string:
 		switch value {
 		case "", "false":
 			return false
 		}
 		return true
+	case *string:
+		return coerceBool(*value)
 	case float64:
 		if value != 0 {
 			return true
 		}
 		return false
+	case *float64:
+		return coerceBool(*value)
 	case float32:
 		if value != 0 {
 			return true
 		}
 		return false
+	case *float32:
+		return coerceBool(*value)
 	case int:
 		if value != 0 {
 			return true
 		}
 		return false
+	case *int:
+		return coerceBool(*value)
 	}
 	return false
 }

--- a/values.go
+++ b/values.go
@@ -320,6 +320,12 @@ func isNullish(value interface{}) bool {
 	if value, ok := value.(string); ok {
 		return value == ""
 	}
+	if value, ok := value.(*string); ok {
+		if value == nil {
+			return true
+		}
+		return *value == ""
+	}
 	if value, ok := value.(int); ok {
 		return math.IsNaN(float64(value))
 	}

--- a/values.go
+++ b/values.go
@@ -329,11 +329,29 @@ func isNullish(value interface{}) bool {
 	if value, ok := value.(int); ok {
 		return math.IsNaN(float64(value))
 	}
+	if value, ok := value.(*int); ok {
+		if value == nil {
+			return true
+		}
+		return math.IsNaN(float64(*value))
+	}
 	if value, ok := value.(float32); ok {
 		return math.IsNaN(float64(value))
 	}
+	if value, ok := value.(*float32); ok {
+		if value == nil {
+			return true
+		}
+		return math.IsNaN(float64(*value))
+	}
 	if value, ok := value.(float64); ok {
 		return math.IsNaN(value)
+	}
+	if value, ok := value.(*float64); ok {
+		if value == nil {
+			return true
+		}
+		return math.IsNaN(*value)
 	}
 	return value == nil
 }


### PR DESCRIPTION
If you have a response struct like the following:

```
struct Foo {
   Bar *string  `json:"bar"`
}
```

And `Bar` is `nil`. The result will be incorrectly encoded on returning.  The result will be `\u003cnil\u003e` instead of `null` (when serialized to JSON).

This fix will fix `isNullish` to check for `*string` type and other primitive types.


