### PR TITLE
possible fix

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -300,7 +300,10 @@ func init() {
 					},
 				},
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					id, _ := strconv.Atoi(p.Args["id"].(string))
+					id, err := strconv.Atoi(p.Args["id"].(string))
+					if err != nil {
+					  return nil, err
+					}
 					return GetHuman(id), nil
 				},
 			},

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -300,7 +300,8 @@ func init() {
 					},
 				},
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					return GetHuman(p.Args["id"].(int)), nil
+					id, _ := strconv.Atoi(p.Args["id"].(string))
+					return GetHuman(id), nil
 				},
 			},
 			"droid": &graphql.Field{


### PR DESCRIPTION
I sent
```
{
  human(id: "1000") {
    name
  }
}
```
And get
```
{
  "data": {
    "human": null
  },
  "errors": [
    {
      "message": "interface conversion: interface {} is string, not int",
      "locations": []
    }
  ]
}
```
don't know whether it was intended, but I fixed