### PR TITLE
Parse float as double-precision floating-point

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -167,7 +167,7 @@ var Float = NewScalar(ScalarConfig{
 	ParseLiteral: func(valueAST ast.Value) interface{} {
 		switch valueAST := valueAST.(type) {
 		case *ast.FloatValue:
-			if floatValue, err := strconv.ParseFloat(valueAST.Value, 32); err == nil {
+			if floatValue, err := strconv.ParseFloat(valueAST.Value, 64); err == nil {
 				return floatValue
 			}
 		case *ast.IntValue:


### PR DESCRIPTION
In the [GraphQL specification](http://facebook.github.io/graphql/July2015/#sec-Float), the float scalar type is specified as as double-precision number:

> The Float scalar type represents signed double‐precision fractional values as specified by IEEE 754. Response formats that support an appropriate double‐precision number type should use that type to represent this scalar.

Hence, it should also be parsed as such, otherwise we get precision errors, i.e. `0.7` becomes ` 0.699999988079071`. This issue has already been raised in https://github.com/graphql-go/graphql/issues/165.

