### PR TITLE
Fix utility function

### DIFF
--- a/util.go
+++ b/util.go
@@ -21,10 +21,11 @@ func BindFields(obj interface{}) Fields {
 	for i := 0; i < v.NumField(); i++ {
 		typeField := v.Type().Field(i)
 
-		tag := typeField.Tag.Get(TAG)
+		tag := extractTag(typeField.Tag)
 		if tag == "-" {
 			continue
 		}
+
 		var graphType Output
 		if typeField.Type.Kind() == reflect.Struct {
 
@@ -120,12 +121,20 @@ func extractValue(originTag string, obj interface{}) interface{} {
 				return res
 			}
 		}
-		curTag := typeField.Tag
-		if originTag == curTag.Get(TAG) {
+
+		if originTag == extractTag(typeField.Tag) {
 			return val.Field(j).Interface()
 		}
 	}
 	return nil
+}
+
+func extractTag(tag reflect.StructTag) string {
+	t := tag.Get(TAG)
+	if t != "" {
+		t = strings.Split(t, ",")[0]
+	}
+	return t
 }
 
 // lazy way of binding args
@@ -135,7 +144,7 @@ func BindArg(obj interface{}, tags ...string) FieldConfigArgument {
 	for i := 0; i < v.NumField(); i++ {
 		typeField := v.Type().Field(i)
 
-		mytag := typeField.Tag.Get(TAG)
+		mytag := extractTag(typeField.Tag)
 		if inArray(tags, mytag) {
 			config[mytag] = &ArgumentConfig{
 				Type: getGraphType(typeField.Type),

--- a/util.go
+++ b/util.go
@@ -64,8 +64,15 @@ func getGraphType(tipe reflect.Type) Output {
 	case reflect.String:
 		return String
 	case reflect.Int:
+		fallthrough
+	case reflect.Int8:
+		fallthrough
+	case reflect.Int32:
+		fallthrough
+	case reflect.Int64:
 		return Int
 	case reflect.Float32:
+		fallthrough
 	case reflect.Float64:
 		return Float
 	case reflect.Bool:
@@ -80,13 +87,17 @@ func getGraphList(tipe reflect.Type) *List {
 	if tipe.Kind() == reflect.Slice {
 		switch tipe.Elem().Kind() {
 		case reflect.Int:
+			fallthrough
 		case reflect.Int8:
+			fallthrough
 		case reflect.Int32:
+			fallthrough
 		case reflect.Int64:
 			return NewList(Int)
 		case reflect.Bool:
 			return NewList(Boolean)
 		case reflect.Float32:
+			fallthrough
 		case reflect.Float64:
 			return NewList(Float)
 		case reflect.String:

--- a/util_test.go
+++ b/util_test.go
@@ -19,7 +19,7 @@ type Person struct {
 }
 
 type Human struct {
-	Alive  bool    `json:"alive"`
+	Alive  bool    `json:"alive,omitempty"`
 	Age    int     `json:"age"`
 	Weight float64 `json:"weight"`
 }
@@ -32,6 +32,7 @@ type Friend struct {
 type Address struct {
 	Street string `json:"street"`
 	City   string `json:"city"`
+	Test   string `json:",omitempty"`
 }
 
 var personSource = Person{
@@ -46,7 +47,7 @@ var personSource = Person{
 		City:   "Jakarta",
 	},
 	Friends: friendSource,
-	Hobbies:[]string{"eat","sleep","code"},
+	Hobbies: []string{"eat", "sleep", "code"},
 }
 
 var friendSource = []Friend{
@@ -109,7 +110,7 @@ func TestBindFields(t *testing.T) {
 
 	newPerson := data.Data.Person
 	if !reflect.DeepEqual(newPerson, personSource) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(newPerson, personSource))
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(personSource, newPerson))
 	}
 }
 


### PR DESCRIPTION
Fix json tag with multiple value (comma separated). The graphql name will return error if the json tag value containing comma
add more case for graph integer type