### PR TITLE
Fix utility function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: go
 
 go:
-  - 1.7
+  - 1.8
+  - 1.9
   - tip
+
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
 
 before_install:
   - go get github.com/axw/gocov/gocov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.8
-  - 1.9
+  - 1.8.x
+  - 1.9.x
   - tip
 
 matrix:
@@ -13,7 +13,6 @@ matrix:
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
-  - go get golang.org/x/tools/cmd/cover
 
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to graphql-go
+# Contributing to graphql
 
-This document is based on the [io.js contribution guidelines](https://github.com/nodejs/io.js/blob/master/CONTRIBUTING.md)
+This document is based on the [Node.js contribution guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md)
 
 ## Chat room 
 
-[![Join the chat at https://gitter.im/chris-ramon/graphql-go](https://badges.gitter.im/Join%20Chat.svg)]
-(https://gitter.im/chris-ramon/graphql-go?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/graphql-go/graphql](https://badges.gitter.im/Join%20Chat.svg)]
+(https://gitter.im/graphql-go/graphql?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Feel free to participate in the chat room for informal discussions and queries. 
 
@@ -15,11 +15,11 @@ Just drop by and say hi!
 
 When opening new issues or commenting on existing issues on this repository
 please make sure discussions are related to concrete technical issues with the
-`graphql-go` software.
+`graphql` implementation.
 
 ## Code Contributions
 
-The `graphql-go` project welcomes new contributors.
+The `graphql` project welcomes new contributors.
 
 This document will guide you through the contribution process.
 
@@ -45,9 +45,9 @@ Descriptions for each of these will eventually be provided below.
 
 
 ## Creating Pull Requests
-Because `graphql-go` makes use of self-referencing import paths, you will want
+Because `graphql` makes use of self-referencing import paths, you will want
 to implement the local copy of your fork as a remote on your copy of the
-original `graphql-go` repo. Katrina Owen has [an excellent post on this workflow](https://splice.com/blog/contributing-open-source-git-repositories-go/).
+original `graphql` repo. Katrina Owen has [an excellent post on this workflow](https://splice.com/blog/contributing-open-source-git-repositories-go/).
 
 The basics are as follows:
 
@@ -56,10 +56,10 @@ The basics are as follows:
 2. `go get` the upstream repo and set it up as the `upstream` remote and your own repo as the `origin` remote:
 
 ```bash
-$ go get github.com/chris-ramon/graphql-go
-$ cd $GOPATH/src/github.com/chris-ramon/graphql-go
+$ go get github.com/graphql-go/graphql
+$ cd $GOPATH/src/github.com/graphql-go/graphql
 $ git remote rename origin upstream
-$ git remote add origin git@github.com/YOUR_GITHUB_NAME/graphql-go
+$ git remote add origin git@github.com/YOUR_GITHUB_NAME/graphql
 ```
 All import paths should now work fine assuming that you've got the
 proper branch checked out.
@@ -70,7 +70,7 @@ proper branch checked out.
 
 1. Set the contributor's fork as an upstream on your checkout
 
-   ```git remote add contrib1 https://github.com/contrib1/graphql-go```
+   ```git remote add contrib1 https://github.com/contrib1/graphql```
 
 2. Fetch the contributor's repo
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This project was originally a port of [v0.4.3](https://github.com/graphql/graphq
 | [graphql-go-handler](https://github.com/graphql-go/graphql-go-handler) | [Hafiz Ismail](https://github.com/sogko) | Middleware to handle GraphQL queries through HTTP requests. |
 | [graphql-relay-go](https://github.com/graphql-go/graphql-relay-go) | [Hafiz Ismail](https://github.com/sogko) | Lib to construct a graphql-go server supporting react-relay. |
 | [golang-relay-starter-kit](https://github.com/sogko/golang-relay-starter-kit) | [Hafiz Ismail](https://github.com/sogko) | Barebones starting point for a Relay application with Golang GraphQL server. |
+| [dataloader](https://github.com/nicksrandall/dataloader) | [Nick Randall](https://github.com/nicksrandall) | [DataLoader](https://github.com/facebook/dataloader) implementation in Go. |
 
 ### Blog Posts
 - [Golang + GraphQL + Relay](http://wehavefaces.net/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# graphql [![Build Status](https://travis-ci.org/graphql-go/graphql.svg)](https://travis-ci.org/graphql-go/graphql) [![GoDoc](https://godoc.org/graphql.co/graphql?status.svg)](https://godoc.org/github.com/graphql-go/graphql) [![Coverage Status](https://coveralls.io/repos/graphql-go/graphql/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql-go/graphql?branch=master) [![Join the chat at https://gitter.im/chris-ramon/graphql](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/graphql-go/graphql?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# graphql [![Build Status](https://travis-ci.org/graphql-go/graphql.svg)](https://travis-ci.org/graphql-go/graphql) [![GoDoc](https://godoc.org/graphql.co/graphql?status.svg)](https://godoc.org/github.com/graphql-go/graphql) [![Coverage Status](https://coveralls.io/repos/graphql-go/graphql/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql-go/graphql?branch=master) [![Join the chat at https://gitter.im/graphql-go/graphql](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/graphql-go/graphql?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A *work-in-progress* implementation of GraphQL for Go.
+A *work-in-progress* implementation of GraphQL in Go. Its currently a port of `graphql-js` [v0.6.0](https://github.com/graphql/graphql-js/releases/tag/v0.6.0) which is based on the [April 2016](https://github.com/facebook/graphql/releases/tag/April2016) GraphQL specification. Future efforts will be guided directly by the [latest formal GraphQL specification](https://github.com/facebook/graphql/releases) (currently: [October 2016](https://github.com/facebook/graphql/releases/tag/October2016)).
 
 ### Documentation
 
@@ -60,10 +60,6 @@ func main() {
 ```
 For more complex examples, refer to the [examples/](https://github.com/graphql-go/graphql/tree/master/examples/) directory and [graphql_test.go](https://github.com/graphql-go/graphql/blob/master/graphql_test.go).
 
-### Origin and Current Direction
-
-This project was originally a port of [v0.4.3](https://github.com/graphql/graphql-js/releases/tag/v0.4.3) of [graphql-js](https://github.com/graphql/graphql-js) (excluding the Validator), which was based on the July 2015 GraphQL specification. `graphql-go` is currently on [v0.6.0](https://github.com/graphql/graphql-js/releases/tag/v0.6.0) of `graphql-js` which is based on the [April 2016](https://github.com/facebook/graphql/releases/tag/April2016) GraphQL specification. However future efforts will be guided directly by the [latest formal GraphQL specification](https://github.com/facebook/graphql/releases) (currently: [October 2016](https://github.com/facebook/graphql/releases/tag/October2016)).
-
 ### Third Party Libraries
 | Name          | Author        | Description  |
 |:-------------:|:-------------:|:------------:|
@@ -74,18 +70,4 @@ This project was originally a port of [v0.4.3](https://github.com/graphql/graphq
 
 ### Blog Posts
 - [Golang + GraphQL + Relay](http://wehavefaces.net/)
-
-### Roadmap
-- [x] Lexer
-- [x] Parser
-- [x] Schema Parser
-- [x] Printer
-- [x] Schema Printer
-- [x] Visitor
-- [x] Executor
-- [x] Validator
-- [ ] Examples
-  - [x] Basic Usage
-  - [ ] React/Relay
-- [ ] Alpha Release (v0.1)
 

--- a/types.go
+++ b/types.go
@@ -12,5 +12,5 @@ type Result struct {
 }
 
 func (r *Result) HasErrors() bool {
-	return (len(r.Errors) > 0)
+	return len(r.Errors) > 0
 }

--- a/util.go
+++ b/util.go
@@ -21,10 +21,11 @@ func BindFields(obj interface{}) Fields {
 	for i := 0; i < v.NumField(); i++ {
 		typeField := v.Type().Field(i)
 
-		tag := typeField.Tag.Get(TAG)
+		tag := extractTag(typeField.Tag)
 		if tag == "-" {
 			continue
 		}
+
 		var graphType Output
 		if typeField.Type.Kind() == reflect.Struct {
 
@@ -120,12 +121,20 @@ func extractValue(originTag string, obj interface{}) interface{} {
 				return res
 			}
 		}
-		curTag := typeField.Tag
-		if originTag == curTag.Get(TAG) {
+
+		if originTag == extractTag(typeField.Tag) {
 			return val.Field(j).Interface()
 		}
 	}
 	return nil
+}
+
+func extractTag(tag reflect.StructTag) string {
+	t := tag.Get(TAG)
+	if t != "" {
+		t = strings.Split(t, ",")[0]
+	}
+	return t
 }
 
 // lazy way of binding args
@@ -135,7 +144,7 @@ func BindArg(obj interface{}, tags ...string) FieldConfigArgument {
 	for i := 0; i < v.NumField(); i++ {
 		typeField := v.Type().Field(i)
 
-		mytag := typeField.Tag.Get(TAG)
+		mytag := extractTag(typeField.Tag)
 		if inArray(tags, mytag) {
 			config[mytag] = &ArgumentConfig{
 				Type: getGraphType(typeField.Type),

--- a/util.go
+++ b/util.go
@@ -64,8 +64,15 @@ func getGraphType(tipe reflect.Type) Output {
 	case reflect.String:
 		return String
 	case reflect.Int:
+		fallthrough
+	case reflect.Int8:
+		fallthrough
+	case reflect.Int32:
+		fallthrough
+	case reflect.Int64:
 		return Int
 	case reflect.Float32:
+		fallthrough
 	case reflect.Float64:
 		return Float
 	case reflect.Bool:
@@ -80,13 +87,17 @@ func getGraphList(tipe reflect.Type) *List {
 	if tipe.Kind() == reflect.Slice {
 		switch tipe.Elem().Kind() {
 		case reflect.Int:
+			fallthrough
 		case reflect.Int8:
+			fallthrough
 		case reflect.Int32:
+			fallthrough
 		case reflect.Int64:
 			return NewList(Int)
 		case reflect.Bool:
 			return NewList(Boolean)
 		case reflect.Float32:
+			fallthrough
 		case reflect.Float64:
 			return NewList(Float)
 		case reflect.String:

--- a/util_test.go
+++ b/util_test.go
@@ -19,7 +19,7 @@ type Person struct {
 }
 
 type Human struct {
-	Alive  bool    `json:"alive"`
+	Alive  bool    `json:"alive,omitempty"`
 	Age    int     `json:"age"`
 	Weight float64 `json:"weight"`
 }
@@ -32,6 +32,7 @@ type Friend struct {
 type Address struct {
 	Street string `json:"street"`
 	City   string `json:"city"`
+	Test   string `json:",omitempty"`
 }
 
 var personSource = Person{
@@ -46,7 +47,7 @@ var personSource = Person{
 		City:   "Jakarta",
 	},
 	Friends: friendSource,
-	Hobbies:[]string{"eat","sleep","code"},
+	Hobbies: []string{"eat", "sleep", "code"},
 }
 
 var friendSource = []Friend{
@@ -109,7 +110,7 @@ func TestBindFields(t *testing.T) {
 
 	newPerson := data.Data.Person
 	if !reflect.DeepEqual(newPerson, personSource) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(newPerson, personSource))
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(personSource, newPerson))
 	}
 }
 


### PR DESCRIPTION
Fix json tag with multiple value (comma separated). The graphql name will return error if the json tag value containing comma
add more case for graph integer type