### PR TITLE
Add a PanicHandler executor field

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -31,6 +31,9 @@ type Params struct {
 	// Context may be provided to pass application-specific per-request
 	// information to resolve functions.
 	Context context.Context
+
+	// PanicHandler will be called if any of the resolvers or mutations panic
+	PanicHandler func(ctx context.Context, err interface{})
 }
 
 func Do(p Params) *Result {
@@ -59,5 +62,6 @@ func Do(p Params) *Result {
 		OperationName: p.OperationName,
 		Args:          p.VariableValues,
 		Context:       p.Context,
+		PanicHandler:  p.PanicHandler,
 	})
 }


### PR DESCRIPTION
Allows you to define a function that gets called if a resolver or mutation
panics

cc https://github.com/graphql-go/graphql/issues/243