### PR TITLE
Include stack trace in errors

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime/debug"
 	"strings"
 
 	"github.com/graphql-go/graphql/gqlerrors"
@@ -61,7 +62,9 @@ func Execute(p ExecuteParams) (result *Result) {
 				if r, ok := r.(error); ok {
 					err = gqlerrors.FormatError(r)
 				}
-				exeContext.Errors = append(exeContext.Errors, gqlerrors.FormatError(err))
+				formattedErr := gqlerrors.FormatError(err)
+				formattedErr.StackTrace = string(debug.Stack())
+				exeContext.Errors = append(exeContext.Errors, formattedErr)
 				result.Errors = exeContext.Errors
 				select {
 				case out <- result:

--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -7,8 +7,9 @@ import (
 )
 
 type FormattedError struct {
-	Message   string                    `json:"message"`
-	Locations []location.SourceLocation `json:"locations"`
+	Message    string                    `json:"message"`
+	Locations  []location.SourceLocation `json:"locations"`
+	StackTrace string                    `json:"-"`
 }
 
 func (g FormattedError) Error() string {

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -1032,10 +1032,19 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldThrows(t *testing.T) {
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
+	ignoreStackTraces(result)
 	if !reflect.DeepEqual(expected, result) {
+		t.Logf("=> err: %v", result.Errors[0].StackTrace)
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
+
+func ignoreStackTraces(res *graphql.Result) {
+	for i, _ := range res.Errors {
+		res.Errors[i].StackTrace = ""
+	}
+}
+
 func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
 	doc := `
       query Q { nonNullPromise }
@@ -1064,6 +1073,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
+	ignoreStackTraces(result)
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
@@ -1096,6 +1106,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldReturnsNull(t *testing.T)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
+	ignoreStackTraces(result)
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
@@ -1128,6 +1139,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldResolvesNull(t *testing.T
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
+	ignoreStackTraces(result)
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}


### PR DESCRIPTION
Hey,

Currently, if a runtime error occurs during the execution of a query, the only information available looks like this:
```json
{
  "data": null,
  "errors": [
    {
      "message": "runtime error: invalid memory address or nil pointer dereference",
      "locations": []
    }
  ]
}
```

Which is quite tricky to debug.

This PR adds a "StackTrace" field to the `FormattedError` object. This field is not exposed to the JSON version, so it doesn't expose possibly sensible debug information but can be used for logs.
Currently the field is only populated in one place but I guess it makes sense to populate it wherever there is a `recover()` call.
Because the call to `debug.Stack()` may be expensive, maybe we should add an option to enable/disable it ? Not sure how we should expose this.

Do you think this feature make sense ?