### PR TITLE
Use standard library's "context" package

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -1,12 +1,12 @@
 package graphql
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"regexp"
 
 	"github.com/graphql-go/graphql/language/ast"
-	"golang.org/x/net/context"
 )
 
 // Type interface for all of the possible kinds of GraphQL types

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 
 	"github.com/graphql-go/graphql"
-	"golang.org/x/net/context"
 )
 
 var Schema graphql.Schema

--- a/executor.go
+++ b/executor.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/ast"
-	"golang.org/x/net/context"
 )
 
 type ExecuteParams struct {

--- a/executor_test.go
+++ b/executor_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +13,6 @@ import (
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
-	"golang.org/x/net/context"
 )
 
 func TestExecutesArbitraryCode(t *testing.T) {

--- a/graphql.go
+++ b/graphql.go
@@ -1,10 +1,11 @@
 package graphql
 
 import (
+	"context"
+
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/parser"
 	"github.com/graphql-go/graphql/language/source"
-	"golang.org/x/net/context"
 )
 
 type Params struct {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1,12 +1,12 @@
 package graphql_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
-	"golang.org/x/net/context"
 )
 
 type T struct {

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -1,12 +1,12 @@
 package graphql_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/testutil"
-	"golang.org/x/net/context"
 )
 
 type testNamedType interface {


### PR DESCRIPTION
While going through the source code, I noticed that it's still using `golang.org/x/net/context`.

This could be swapped with `golang.org/pkg/context` without any further code changes. However, this  mean the package would need Go 1.7+ to work.

wdyt?