### PR TITLE
executor: adds panic handler

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -22,7 +22,6 @@ type ExecuteParams struct {
 	// information to resolve functions.
 	Context context.Context
 
-	// PanicHandler will be called if any of the resolvers or mutations panic
 	PanicHandler func(ctx context.Context, err interface{})
 }
 

--- a/executor.go
+++ b/executor.go
@@ -22,7 +22,7 @@ type ExecuteParams struct {
 	// information to resolve functions.
 	Context context.Context
 
-	PanicHandler func(ctx context.Context, err interface{})
+	PanicHandler PanicHandler
 }
 
 func Execute(p ExecuteParams) (result *Result) {

--- a/executor.go
+++ b/executor.go
@@ -589,8 +589,7 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 	})
 
 	if resolveFnError != nil {
-		eCtx.Errors = append(eCtx.Errors, gqlerrors.FormatError(resolveFnError))
-		return result, resultState
+		panic(gqlerrors.FormatError(resolveFnError))
 	}
 
 	completed := completeValueCatchingError(eCtx, returnType, fieldASTs, info, result)

--- a/executor.go
+++ b/executor.go
@@ -60,9 +60,6 @@ func Execute(p ExecuteParams) (result *Result) {
 
 		defer func() {
 			if r := recover(); r != nil {
-				if p.PanicHandler != nil {
-					p.PanicHandler(ctx, r)
-				}
 				var err error
 				if r, ok := r.(error); ok {
 					err = gqlerrors.FormatError(r)
@@ -524,7 +521,6 @@ func resolveField(eCtx *ExecutionContext, parentType *Object, source interface{}
 			if eCtx.PanicHandler != nil {
 				eCtx.PanicHandler(eCtx.Context, r)
 			}
-
 			var err error
 			if r, ok := r.(string); ok {
 				err = NewLocatedError(
@@ -600,9 +596,6 @@ func completeValueCatchingError(eCtx *ExecutionContext, returnType Type, fieldAS
 	// catch panic
 	defer func() interface{} {
 		if r := recover(); r != nil {
-			if eCtx.PanicHandler != nil {
-				eCtx.PanicHandler(eCtx.Context, r)
-			}
 			//send panic upstream
 			if _, ok := returnType.(*NonNull); ok {
 				panic(r)

--- a/executor_test.go
+++ b/executor_test.go
@@ -628,8 +628,8 @@ func TestPanicHandler(t *testing.T) {
 		Schema: schema,
 		AST:    ast,
 		Root:   data,
-		PanicHandler: func(ctx context.Context, err interface{}) {
-			caughtPanic = err
+		PanicHandler: func(ctx context.Context, v interface{}) {
+			caughtPanic = v
 		},
 	}
 	result := testutil.TestExecute(t, ep)

--- a/graphql.go
+++ b/graphql.go
@@ -32,7 +32,7 @@ type Params struct {
 	// information to resolve functions.
 	Context context.Context
 
-	// PanicHandler will be called if any of the resolvers or mutations panic
+	// PanicHandler is called if any resolver panics.
 	PanicHandler func(ctx context.Context, err interface{})
 }
 

--- a/graphql.go
+++ b/graphql.go
@@ -31,6 +31,9 @@ type Params struct {
 	// Context may be provided to pass application-specific per-request
 	// information to resolve functions.
 	Context context.Context
+
+	// PanicHandler will be called if any of the resolvers or mutations panic
+	PanicHandler func(ctx context.Context, err interface{})
 }
 
 func Do(p Params) *Result {
@@ -59,5 +62,6 @@ func Do(p Params) *Result {
 		OperationName: p.OperationName,
 		Args:          p.VariableValues,
 		Context:       p.Context,
+		PanicHandler:  p.PanicHandler,
 	})
 }

--- a/graphql.go
+++ b/graphql.go
@@ -8,6 +8,8 @@ import (
 	"github.com/graphql-go/graphql/language/source"
 )
 
+type PanicHandler func(ctx context.Context, v interface{})
+
 type Params struct {
 	// The GraphQL type system to use when validating and executing a query.
 	Schema Schema
@@ -33,7 +35,7 @@ type Params struct {
 	Context context.Context
 
 	// PanicHandler is called if any resolver panics.
-	PanicHandler func(ctx context.Context, err interface{})
+	PanicHandler PanicHandler
 }
 
 func Do(p Params) *Result {


### PR DESCRIPTION
#### Overview
- graphql: adds `PanicHandler` type.
- graphql: adds `Params.PanicHandler` field.
- executor: calls PanicHandler when there's a panic while resolving a field.

#### Test plan
- Unit test.