### PR TITLE
Fixes #340. Thunk results are completed as per non-thunk results.

### DIFF
--- a/lists_test.go
+++ b/lists_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func checkList(t *testing.T, testType graphql.Type, testData interface{}, expected *graphql.Result) {
-	t.Helper()
+	// TODO: uncomment t.Helper when support for go1.8 is dropped.
+	//t.Helper()
 	data := map[string]interface{}{
 		"test": testData,
 	}

--- a/lists_test.go
+++ b/lists_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func checkList(t *testing.T, testType graphql.Type, testData interface{}, expected *graphql.Result) {
+	t.Helper()
 	data := map[string]interface{}{
 		"test": testData,
 	}
@@ -561,8 +562,17 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
-				"test": []interface{}{
-					1, nil, 2,
+				"test": nil,
+			},
+		},
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
 				},
 			},
 		},
@@ -752,9 +762,16 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 	}
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": []interface{}{
-					1, nil, 2,
+			"nest": nil,
+		},
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Note that the following tests previously passed and have been modified.

* TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls
* TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls

It seems to me that both of these tests should have failed previously, as they involved passing nil values where nil values were not permitted. Please advise if my understanding is incorrect.