### PR TITLE
scalars: datetime

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -292,8 +292,6 @@ func serializeDateTime(value interface{}) interface{} {
 	default:
 		return nil
 	}
-
-	return nil
 }
 
 func unserializeDateTime(value interface{}) interface{} {
@@ -313,8 +311,6 @@ func unserializeDateTime(value interface{}) interface{} {
 	default:
 		return nil
 	}
-
-	return nil
 }
 
 var DateTime = NewScalar(ScalarConfig{

--- a/scalars.go
+++ b/scalars.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"time"
 
 	"github.com/graphql-go/graphql/language/ast"
 )
@@ -270,6 +271,60 @@ var ID = NewScalar(ScalarConfig{
 		switch valueAST := valueAST.(type) {
 		case *ast.IntValue:
 			return valueAST.Value
+		case *ast.StringValue:
+			return valueAST.Value
+		}
+		return nil
+	},
+})
+
+func serializeDateTime(value interface{}) interface{} {
+	switch value := value.(type) {
+	case time.Time:
+		buff, err := value.MarshalText()
+		if err != nil {
+			return nil
+		}
+
+		return string(buff)
+	case *time.Time:
+		return serializeDateTime(*value)
+	default:
+		return nil
+	}
+
+	return nil
+}
+
+func unserializeDateTime(value interface{}) interface{} {
+	switch value := value.(type) {
+	case []byte:
+		t := time.Time{}
+		err := t.UnmarshalText(value)
+		if err != nil {
+			return nil
+		}
+
+		return t
+	case string:
+		return unserializeDateTime([]byte(value))
+	case *string:
+		return unserializeDateTime([]byte(*value))
+	default:
+		return nil
+	}
+
+	return nil
+}
+
+var DateTime = NewScalar(ScalarConfig{
+	Name: "DateTime",
+	Description: "The `DateTime` scalar type represents a DateTime." +
+		" The DateTime is serialized as an RFC 3339 quoted string",
+	Serialize:  serializeDateTime,
+	ParseValue: unserializeDateTime,
+	ParseLiteral: func(valueAST ast.Value) interface{} {
+		switch valueAST := valueAST.(type) {
 		case *ast.StringValue:
 			return valueAST.Value
 		}

--- a/scalars_parsevalue_test.go
+++ b/scalars_parsevalue_test.go
@@ -1,0 +1,26 @@
+package graphql_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/graphql-go/graphql"
+)
+
+func TestTypeSystem_Scalar_ParseValueOutputDateTime(t *testing.T) {
+	t1, _ := time.Parse(time.RFC3339, "2017-07-23T03:46:56.647Z")
+	tests := []dateTimeSerializationTest{
+		{nil, nil},
+		{"", nil},
+		{"2017-07-23", nil},
+		{"2017-07-23T03:46:56.647Z", t1},
+	}
+	for _, test := range tests {
+		val := graphql.DateTime.ParseValue(test.Value)
+		if val != test.Expected {
+			reflectedValue := reflect.ValueOf(test.Value)
+			t.Fatalf("failed DateTime.ParseValue(%v(%v)), expected: %v, got %v", reflectedValue.Type(), test.Value, test.Expected, val)
+		}
+	}
+}

--- a/scalars_serialization_test.go
+++ b/scalars_serialization_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/graphql-go/graphql"
 )
@@ -12,6 +13,7 @@ type intSerializationTest struct {
 	Value    interface{}
 	Expected interface{}
 }
+
 type float64SerializationTest struct {
 	Value    interface{}
 	Expected interface{}
@@ -20,6 +22,11 @@ type float64SerializationTest struct {
 type stringSerializationTest struct {
 	Value    interface{}
 	Expected string
+}
+
+type dateTimeSerializationTest struct {
+	Value    interface{}
+	Expected interface{}
 }
 
 type boolSerializationTest struct {
@@ -160,6 +167,33 @@ func TestTypeSystem_Scalar_SerializesOutputBoolean(t *testing.T) {
 		if val != test.Expected {
 			reflectedValue := reflect.ValueOf(test.Value)
 			t.Fatalf("Failed String.Boolean(%v(%v)), expected: %v, got %v", reflectedValue.Type(), test.Value, test.Expected, val)
+		}
+	}
+}
+
+func TestTypeSystem_Scalar_SerializeOutputDateTime(t *testing.T) {
+	now := time.Now()
+	nowString, err := now.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []dateTimeSerializationTest{
+		{"string", nil},
+		{int(1), nil},
+		{float32(-1.1), nil},
+		{float64(-1.1), nil},
+		{true, nil},
+		{false, nil},
+		{now, string(nowString)},
+		{&now, string(nowString)},
+	}
+
+	for _, test := range tests {
+		val := graphql.DateTime.Serialize(test.Value)
+		if val != test.Expected {
+			reflectedValue := reflect.ValueOf(test.Value)
+			t.Fatalf("Failed DateTime.Serialize(%v(%v)), expected: %v, got %v", reflectedValue.Type(), test.Value, test.Expected, val)
 		}
 	}
 }


### PR DESCRIPTION
#### Overview
- Build on top of: https://github.com/graphql-go/graphql/pull/209 - thanks a lot @jeromer!
- scalars: adds `DateTime` scalar.
- scalars/test: adds test for `DateTime.Serialize` & `DateTime.ParseValue`

#### Test plan
- [x] Unit test.