### PR TITLE
Keep original error in FormattedError

### DIFF
--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -7,8 +7,9 @@ import (
 )
 
 type FormattedError struct {
-	Message   string                    `json:"message"`
-	Locations []location.SourceLocation `json:"locations"`
+	Message       string                    `json:"message"`
+	Locations     []location.SourceLocation `json:"locations"`
+	OriginalError error                     `json:"-"`
 }
 
 func (g FormattedError) Error() string {
@@ -26,18 +27,21 @@ func FormatError(err error) FormattedError {
 		return err
 	case *Error:
 		return FormattedError{
-			Message:   err.Error(),
-			Locations: err.Locations,
+			Message:       err.Error(),
+			Locations:     err.Locations,
+			OriginalError: err,
 		}
 	case Error:
 		return FormattedError{
-			Message:   err.Error(),
-			Locations: err.Locations,
+			Message:       err.Error(),
+			Locations:     err.Locations,
+			OriginalError: err,
 		}
 	default:
 		return FormattedError{
-			Message:   err.Error(),
-			Locations: []location.SourceLocation{},
+			Message:       err.Error(),
+			Locations:     []location.SourceLocation{},
+			OriginalError: err,
 		}
 	}
 }


### PR DESCRIPTION
Hi all, 

First, thanks for this lib. The work you've done is amazing.

The purpose of this PR is to keep the original error in the `FormattedError` struct so we can use it later.

Why would I do this : lets say I've got books. Some of them are public, other none. As I only get the book id in the resolver, I can not do the public/private check before calling `results := graphql.Do(...)`. But once in the resolver I can not set the response code (and I should not, its not its responsability). Thus, after the call, I check on `results.Errors`. And with my PR I can do something like that :
```golang
result := graphql.Do(graphql.Params{
    Schema:        schema,
    RequestString: r.URL.Query().Get("query"),
    Context:       c,
})

if len(result.Errors) > 0 {
    authorisationError, isOk := result.Errors[0].OriginalError.(AuthorisationError)
    if isOk {
        w.WriteHeader(401)
    }
    else {
        w.WriteHeader(400)
    }
    fmt.Printf("wrong result, unexpected errors: %v", result.Errors)
}

json.NewEncoder(w).Encode(result)
```

The other way would be to pass it through the RootObject (as mentionned [here](https://github.com/graphql-go/graphql/issues/156)), but I think that its a better thing to keep an information we already have instead of destroying it and use and other mechanism to pass it.

What do you think ?

Ruben