### PR TITLE
treat arrays as iterable

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -782,7 +782,7 @@ func completeListValue(eCtx *executionContext, returnType *List, fieldASTs []*as
 		parentTypeName = info.ParentType.Name()
 	}
 	err := invariantf(
-		resultVal.IsValid() && resultVal.Type().Kind() == reflect.Slice,
+		resultVal.IsValid() && isIterable(result),
 		"User Error: expected iterable, but did not find one "+
 			"for field %v.%v.", parentTypeName, info.FieldName)
 

--- a/lists_test.go
+++ b/lists_test.go
@@ -773,8 +773,25 @@ func TestLists_UserErrorExpectIterableButDidNotGetOne(t *testing.T) {
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
-				Message:   "User Error: expected iterable, but did not find one for field DataType.test.",
+				Message:   "User Error: aexpected iterable, but did not find one for field DataType.test.",
 				Locations: []location.SourceLocation{},
+			},
+		},
+	}
+	checkList(t, ttype, data, expected)
+}
+
+func TestLists_ArrayOfNullableObjects_ContainsValues(t *testing.T) {
+	ttype := graphql.NewList(graphql.Int)
+	data := [2]interface{}{
+		1, 2,
+	}
+	expected := &graphql.Result{
+		Data: map[string]interface{}{
+			"nest": map[string]interface{}{
+				"test": []interface{}{
+					1, 2,
+				},
 			},
 		},
 	}

--- a/values.go
+++ b/values.go
@@ -339,6 +339,15 @@ func isNullish(src interface{}) bool {
 	return false
 }
 
+// Returns true if src is a slice or an array
+func isIterable(src interface{}) bool {
+	if src == nil {
+		return false
+	}
+	t := reflect.TypeOf(src)
+	return t.Kind() == reflect.Slice || t.Kind() == reflect.Array
+}
+
 /**
  * Produces a value given a GraphQL Value AST.
  *

--- a/values_test.go
+++ b/values_test.go
@@ -1,0 +1,18 @@
+package graphql
+
+import "testing"
+
+func TestIsIterable(t *testing.T) {
+	if !isIterable([]int{}) {
+		t.Fatal("expected isIterable to return true for a slice, got false")
+	}
+	if !isIterable([]int{}) {
+		t.Fatal("expected isIterable to return true for an array, got false")
+	}
+	if isIterable(1) {
+		t.Fatal("expected isIterable to return false for an int, got true")
+	}
+	if isIterable(nil) {
+		t.Fatal("expected isIterable to return false for nil, got true")
+	}
+}


### PR DESCRIPTION
This pr changes the executor to treat Go arrays as iterable. This means that if a user defines a schema including a `graphql.List`, and the value for that list is an array, then the array will be serialized as a json list.

Solves #323 