### PR TITLE
types: enum pointer values

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -988,17 +988,27 @@ func (gt *Enum) Values() []*EnumValueDefinition {
 	return gt.values
 }
 func (gt *Enum) Serialize(value interface{}) interface{} {
-	if enumValue, ok := gt.getValueLookup()[value]; ok {
+	v := value
+	if reflect.ValueOf(v).Kind() == reflect.Ptr {
+		v = reflect.Indirect(reflect.ValueOf(v)).Interface()
+	}
+	if enumValue, ok := gt.getValueLookup()[v]; ok {
 		return enumValue.Name
 	}
 	return nil
 }
 func (gt *Enum) ParseValue(value interface{}) interface{} {
-	valueStr, ok := value.(string)
-	if !ok {
+	var v string
+
+	switch value := value.(type) {
+	case string:
+		v = value
+	case *string:
+		v = *value
+	default:
 		return nil
 	}
-	if enumValue, ok := gt.getNameLookup()[valueStr]; ok {
+	if enumValue, ok := gt.getNameLookup()[v]; ok {
 		return enumValue.Value
 	}
 	return nil


### PR DESCRIPTION
#### Overview
- Built on top of: https://github.com/graphql-go/graphql/pull/206 — thanks a lot @threadwaste
- types: adds support for using pointers values on enum type.
- types/test: adds test for enum types pointer values.

#### Test plan
- [x] `go test ./...`