### PR TITLE
Update .travis.yml to test Go 1.8, and Go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: go
 
 go:
-  - 1.7
+  - 1.8
+  - 1.9
   - tip
+
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
 
 before_install:
   - go get github.com/axw/gocov/gocov


### PR DESCRIPTION
Allow failures testing Go tip.