### PR TITLE
Cleaner default resolver, cache FieldDefMap Get, preallocate

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -441,6 +441,9 @@ func (gt *Object) String() string {
 	return gt.PrivateName
 }
 func (gt *Object) Fields() FieldDefinitionMap {
+	if len(gt.fields) != 0 {
+		return gt.fields
+	}
 	var configureFields Fields
 	switch gt.typeConfig.Fields.(type) {
 	case Fields:

--- a/executor.go
+++ b/executor.go
@@ -827,12 +827,17 @@ func defaultResolveTypeFn(p ResolveTypeParams, abstractType Abstract) *Object {
 func DefaultResolveFn(p ResolveParams) (interface{}, error) {
 	// try to resolve p.Source as a struct first
 	sourceVal := reflect.ValueOf(p.Source)
-	if sourceVal.IsValid() && sourceVal.Type().Kind() == reflect.Ptr {
-		sourceVal = sourceVal.Elem()
-	}
-	if !sourceVal.IsValid() {
+	if sourceVal.IsValid() {
+		if sourceVal.Type().Kind() == reflect.Ptr {
+			sourceVal = sourceVal.Elem()
+			if !sourceVal.IsValid() {
+				return nil, nil
+			}
+		}
+	} else {
 		return nil, nil
 	}
+
 	if sourceVal.Type().Kind() == reflect.Struct {
 		// try matching the field name first
 		if v := sourceVal.FieldByName(p.Info.FieldName); v.IsValid() {


### PR DESCRIPTION
Returning 26k rows for me was taking 8 seconds of post-Resolve() processing. I reduced that to 305ms by:

- Returning the cached FieldDefMap (7 seconds)
- Preallocating result map/array structures (5ms or so)
- DefaultResolver logically identical, but far more efficient: uses reflect.FieldByName instead of checking in a loop. Allocates fewer variables.