### PR TITLE
SDL: Implement descriptions as strings

### DIFF
--- a/language/ast/definitions.go
+++ b/language/ast/definitions.go
@@ -200,11 +200,12 @@ func (def *TypeExtensionDefinition) GetOperation() string {
 
 // DirectiveDefinition implements Node, Definition
 type DirectiveDefinition struct {
-	Kind      string
-	Loc       *Location
-	Name      *Name
-	Arguments []*InputValueDefinition
-	Locations []*Name
+	Kind        string
+	Loc         *Location
+	Name        *Name
+	Description *StringValue
+	Arguments   []*InputValueDefinition
+	Locations   []*Name
 }
 
 func NewDirectiveDefinition(def *DirectiveDefinition) *DirectiveDefinition {
@@ -212,11 +213,12 @@ func NewDirectiveDefinition(def *DirectiveDefinition) *DirectiveDefinition {
 		def = &DirectiveDefinition{}
 	}
 	return &DirectiveDefinition{
-		Kind:      kinds.DirectiveDefinition,
-		Loc:       def.Loc,
-		Name:      def.Name,
-		Arguments: def.Arguments,
-		Locations: def.Locations,
+		Kind:        kinds.DirectiveDefinition,
+		Loc:         def.Loc,
+		Name:        def.Name,
+		Description: def.Description,
+		Arguments:   def.Arguments,
+		Locations:   def.Locations,
 	}
 }
 

--- a/language/ast/definitions.go
+++ b/language/ast/definitions.go
@@ -241,3 +241,7 @@ func (def *DirectiveDefinition) GetSelectionSet() *SelectionSet {
 func (def *DirectiveDefinition) GetOperation() string {
 	return ""
 }
+
+func (def *DirectiveDefinition) GetDescription() *StringValue {
+	return def.Description
+}

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -198,12 +198,13 @@ func (def *ObjectDefinition) GetOperation() string {
 
 // FieldDefinition implements Node
 type FieldDefinition struct {
-	Kind       string
-	Loc        *Location
-	Name       *Name
-	Arguments  []*InputValueDefinition
-	Type       Type
-	Directives []*Directive
+	Kind        string
+	Loc         *Location
+	Name        *Name
+	Description *StringValue
+	Arguments   []*InputValueDefinition
+	Type        Type
+	Directives  []*Directive
 }
 
 func NewFieldDefinition(def *FieldDefinition) *FieldDefinition {
@@ -211,12 +212,13 @@ func NewFieldDefinition(def *FieldDefinition) *FieldDefinition {
 		def = &FieldDefinition{}
 	}
 	return &FieldDefinition{
-		Kind:       kinds.FieldDefinition,
-		Loc:        def.Loc,
-		Name:       def.Name,
-		Arguments:  def.Arguments,
-		Type:       def.Type,
-		Directives: def.Directives,
+		Kind:        kinds.FieldDefinition,
+		Loc:         def.Loc,
+		Name:        def.Name,
+		Description: def.Description,
+		Arguments:   def.Arguments,
+		Type:        def.Type,
+		Directives:  def.Directives,
 	}
 }
 

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -4,7 +4,13 @@ import (
 	"github.com/graphql-go/graphql/language/kinds"
 )
 
+// DescribableNode are nodes that have descriptions associated with them.
+type DescribableNode interface {
+	GetDescription() *StringValue
+}
+
 type TypeDefinition interface {
+	DescribableNode
 	GetOperation() string
 	GetVariableDefinitions() []*VariableDefinition
 	GetSelectionSet() *SelectionSet
@@ -146,6 +152,10 @@ func (def *ScalarDefinition) GetOperation() string {
 	return ""
 }
 
+func (def *ScalarDefinition) GetDescription() *StringValue {
+	return def.Description
+}
+
 // ObjectDefinition implements Node, Definition
 type ObjectDefinition struct {
 	Kind        string
@@ -196,6 +206,10 @@ func (def *ObjectDefinition) GetOperation() string {
 	return ""
 }
 
+func (def *ObjectDefinition) GetDescription() *StringValue {
+	return def.Description
+}
+
 // FieldDefinition implements Node
 type FieldDefinition struct {
 	Kind        string
@@ -230,6 +244,10 @@ func (def *FieldDefinition) GetLoc() *Location {
 	return def.Loc
 }
 
+func (def *FieldDefinition) GetDescription() *StringValue {
+	return def.Description
+}
+
 // InputValueDefinition implements Node
 type InputValueDefinition struct {
 	Kind         string
@@ -262,6 +280,10 @@ func (def *InputValueDefinition) GetKind() string {
 
 func (def *InputValueDefinition) GetLoc() *Location {
 	return def.Loc
+}
+
+func (def *InputValueDefinition) GetDescription() *StringValue {
+	return def.Description
 }
 
 // InterfaceDefinition implements Node, Definition
@@ -312,6 +334,10 @@ func (def *InterfaceDefinition) GetOperation() string {
 	return ""
 }
 
+func (def *InterfaceDefinition) GetDescription() *StringValue {
+	return def.Description
+}
+
 // UnionDefinition implements Node, Definition
 type UnionDefinition struct {
 	Kind        string
@@ -358,6 +384,10 @@ func (def *UnionDefinition) GetSelectionSet() *SelectionSet {
 
 func (def *UnionDefinition) GetOperation() string {
 	return ""
+}
+
+func (def *UnionDefinition) GetDescription() *StringValue {
+	return def.Description
 }
 
 // EnumDefinition implements Node, Definition
@@ -408,6 +438,10 @@ func (def *EnumDefinition) GetOperation() string {
 	return ""
 }
 
+func (def *EnumDefinition) GetDescription() *StringValue {
+	return def.Description
+}
+
 // EnumValueDefinition implements Node, Definition
 type EnumValueDefinition struct {
 	Kind        string
@@ -436,6 +470,10 @@ func (def *EnumValueDefinition) GetKind() string {
 
 func (def *EnumValueDefinition) GetLoc() *Location {
 	return def.Loc
+}
+
+func (def *EnumValueDefinition) GetDescription() *StringValue {
+	return def.Description
 }
 
 // InputObjectDefinition implements Node, Definition
@@ -484,4 +522,8 @@ func (def *InputObjectDefinition) GetSelectionSet() *SelectionSet {
 
 func (def *InputObjectDefinition) GetOperation() string {
 	return ""
+}
+
+func (def *InputObjectDefinition) GetDescription() *StringValue {
+	return def.Description
 }

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -148,12 +148,13 @@ func (def *ScalarDefinition) GetOperation() string {
 
 // ObjectDefinition implements Node, Definition
 type ObjectDefinition struct {
-	Kind       string
-	Loc        *Location
-	Name       *Name
-	Interfaces []*Named
-	Directives []*Directive
-	Fields     []*FieldDefinition
+	Kind        string
+	Loc         *Location
+	Name        *Name
+	Description *StringValue
+	Interfaces  []*Named
+	Directives  []*Directive
+	Fields      []*FieldDefinition
 }
 
 func NewObjectDefinition(def *ObjectDefinition) *ObjectDefinition {
@@ -161,12 +162,13 @@ func NewObjectDefinition(def *ObjectDefinition) *ObjectDefinition {
 		def = &ObjectDefinition{}
 	}
 	return &ObjectDefinition{
-		Kind:       kinds.ObjectDefinition,
-		Loc:        def.Loc,
-		Name:       def.Name,
-		Interfaces: def.Interfaces,
-		Directives: def.Directives,
-		Fields:     def.Fields,
+		Kind:        kinds.ObjectDefinition,
+		Loc:         def.Loc,
+		Name:        def.Name,
+		Description: def.Description,
+		Interfaces:  def.Interfaces,
+		Directives:  def.Directives,
+		Fields:      def.Fields,
 	}
 }
 

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -440,11 +440,12 @@ func (def *EnumValueDefinition) GetLoc() *Location {
 
 // InputObjectDefinition implements Node, Definition
 type InputObjectDefinition struct {
-	Kind       string
-	Loc        *Location
-	Name       *Name
-	Directives []*Directive
-	Fields     []*InputValueDefinition
+	Kind        string
+	Loc         *Location
+	Name        *Name
+	Description *StringValue
+	Directives  []*Directive
+	Fields      []*InputValueDefinition
 }
 
 func NewInputObjectDefinition(def *InputObjectDefinition) *InputObjectDefinition {
@@ -452,11 +453,12 @@ func NewInputObjectDefinition(def *InputObjectDefinition) *InputObjectDefinition
 		def = &InputObjectDefinition{}
 	}
 	return &InputObjectDefinition{
-		Kind:       kinds.InputObjectDefinition,
-		Loc:        def.Loc,
-		Name:       def.Name,
-		Directives: def.Directives,
-		Fields:     def.Fields,
+		Kind:        kinds.InputObjectDefinition,
+		Loc:         def.Loc,
+		Name:        def.Name,
+		Description: def.Description,
+		Directives:  def.Directives,
+		Fields:      def.Fields,
 	}
 }
 

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -410,10 +410,11 @@ func (def *EnumDefinition) GetOperation() string {
 
 // EnumValueDefinition implements Node, Definition
 type EnumValueDefinition struct {
-	Kind       string
-	Loc        *Location
-	Name       *Name
-	Directives []*Directive
+	Kind        string
+	Loc         *Location
+	Name        *Name
+	Description *StringValue
+	Directives  []*Directive
 }
 
 func NewEnumValueDefinition(def *EnumValueDefinition) *EnumValueDefinition {
@@ -421,10 +422,11 @@ func NewEnumValueDefinition(def *EnumValueDefinition) *EnumValueDefinition {
 		def = &EnumValueDefinition{}
 	}
 	return &EnumValueDefinition{
-		Kind:       kinds.EnumValueDefinition,
-		Loc:        def.Loc,
-		Name:       def.Name,
-		Directives: def.Directives,
+		Kind:        kinds.EnumValueDefinition,
+		Loc:         def.Loc,
+		Name:        def.Name,
+		Description: def.Description,
+		Directives:  def.Directives,
 	}
 }
 

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -314,11 +314,12 @@ func (def *InterfaceDefinition) GetOperation() string {
 
 // UnionDefinition implements Node, Definition
 type UnionDefinition struct {
-	Kind       string
-	Loc        *Location
-	Name       *Name
-	Directives []*Directive
-	Types      []*Named
+	Kind        string
+	Loc         *Location
+	Name        *Name
+	Description *StringValue
+	Directives  []*Directive
+	Types       []*Named
 }
 
 func NewUnionDefinition(def *UnionDefinition) *UnionDefinition {
@@ -326,11 +327,12 @@ func NewUnionDefinition(def *UnionDefinition) *UnionDefinition {
 		def = &UnionDefinition{}
 	}
 	return &UnionDefinition{
-		Kind:       kinds.UnionDefinition,
-		Loc:        def.Loc,
-		Name:       def.Name,
-		Directives: def.Directives,
-		Types:      def.Types,
+		Kind:        kinds.UnionDefinition,
+		Loc:         def.Loc,
+		Name:        def.Name,
+		Description: def.Description,
+		Directives:  def.Directives,
+		Types:       def.Types,
 	}
 }
 

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -362,11 +362,12 @@ func (def *UnionDefinition) GetOperation() string {
 
 // EnumDefinition implements Node, Definition
 type EnumDefinition struct {
-	Kind       string
-	Loc        *Location
-	Name       *Name
-	Directives []*Directive
-	Values     []*EnumValueDefinition
+	Kind        string
+	Loc         *Location
+	Name        *Name
+	Description *StringValue
+	Directives  []*Directive
+	Values      []*EnumValueDefinition
 }
 
 func NewEnumDefinition(def *EnumDefinition) *EnumDefinition {
@@ -374,11 +375,12 @@ func NewEnumDefinition(def *EnumDefinition) *EnumDefinition {
 		def = &EnumDefinition{}
 	}
 	return &EnumDefinition{
-		Kind:       kinds.EnumDefinition,
-		Loc:        def.Loc,
-		Name:       def.Name,
-		Directives: def.Directives,
-		Values:     def.Values,
+		Kind:        kinds.EnumDefinition,
+		Loc:         def.Loc,
+		Name:        def.Name,
+		Description: def.Description,
+		Directives:  def.Directives,
+		Values:      def.Values,
 	}
 }
 

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -235,6 +235,7 @@ type InputValueDefinition struct {
 	Kind         string
 	Loc          *Location
 	Name         *Name
+	Description  *StringValue
 	Type         Type
 	DefaultValue Value
 	Directives   []*Directive
@@ -248,6 +249,7 @@ func NewInputValueDefinition(def *InputValueDefinition) *InputValueDefinition {
 		Kind:         kinds.InputValueDefinition,
 		Loc:          def.Loc,
 		Name:         def.Name,
+		Description:  def.Description,
 		Type:         def.Type,
 		DefaultValue: def.DefaultValue,
 		Directives:   def.Directives,

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -72,7 +72,7 @@ func (def *SchemaDefinition) GetOperation() string {
 	return ""
 }
 
-// ScalarDefinition implements Node, Definition
+// OperationTypeDefinition implements Node, Definition
 type OperationTypeDefinition struct {
 	Kind      string
 	Loc       *Location
@@ -102,10 +102,11 @@ func (def *OperationTypeDefinition) GetLoc() *Location {
 
 // ScalarDefinition implements Node, Definition
 type ScalarDefinition struct {
-	Kind       string
-	Loc        *Location
-	Name       *Name
-	Directives []*Directive
+	Kind        string
+	Loc         *Location
+	Description *StringValue
+	Name        *Name
+	Directives  []*Directive
 }
 
 func NewScalarDefinition(def *ScalarDefinition) *ScalarDefinition {
@@ -113,10 +114,11 @@ func NewScalarDefinition(def *ScalarDefinition) *ScalarDefinition {
 		def = &ScalarDefinition{}
 	}
 	return &ScalarDefinition{
-		Kind:       kinds.ScalarDefinition,
-		Loc:        def.Loc,
-		Name:       def.Name,
-		Directives: def.Directives,
+		Kind:        kinds.ScalarDefinition,
+		Loc:         def.Loc,
+		Description: def.Description,
+		Name:        def.Name,
+		Directives:  def.Directives,
 	}
 }
 

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -266,11 +266,12 @@ func (def *InputValueDefinition) GetLoc() *Location {
 
 // InterfaceDefinition implements Node, Definition
 type InterfaceDefinition struct {
-	Kind       string
-	Loc        *Location
-	Name       *Name
-	Directives []*Directive
-	Fields     []*FieldDefinition
+	Kind        string
+	Loc         *Location
+	Name        *Name
+	Description *StringValue
+	Directives  []*Directive
+	Fields      []*FieldDefinition
 }
 
 func NewInterfaceDefinition(def *InterfaceDefinition) *InterfaceDefinition {
@@ -278,11 +279,12 @@ func NewInterfaceDefinition(def *InterfaceDefinition) *InterfaceDefinition {
 		def = &InterfaceDefinition{}
 	}
 	return &InterfaceDefinition{
-		Kind:       kinds.InterfaceDefinition,
-		Loc:        def.Loc,
-		Name:       def.Name,
-		Directives: def.Directives,
-		Fields:     def.Fields,
+		Kind:        kinds.InterfaceDefinition,
+		Loc:         def.Loc,
+		Name:        def.Name,
+		Description: def.Description,
+		Directives:  def.Directives,
+		Fields:      def.Fields,
 	}
 }
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1207,11 +1207,15 @@ func parseInterfaceTypeDefinition(parser *Parser) (*ast.InterfaceDefinition, err
 }
 
 /**
- * UnionTypeDefinition : union Name Directives? = UnionMembers
+ * UnionTypeDefinition : Description? union Name Directives? = UnionMembers
  */
 func parseUnionTypeDefinition(parser *Parser) (*ast.UnionDefinition, error) {
 	start := parser.Token.Start
-	_, err := expectKeyWord(parser, "union")
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
+	_, err = expectKeyWord(parser, "union")
 	if err != nil {
 		return nil, err
 	}
@@ -1232,10 +1236,11 @@ func parseUnionTypeDefinition(parser *Parser) (*ast.UnionDefinition, error) {
 		return nil, err
 	}
 	return ast.NewUnionDefinition(&ast.UnionDefinition{
-		Name:       name,
-		Directives: directives,
-		Loc:        loc(parser, start),
-		Types:      types,
+		Name:        name,
+		Description: description,
+		Directives:  directives,
+		Loc:         loc(parser, start),
+		Types:       types,
 	}), nil
 }
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1118,10 +1118,14 @@ func parseArgumentDefs(parser *Parser) ([]*ast.InputValueDefinition, error) {
 }
 
 /**
- * InputValueDefinition : Name : Type DefaultValue? Directives?
+ * InputValueDefinition : Description? Name : Type DefaultValue? Directives?
  */
 func parseInputValueDef(parser *Parser) (interface{}, error) {
 	start := parser.Token.Start
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
 	name, err := parseName(parser)
 	if err != nil {
 		return nil, err
@@ -1152,6 +1156,7 @@ func parseInputValueDef(parser *Parser) (interface{}, error) {
 	}
 	return ast.NewInputValueDefinition(&ast.InputValueDefinition{
 		Name:         name,
+		Description:  description,
 		Type:         ttype,
 		DefaultValue: defaultValue,
 		Directives:   directives,

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1400,7 +1400,11 @@ func parseTypeExtensionDefinition(parser *Parser) (*ast.TypeExtensionDefinition,
  */
 func parseDirectiveDefinition(parser *Parser) (*ast.DirectiveDefinition, error) {
 	start := parser.Token.Start
-	_, err := expectKeyWord(parser, "directive")
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
+	_, err = expectKeyWord(parser, "directive")
 	if err != nil {
 		return nil, err
 	}
@@ -1426,10 +1430,11 @@ func parseDirectiveDefinition(parser *Parser) (*ast.DirectiveDefinition, error) 
 	}
 
 	return ast.NewDirectiveDefinition(&ast.DirectiveDefinition{
-		Loc:       loc(parser, start),
-		Name:      name,
-		Arguments: args,
-		Locations: locations,
+		Loc:         loc(parser, start),
+		Name:        name,
+		Description: description,
+		Arguments:   args,
+		Locations:   locations,
 	}), nil
 }
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1058,10 +1058,14 @@ func parseImplementsInterfaces(parser *Parser) ([]*ast.Named, error) {
 }
 
 /**
- * FieldDefinition : Name ArgumentsDefinition? : Type Directives?
+ * FieldDefinition : Description? Name ArgumentsDefinition? : Type Directives?
  */
 func parseFieldDefinition(parser *Parser) (interface{}, error) {
 	start := parser.Token.Start
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
 	name, err := parseName(parser)
 	if err != nil {
 		return nil, err
@@ -1083,11 +1087,12 @@ func parseFieldDefinition(parser *Parser) (interface{}, error) {
 		return nil, err
 	}
 	return ast.NewFieldDefinition(&ast.FieldDefinition{
-		Name:       name,
-		Arguments:  args,
-		Type:       ttype,
-		Directives: directives,
-		Loc:        loc(parser, start),
+		Name:        name,
+		Description: description,
+		Arguments:   args,
+		Type:        ttype,
+		Directives:  directives,
+		Loc:         loc(parser, start),
 	}), nil
 }
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1334,11 +1334,16 @@ func parseEnumValueDefinition(parser *Parser) (interface{}, error) {
 }
 
 /**
- * InputObjectTypeDefinition : input Name Directives? { InputValueDefinition+ }
+ * InputObjectTypeDefinition :
+ *   - Description? input Name Directives? { InputValueDefinition+ }
  */
 func parseInputObjectTypeDefinition(parser *Parser) (*ast.InputObjectDefinition, error) {
 	start := parser.Token.Start
-	_, err := expectKeyWord(parser, "input")
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
+	_, err = expectKeyWord(parser, "input")
 	if err != nil {
 		return nil, err
 	}
@@ -1361,10 +1366,11 @@ func parseInputObjectTypeDefinition(parser *Parser) (*ast.InputObjectDefinition,
 		}
 	}
 	return ast.NewInputObjectDefinition(&ast.InputObjectDefinition{
-		Name:       name,
-		Directives: directives,
-		Loc:        loc(parser, start),
-		Fields:     fields,
+		Name:        name,
+		Description: description,
+		Directives:  directives,
+		Loc:         loc(parser, start),
+		Fields:      fields,
 	}), nil
 }
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -958,11 +958,15 @@ func parseOperationTypeDefinition(parser *Parser) (interface{}, error) {
 }
 
 /**
- * ScalarTypeDefinition : scalar Name Directives?
+ * ScalarTypeDefinition : Description? scalar Name Directives?
  */
 func parseScalarTypeDefinition(parser *Parser) (*ast.ScalarDefinition, error) {
 	start := parser.Token.Start
-	_, err := expectKeyWord(parser, "scalar")
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
+	_, err = expectKeyWord(parser, "scalar")
 	if err != nil {
 		return nil, err
 	}
@@ -975,9 +979,10 @@ func parseScalarTypeDefinition(parser *Parser) (*ast.ScalarDefinition, error) {
 		return nil, err
 	}
 	def := ast.NewScalarDefinition(&ast.ScalarDefinition{
-		Name:       name,
-		Directives: directives,
-		Loc:        loc(parser, start),
+		Name:        name,
+		Description: description,
+		Directives:  directives,
+		Loc:         loc(parser, start),
 	})
 	return def, nil
 }

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -988,11 +988,17 @@ func parseScalarTypeDefinition(parser *Parser) (*ast.ScalarDefinition, error) {
 }
 
 /**
- * ObjectTypeDefinition : type Name ImplementsInterfaces? Directives? { FieldDefinition+ }
+ * ObjectTypeDefinition :
+ *   Description?
+ *   type Name ImplementsInterfaces? Directives? { FieldDefinition+ }
  */
 func parseObjectTypeDefinition(parser *Parser) (*ast.ObjectDefinition, error) {
 	start := parser.Token.Start
-	_, err := expectKeyWord(parser, "type")
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
+	_, err = expectKeyWord(parser, "type")
 	if err != nil {
 		return nil, err
 	}
@@ -1019,11 +1025,12 @@ func parseObjectTypeDefinition(parser *Parser) (*ast.ObjectDefinition, error) {
 		}
 	}
 	return ast.NewObjectDefinition(&ast.ObjectDefinition{
-		Name:       name,
-		Loc:        loc(parser, start),
-		Interfaces: interfaces,
-		Directives: directives,
-		Fields:     fields,
+		Name:        name,
+		Description: description,
+		Loc:         loc(parser, start),
+		Interfaces:  interfaces,
+		Directives:  directives,
+		Fields:      fields,
 	}), nil
 }
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1267,11 +1267,15 @@ func parseUnionMembers(parser *Parser) ([]*ast.Named, error) {
 }
 
 /**
- * EnumTypeDefinition : enum Name Directives? { EnumValueDefinition+ }
+ * EnumTypeDefinition : Description? enum Name Directives? { EnumValueDefinition+ }
  */
 func parseEnumTypeDefinition(parser *Parser) (*ast.EnumDefinition, error) {
 	start := parser.Token.Start
-	_, err := expectKeyWord(parser, "enum")
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
+	_, err = expectKeyWord(parser, "enum")
 	if err != nil {
 		return nil, err
 	}
@@ -1294,10 +1298,11 @@ func parseEnumTypeDefinition(parser *Parser) (*ast.EnumDefinition, error) {
 		}
 	}
 	return ast.NewEnumDefinition(&ast.EnumDefinition{
-		Name:       name,
-		Directives: directives,
-		Loc:        loc(parser, start),
-		Values:     values,
+		Name:        name,
+		Description: description,
+		Directives:  directives,
+		Loc:         loc(parser, start),
+		Values:      values,
 	}), nil
 }
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1307,12 +1307,16 @@ func parseEnumTypeDefinition(parser *Parser) (*ast.EnumDefinition, error) {
 }
 
 /**
- * EnumValueDefinition : EnumValue Directives?
+ * EnumValueDefinition : Description? EnumValue Directives?
  *
  * EnumValue : Name
  */
 func parseEnumValueDefinition(parser *Parser) (interface{}, error) {
 	start := parser.Token.Start
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
 	name, err := parseName(parser)
 	if err != nil {
 		return nil, err
@@ -1322,9 +1326,10 @@ func parseEnumValueDefinition(parser *Parser) (interface{}, error) {
 		return nil, err
 	}
 	return ast.NewEnumValueDefinition(&ast.EnumValueDefinition{
-		Name:       name,
-		Directives: directives,
-		Loc:        loc(parser, start),
+		Name:        name,
+		Description: description,
+		Directives:  directives,
+		Loc:         loc(parser, start),
 	}), nil
 }
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1165,11 +1165,17 @@ func parseInputValueDef(parser *Parser) (interface{}, error) {
 }
 
 /**
- * InterfaceTypeDefinition : interface Name Directives? { FieldDefinition+ }
+ * InterfaceTypeDefinition :
+ *   Description?
+ *   interface Name Directives? { FieldDefinition+ }
  */
 func parseInterfaceTypeDefinition(parser *Parser) (*ast.InterfaceDefinition, error) {
 	start := parser.Token.Start
-	_, err := expectKeyWord(parser, "interface")
+	description, err := parseDescription(parser)
+	if err != nil {
+		return nil, err
+	}
+	_, err = expectKeyWord(parser, "interface")
 	if err != nil {
 		return nil, err
 	}
@@ -1192,10 +1198,11 @@ func parseInterfaceTypeDefinition(parser *Parser) (*ast.InterfaceDefinition, err
 		}
 	}
 	return ast.NewInterfaceDefinition(&ast.InterfaceDefinition{
-		Name:       name,
-		Directives: directives,
-		Loc:        loc(parser, start),
-		Fields:     fields,
+		Name:        name,
+		Description: description,
+		Directives:  directives,
+		Loc:         loc(parser, start),
+		Fields:      fields,
 	}), nil
 }
 

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -586,6 +586,17 @@ func TestParsesInputObjectDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestDirectiveDefinitionWithDescription(t *testing.T) {
+	source := `
+		"cool skip"
+		directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -570,6 +570,22 @@ func TestParsesEnumValueDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesInputObjectDefinitionWithDescription(t *testing.T) {
+	source := `
+		"""
+		InputType is indeed a type
+		"""
+		input InputType {
+			key: String!
+			answer: Int = 42
+		}
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -553,6 +553,23 @@ func TestParsesEnumDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesEnumValueDefinitionWithDescription(t *testing.T) {
+	source := `
+		enum Site {
+			"description 1"
+			DESKTOP
+			"""
+			description 2
+			"""
+			MOBILE
+		}
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -477,6 +477,21 @@ func TestParsesObjectTypeDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesFieldDefinitionWithDescription(t *testing.T) {
+	source := `
+		type Foo implements Bar {
+			"""
+			foo is quite the field.
+			"""
+			foo: String!
+		}
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -509,6 +509,21 @@ func TestParsesInputValueDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesInterfaceDefinitionWithDescription(t *testing.T) {
+	source := `
+		"""
+		Bar is a symptom of the communist agenda
+		"""
+		interface  Bar {
+			foo: String!
+		}
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -492,6 +492,23 @@ func TestParsesFieldDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesInputValueDefinitionWithDescription(t *testing.T) {
+	source := `
+		type Foo implements Bar {
+			foo(
+				"""
+				input value comment
+				"""
+				bar: String!
+			): String!
+		}
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -449,34 +449,6 @@ func TestParsesNamedSubscriptionOperations(t *testing.T) {
 	}
 }
 
-func TestParsesScalarWithDescription(t *testing.T) {
-	source := `
-		"""
-		Returns RFC666; includes timezone offset.
-		"""
-		scalar TimeWithZone
-	`
-	_, err := Parse(ParseParams{Source: source})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestParsesObjectTypeDefinitionWithDescription(t *testing.T) {
-	source := `
-		"""
-		★ Foo ★
-		"""
-		type Foo implements Bar {
-			foo: String!
-		}
-	`
-	_, err := Parse(ParseParams{Source: source})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 func TestParsesFieldDefinitionWithDescription(t *testing.T) {
 	source := `
 		type Foo implements Bar {
@@ -509,50 +481,6 @@ func TestParsesInputValueDefinitionWithDescription(t *testing.T) {
 	}
 }
 
-func TestParsesInterfaceDefinitionWithDescription(t *testing.T) {
-	source := `
-		"""
-		Bar is a symptom of the communist agenda
-		"""
-		interface  Bar {
-			foo: String!
-		}
-	`
-	_, err := Parse(ParseParams{Source: source})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestParsesUnionDefinitionWithDescription(t *testing.T) {
-	source := `
-		"""
-		Cruft ...
-		"""
-		union Cruft = Foo | Bar
-	`
-	_, err := Parse(ParseParams{Source: source})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestParsesEnumDefinitionWithDescription(t *testing.T) {
-	source := `
-		"""
-		description 2
-		"""
-		enum Site {
-			DESKTOP
-			MOBILE
-		}
-	`
-	_, err := Parse(ParseParams{Source: source})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 func TestParsesEnumValueDefinitionWithDescription(t *testing.T) {
 	source := `
 		enum Site {
@@ -570,30 +498,114 @@ func TestParsesEnumValueDefinitionWithDescription(t *testing.T) {
 	}
 }
 
-func TestParsesInputObjectDefinitionWithDescription(t *testing.T) {
-	source := `
-		"""
-		InputType is indeed a type
-		"""
-		input InputType {
-			key: String!
-			answer: Int = 42
-		}
-	`
-	_, err := Parse(ParseParams{Source: source})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestDefinitionsWithDescriptions(t *testing.T) {
+	testCases := []struct {
+		name            string
+		source          string
+		expectedComment string
+	}{
+		{
+			name: "directives",
+			source: `
+				"cool skip"
+				directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+			`,
+			expectedComment: "cool skip",
+		},
+		{
+			name: "input",
+			source: `
+				"""
+				InputType is indeed a type
+				"""
+				input InputType {
+					key: String!
+					answer: Int = 42
+				}
+			`,
+			expectedComment: "InputType is indeed a type",
+		},
+		{
+			name: "enum",
+			source: `
+				"""
+				description 2
+				"""
+				enum Site {
+					DESKTOP
+					MOBILE
+				}
+			`,
+			expectedComment: "description 2",
+		},
+		{
+			name: "union",
+			source: `
+				"""
+				Cruft ...
+				"""
+				union Cruft = Foo | Bar
+			`,
+			expectedComment: "Cruft ...",
+		},
+		{
+			name: "interface",
+			source: `
+				"""
+				Bar is a symptom of the communist agenda
+				"""
+				interface  Bar {
+					foo: String!
+				}
+			`,
+			expectedComment: "Bar is a symptom of the communist agenda",
+		},
+		{
+			name: "object",
+			source: `
+				"""
+				★ Foo ★
+				"""
+				type Foo implements Bar {
+					foo: String!
+				}
+			`,
+			expectedComment: "★ Foo ★",
+		},
+		{
+			name: "scalar",
+			source: `
+				"""
+				Returns RFC666; includes timezone offset.
+				"""
+				scalar TimeWithZone
+			`,
+			expectedComment: "Returns RFC666; includes timezone offset.",
+		},
 	}
-}
 
-func TestDirectiveDefinitionWithDescription(t *testing.T) {
-	source := `
-		"cool skip"
-		directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-	`
-	_, err := Parse(ParseParams{Source: source})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s may have comments", tc.name), func(t *testing.T) {
+			doc, err := Parse(ParseParams{Source: tc.source})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if doc == nil {
+				t.Fatal("no document was returned")
+			}
+			for _, def := range doc.Definitions {
+				fmt.Printf("%#v\n", def)
+			}
+			if node, ok := doc.Definitions[0].(ast.DescribableNode); !ok {
+				t.Fatalf("unexpected node received %#v", doc.Definitions[0])
+			} else if node.GetDescription().Value != tc.expectedComment {
+				t.Fatalf(
+					"parsed description '%s' does not match '%s'",
+					node.GetDescription().Value,
+					tc.expectedComment,
+				)
+			}
+		})
 	}
 }
 

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -449,6 +449,19 @@ func TestParsesNamedSubscriptionOperations(t *testing.T) {
 	}
 }
 
+func TestParsesScalarWithDescription(t *testing.T) {
+	source := `
+		"""
+		Returns RFC666; includes timezone offset.
+		"""
+		scalar TimeWithZone
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -462,6 +462,21 @@ func TestParsesScalarWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesObjectTypeDefinitionWithDescription(t *testing.T) {
+	source := `
+		"""
+		★ Foo ★
+		"""
+		type Foo implements Bar {
+			foo: String!
+		}
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -537,6 +537,22 @@ func TestParsesUnionDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesEnumDefinitionWithDescription(t *testing.T) {
+	source := `
+		"""
+		description 2
+		"""
+		enum Site {
+			DESKTOP
+			MOBILE
+		}
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -524,6 +524,19 @@ func TestParsesInterfaceDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesUnionDefinitionWithDescription(t *testing.T) {
+	source := `
+		"""
+		Cruft ...
+		"""
+		union Cruft = Foo | Bar
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseCreatesAst(t *testing.T) {
 	body := `{
   node(id: 4) {


### PR DESCRIPTION
- Defined in facebook/graphql#90.
- [Grammar Summary](https://github.com/facebook/graphql/blob/398e443983724463b8474b12a260fba31c19c2a9/spec/Appendix%20B%20--%20Grammar%20Summary.md#document).
- Parser changes largely inspired by [graphql-js implementation](https://github.com/graphql/graphql-js/blob/8e0c599ceccfa8c40d6edf3b72ee2a71490b10e0/src/language/parser.js#L717-L1145).

tldr; when describing your schema using GraphQL's Schema Definition Language (SDL) you can provide descriptions for your types using strings.

```golang
"""
My Great Type
"""
type Dog implements Pet {
  name: String!
  breed: [BREED]
}

"""
Pets are great
"""
interface Pets {
  "All pets should have a name"
  name: String!
}

"""
Dog Breeds
"""
enum BREED {
  """
  Description 1
  """
  BORDER_COLLIE
  "Description 2"
  SHIBA
  """
  Do not as me how to spell this
  """
  POM
}

// ...
```
