### PR TITLE
go-fuzz fixes

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -1517,7 +1517,7 @@ func UniqueInputFieldNamesRule(context *ValidationContext) *ValidationRuleInstan
 //
 // A GraphQL document is only valid if all defined operations have unique names.
 func UniqueOperationNamesRule(context *ValidationContext) *ValidationRuleInstance {
-	knownOperationNames := map[string]*ast.Name{}
+	knownOperationNames := make(map[string]ast.Node)
 
 	visitorOpts := &visitor.VisitorOptions{
 		KindFuncMap: map[string]visitor.NamedVisitFuncs{
@@ -1528,14 +1528,18 @@ func UniqueOperationNamesRule(context *ValidationContext) *ValidationRuleInstanc
 						if node.Name != nil {
 							operationName = node.Name.Value
 						}
+						var errNode ast.Node = node
+						if node.Name != nil {
+							errNode = node.Name
+						}
 						if nameAST, ok := knownOperationNames[operationName]; ok {
 							reportError(
 								context,
 								fmt.Sprintf(`There can only be one operation named "%v".`, operationName),
-								[]ast.Node{nameAST, node.Name},
+								[]ast.Node{nameAST, errNode},
 							)
 						} else {
-							knownOperationNames[operationName] = node.Name
+							knownOperationNames[operationName] = errNode
 						}
 					}
 					return visitor.ActionSkip, nil

--- a/rules_unique_operation_names_test.go
+++ b/rules_unique_operation_names_test.go
@@ -102,3 +102,9 @@ func TestValidate_UniqueOperationNames_MultipleOperationsOfSameNameOfDifferentTy
 		testutil.RuleError(`There can only be one operation named "Foo".`, 2, 13, 5, 20),
 	})
 }
+
+func TestValidate_UniqueOperationNames_MultipleAnonymousOperations(t *testing.T) {
+	testutil.ExpectFailsRule(t, graphql.UniqueOperationNamesRule, `{a}{b}`, []gqlerrors.FormattedError{
+		testutil.RuleError(`There can only be one operation named "".`, 1, 1, 1, 4),
+	})
+}


### PR DESCRIPTION
#### Overview
- Commit taken from https://github.com/graphql-go/graphql/pull/147 — thanks a lot @titanous :+1: 

#### Test plan
- [x] `go test ./...`