### PR TITLE
Add optional Type to FormattedError

### DIFF
--- a/gqlerrors/error.go
+++ b/gqlerrors/error.go
@@ -17,7 +17,12 @@ type Error struct {
 	Positions     []int
 	Locations     []location.SourceLocation
 	OriginalError error
+	Extensions    ErrorExtensions
 }
+
+// ErrorExtensions contains custom extensions that are passed through to the
+// client.
+type ErrorExtensions map[string]interface{}
 
 // implements Golang's built-in `error` interface
 func (g Error) Error() string {

--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -6,21 +6,44 @@ import (
 	"github.com/graphql-go/graphql/language/location"
 )
 
+// FormattedError contains user and machine readable, formatted error messages.
 type FormattedError struct {
 	Message   string                    `json:"message"`
 	Locations []location.SourceLocation `json:"locations"`
+	Type      string                    `json:"type,omitempty"`
 }
 
+// ErrorType describes the type of the error. For example "NOT_FOUND" might be
+// an error type the server wants to communicate to the client.
+type ErrorType string
+
+// FormattedErrorType is an interface that can be implemented by the underlying
+// error that is passed to `FormatError` (or `FormatErrors`). If the error
+// implements this interface the `Type` property of `FormattedError` is set to
+// this value.
+type FormattedErrorType interface {
+	ErrorType() string
+}
+
+// Error implements the `error` interface.
 func (g FormattedError) Error() string {
 	return g.Message
 }
 
+// NewFormattedError creates a new formatted error from a string.
 func NewFormattedError(message string) FormattedError {
 	err := errors.New(message)
 	return FormatError(err)
 }
 
+// FormatError from a plain error type.
 func FormatError(err error) FormattedError {
+	var errorType string
+	formattedErrorType, isFormattedErrorType := err.(FormattedErrorType)
+	if isFormattedErrorType {
+		errorType = formattedErrorType.ErrorType()
+	}
+
 	switch err := err.(type) {
 	case FormattedError:
 		return err
@@ -28,20 +51,24 @@ func FormatError(err error) FormattedError {
 		return FormattedError{
 			Message:   err.Error(),
 			Locations: err.Locations,
+			Type:      errorType,
 		}
 	case Error:
 		return FormattedError{
 			Message:   err.Error(),
 			Locations: err.Locations,
+			Type:      errorType,
 		}
 	default:
 		return FormattedError{
 			Message:   err.Error(),
 			Locations: []location.SourceLocation{},
+			Type:      errorType,
 		}
 	}
 }
 
+// FormatErrors creates an array of `FormattedError`s from plain errors.
 func FormatErrors(errs ...error) []FormattedError {
 	formattedErrors := []FormattedError{}
 	for _, err := range errs {


### PR DESCRIPTION
This is how github's API exposes machine-readable error strings. We need this in our API to better be able to handle specific errors in the client. This is just a proposal to start a discussion on how to best handle this requirement 😃 

For example:

Query:
```graphql
{
  repository(owner:"bla",name:"blubb") {
    id
  }
}
```

Response:
```json
{
  "data": {
    "repository": null
  },
  "errors": [
    {
      "message": "Could not resolve to a Repository with the name 'blubb'.",
      "type": "NOT_FOUND",
      "path": [
        "repository"
      ],
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ]
    }
  ]
}
```