### PR TITLE
Disable Field.Resolve from JSON export

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -631,9 +631,9 @@ type Field struct {
 	Name              string              `json:"name"` // used by graphlql-relay
 	Type              Output              `json:"type"`
 	Args              FieldConfigArgument `json:"args"`
-	Resolve           FieldResolveFn
-	DeprecationReason string `json:"deprecationReason"`
-	Description       string `json:"description"`
+	Resolve           FieldResolveFn      `json:"-"`
+	DeprecationReason string              `json:"deprecationReason"`
+	Description       string              `json:"description"`
 }
 
 type FieldConfigArgument map[string]*ArgumentConfig


### PR DESCRIPTION
Hello,

I've just add `json:"-"` to this line `Resolve           FieldResolveFn` to allow JSON export of `Field`.

Thanks for this amazing project and time!

— JBX