### PR TITLE
Examples: use '.Get("query")' instead of '["query"][0]'

### DIFF
--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -46,7 +46,7 @@ func graphqlHandler(w http.ResponseWriter, r *http.Request) {
 	}{1, "cool user"}
 	result := graphql.Do(graphql.Params{
 		Schema:        Schema,
-		RequestString: r.URL.Query()["query"][0],
+		RequestString: r.URL.Query().Get("query"),
 		Context:       context.WithValue(context.Background(), "currentUser", user),
 	})
 	if len(result.Errors) > 0 {

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -88,7 +88,7 @@ func main() {
 	_ = importJSONDataFromFile("data.json", &data)
 
 	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
-		result := executeQuery(r.URL.Query()["query"][0], schema)
+		result := executeQuery(r.URL.Query().Get("query"), schema)
 		json.NewEncoder(w).Encode(result)
 	})
 

--- a/examples/httpdynamic/main.go
+++ b/examples/httpdynamic/main.go
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
-		result := executeQuery(r.URL.Query()["query"][0], schema)
+		result := executeQuery(r.URL.Query().Get("query"), schema)
 		json.NewEncoder(w).Encode(result)
 	})
 

--- a/examples/star-wars/main.go
+++ b/examples/star-wars/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query()["query"][0]
+		query := r.URL.Query().Get("query")
 		result := graphql.Do(graphql.Params{
 			Schema:        testutil.StarWarsSchema,
 			RequestString: query,

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -207,7 +207,7 @@ func executeQuery(query string, schema graphql.Schema) *graphql.Result {
 
 func main() {
 	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
-		result := executeQuery(r.URL.Query()["query"][0], schema)
+		result := executeQuery(r.URL.Query().Get("query"), schema)
 		json.NewEncoder(w).Encode(result)
 	})
 	// Serve static files


### PR DESCRIPTION
In examples, 
if the query(`RawQuery`) values does not contain the key `"query"`:
1. Use `r.URL.Query()["query"][0]`, throws runtime error: `index out of range`.
1. Use `r.URL.Query().Get("query")`, gets the `graphql.Result.Errors` string such as `[Must provide an operation.]`. Maybe more friendly.

It works in go1.5.
