### PR TITLE
DefaultResolveFn: Use case insensitive comparison

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -851,7 +851,7 @@ func DefaultResolveFn(p ResolveParams) (interface{}, error) {
 			valueField := sourceVal.Field(i)
 			typeField := sourceVal.Type().Field(i)
 			// try matching the field name first
-			if typeField.Name == p.Info.FieldName {
+			if strings.EqualFold(typeField.Name, p.Info.FieldName) {
 				return valueField.Interface(), nil
 			}
 			tag := typeField.Tag


### PR DESCRIPTION
To be able to use struct type for resolver without using field tags

schema:
```graphql
type User {
  id: ID!
  name: String
}
```

Go:
```go
type User struct {
  ID string
  Name string
}