### PR TITLE
scalars: coerceFloat should return nil as default

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -192,9 +192,9 @@ func coerceFloat(value interface{}) interface{} {
 		return coerceFloat(*value)
 	}
 
-	// TODO: check the graphql spec: coerceInt returns nil if it
-	// cannot convert, should coerceFloat do the same?
-	return 0.0
+	// If the value cannot be transformed into an float, return nil instead of '0.0'
+	// to denote 'no float found'
+	return nil
 }
 
 // Float is the GraphQL float type definition.

--- a/scalars.go
+++ b/scalars.go
@@ -21,6 +21,8 @@ func coerceInt(value interface{}) interface{} {
 			return 1
 		}
 		return 0
+	case *bool:
+		return coerceInt(*value)
 	case int:
 		if value < int(math.MinInt32) || value > int(math.MaxInt32) {
 			return nil
@@ -134,7 +136,43 @@ func coerceFloat(value interface{}) interface{} {
 		return coerceFloat(*value)
 	case int:
 		return float64(value)
+	case *int:
+		return coerceFloat(*value)
+	case int8:
+		return float64(value)
+	case *int8:
+		return coerceFloat(*value)
+	case int16:
+		return float64(value)
+	case *int16:
+		return coerceFloat(*value)
+	case int32:
+		return float64(value)
 	case *int32:
+		return coerceFloat(*value)
+	case int64:
+		return float64(value)
+	case *int64:
+		return coerceFloat(*value)
+	case uint:
+		return float64(value)
+	case *uint:
+		return coerceFloat(*value)
+	case uint8:
+		return float64(value)
+	case *uint8:
+		return coerceFloat(*value)
+	case uint16:
+		return float64(value)
+	case *uint16:
+		return coerceFloat(*value)
+	case uint32:
+		return float64(value)
+	case *uint32:
+		return coerceFloat(*value)
+	case uint64:
+		return float64(value)
+	case *uint64:
 		return coerceFloat(*value)
 	case float32:
 		return value
@@ -153,6 +191,9 @@ func coerceFloat(value interface{}) interface{} {
 	case *string:
 		return coerceFloat(*value)
 	}
+
+	// TODO: check the graphql spec: coerceInt returns nil if it
+	// cannot convert, should coerceFloat do the same?
 	return 0.0
 }
 
@@ -237,6 +278,69 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *int:
+		return coerceBool(*value)
+	case int8:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *int8:
+		return coerceBool(*value)
+	case int16:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *int16:
+		return coerceBool(*value)
+	case int32:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *int32:
+		return coerceBool(*value)
+	case int64:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *int64:
+		return coerceBool(*value)
+	case uint:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *uint:
+		return coerceBool(*value)
+	case uint8:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *uint8:
+		return coerceBool(*value)
+	case uint16:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *uint16:
+		return coerceBool(*value)
+	case uint32:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *uint32:
+		return coerceBool(*value)
+	case uint64:
+		if value != 0 {
+			return true
+		}
+		return false
+	case *uint64:
 		return coerceBool(*value)
 	}
 	return false

--- a/scalars_test.go
+++ b/scalars_test.go
@@ -324,7 +324,7 @@ func TestCoerceFloat(t *testing.T) {
 		},
 		{
 			in:   make(map[string]interface{}),
-			want: 0.0,
+			want: nil,
 		},
 	}
 

--- a/scalars_test.go
+++ b/scalars_test.go
@@ -1,0 +1,642 @@
+package graphql
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCoerceInt(t *testing.T) {
+	tests := []struct {
+		in   interface{}
+		want interface{}
+	}{
+		{
+			in:   false,
+			want: 0,
+		},
+		{
+			in:   true,
+			want: 1,
+		},
+		{
+			in:   boolPtr(false),
+			want: 0,
+		},
+		{
+			in:   boolPtr(true),
+			want: 1,
+		},
+		{
+			in:   int(math.MinInt32) - 1,
+			want: nil,
+		},
+		{
+			in:   int(math.MaxInt32) + 1,
+			want: nil,
+		},
+		{
+			in:   uint(math.MaxInt32) + 1,
+			want: nil,
+		},
+		{
+			in:   uint32(math.MaxInt32) + 1,
+			want: nil,
+		},
+		{
+			in:   int64(math.MinInt32) - 1,
+			want: nil,
+		},
+		{
+			in:   int64(math.MaxInt32) + 1,
+			want: nil,
+		},
+		{
+			in:   uint64(math.MaxInt32) + 1,
+			want: nil,
+		},
+		{
+			// need to subtract more than one because of float32 precision
+			in:   float32(math.MinInt32) - 1000,
+			want: nil,
+		},
+		{
+			// need to add more than one because of float32 precision
+			in:   float32(math.MaxInt32) + 1000,
+			want: nil,
+		},
+		{
+			in:   float64(math.MinInt32) - 1,
+			want: nil,
+		},
+		{
+			in:   float64(math.MaxInt32) + 1,
+			want: nil,
+		},
+		{
+			in:   int(math.MinInt32),
+			want: int(math.MinInt32),
+		},
+		{
+			in:   int(math.MaxInt32),
+			want: int(math.MaxInt32),
+		},
+		{
+			in:   intPtr(12),
+			want: 12,
+		},
+		{
+			in:   int8(13),
+			want: int(13),
+		},
+		{
+			in:   int8Ptr(14),
+			want: int(14),
+		},
+		{
+			in:   int16(15),
+			want: int(15),
+		},
+		{
+			in:   int16Ptr(16),
+			want: int(16),
+		},
+		{
+			in:   int32(17),
+			want: int(17),
+		},
+		{
+			in:   int32Ptr(18),
+			want: int(18),
+		},
+		{
+			in:   int64(19),
+			want: int(19),
+		},
+		{
+			in:   int64Ptr(20),
+			want: int(20),
+		},
+		{
+			in:   uint8(21),
+			want: int(21),
+		},
+		{
+			in:   uint8Ptr(22),
+			want: int(22),
+		},
+		{
+			in:   uint16(23),
+			want: int(23),
+		},
+		{
+			in:   uint16Ptr(24),
+			want: int(24),
+		},
+		{
+			in:   uint32(25),
+			want: int(25),
+		},
+		{
+			in:   uint32Ptr(26),
+			want: int(26),
+		},
+		{
+			in:   uint64(27),
+			want: int(27),
+		},
+		{
+			in:   uint64Ptr(28),
+			want: int(28),
+		},
+		{
+			in:   uintPtr(29),
+			want: int(29),
+		},
+		{
+			in:   float32(30.1),
+			want: int(30),
+		},
+		{
+			in:   float32Ptr(31.2),
+			want: int(31),
+		},
+		{
+			in:   float64(32),
+			want: int(32),
+		},
+		{
+			in:   float64Ptr(33.1),
+			want: int(33),
+		},
+		{
+			in:   "34",
+			want: int(34),
+		},
+		{
+			in:   stringPtr("35"),
+			want: int(35),
+		},
+		{
+			in:   "I'm not a number",
+			want: nil,
+		},
+		{
+			in:   make(map[string]interface{}),
+			want: nil,
+		},
+	}
+
+	for i, tt := range tests {
+		if got, want := coerceInt(tt.in), tt.want; got != want {
+			t.Errorf("%d: in=%v, got=%v, want=%v", i, tt.in, got, want)
+		}
+	}
+}
+
+func TestCoerceFloat(t *testing.T) {
+	tests := []struct {
+		in   interface{}
+		want interface{}
+	}{
+		{
+			in:   false,
+			want: 0.0,
+		},
+		{
+			in:   true,
+			want: 1.0,
+		},
+		{
+			in:   boolPtr(false),
+			want: 0.0,
+		},
+		{
+			in:   boolPtr(true),
+			want: 1.0,
+		},
+		{
+			in:   int(math.MinInt32),
+			want: float64(math.MinInt32),
+		},
+		{
+			in:   int(math.MaxInt32),
+			want: float64(math.MaxInt32),
+		},
+		{
+			in:   intPtr(12),
+			want: float64(12),
+		},
+		{
+			in:   int8(13),
+			want: float64(13),
+		},
+		{
+			in:   int8Ptr(14),
+			want: float64(14),
+		},
+		{
+			in:   int16(15),
+			want: float64(15),
+		},
+		{
+			in:   int16Ptr(16),
+			want: float64(16),
+		},
+		{
+			in:   int32(17),
+			want: float64(17),
+		},
+		{
+			in:   int32Ptr(18),
+			want: float64(18),
+		},
+		{
+			in:   int64(19),
+			want: float64(19),
+		},
+		{
+			in:   int64Ptr(20),
+			want: float64(20),
+		},
+		{
+			in:   uint8(21),
+			want: float64(21),
+		},
+		{
+			in:   uint8Ptr(22),
+			want: float64(22),
+		},
+		{
+			in:   uint16(23),
+			want: float64(23),
+		},
+		{
+			in:   uint16Ptr(24),
+			want: float64(24),
+		},
+		{
+			in:   uint32(25),
+			want: float64(25),
+		},
+		{
+			in:   uint32Ptr(26),
+			want: float64(26),
+		},
+		{
+			in:   uint64(27),
+			want: float64(27),
+		},
+		{
+			in:   uint64Ptr(28),
+			want: float64(28),
+		},
+		{
+			in:   uintPtr(29),
+			want: float64(29),
+		},
+		{
+			in:   float32(30),
+			want: float32(30),
+		},
+		{
+			in:   float32Ptr(31),
+			want: float32(31),
+		},
+		{
+			in:   float64(32),
+			want: float64(32),
+		},
+		{
+			in:   float64Ptr(33.2),
+			want: float64(33.2),
+		},
+		{
+			in:   "34",
+			want: float64(34),
+		},
+		{
+			in:   stringPtr("35.2"),
+			want: float64(35.2),
+		},
+		{
+			in:   "I'm not a number",
+			want: nil,
+		},
+		{
+			in:   make(map[string]interface{}),
+			want: 0.0,
+		},
+	}
+
+	for i, tt := range tests {
+		if got, want := coerceFloat(tt.in), tt.want; got != want {
+			t.Errorf("%d: in=%v, got=%v, want=%v", i, tt.in, got, want)
+		}
+	}
+}
+
+func TestCoerceBool(t *testing.T) {
+	tests := []struct {
+		in   interface{}
+		want interface{}
+	}{
+		{
+			in:   false,
+			want: false,
+		},
+		{
+			in:   true,
+			want: true,
+		},
+		{
+			in:   boolPtr(false),
+			want: false,
+		},
+		{
+			in:   boolPtr(true),
+			want: true,
+		},
+		{
+			in:   int(math.MinInt32),
+			want: true,
+		},
+		{
+			in:   int(math.MaxInt32),
+			want: true,
+		},
+		{
+			in:   int(0),
+			want: false,
+		},
+		{
+			in:   intPtr(12),
+			want: true,
+		},
+		{
+			in:   intPtr(0),
+			want: false,
+		},
+		{
+			in:   int8(13),
+			want: true,
+		},
+		{
+			in:   int8(0),
+			want: false,
+		},
+		{
+			in:   int8Ptr(14),
+			want: true,
+		},
+		{
+			in:   int8Ptr(0),
+			want: false,
+		},
+		{
+			in:   int16(15),
+			want: true,
+		},
+		{
+			in:   int16(0),
+			want: false,
+		},
+		{
+			in:   int16Ptr(16),
+			want: true,
+		},
+		{
+			in:   int16Ptr(0),
+			want: false,
+		},
+		{
+			in:   int32(17),
+			want: true,
+		},
+		{
+			in:   int32(0),
+			want: false,
+		},
+		{
+			in:   int32Ptr(18),
+			want: true,
+		},
+		{
+			in:   int32Ptr(0),
+			want: false,
+		},
+		{
+			in:   int64(19),
+			want: true,
+		},
+		{
+			in:   int64(0),
+			want: false,
+		},
+		{
+			in:   int64Ptr(20),
+			want: true,
+		},
+		{
+			in:   int64Ptr(0),
+			want: false,
+		},
+		{
+			in:   uint8(21),
+			want: true,
+		},
+		{
+			in:   uint8(0),
+			want: false,
+		},
+		{
+			in:   uint8Ptr(22),
+			want: true,
+		},
+		{
+			in:   uint8Ptr(0),
+			want: false,
+		},
+		{
+			in:   uint16(23),
+			want: true,
+		},
+		{
+			in:   uint16(0),
+			want: false,
+		},
+		{
+			in:   uint16Ptr(24),
+			want: true,
+		},
+		{
+			in:   uint16Ptr(0),
+			want: false,
+		},
+		{
+			in:   uint32(25),
+			want: true,
+		},
+		{
+			in:   uint32(0),
+			want: false,
+		},
+		{
+			in:   uint32Ptr(26),
+			want: true,
+		},
+		{
+			in:   uint32Ptr(0),
+			want: false,
+		},
+		{
+			in:   uint64(27),
+			want: true,
+		},
+		{
+			in:   uint64(0),
+			want: false,
+		},
+		{
+			in:   uint64Ptr(28),
+			want: true,
+		},
+		{
+			in:   uint64Ptr(0),
+			want: false,
+		},
+		{
+			in:   uintPtr(29),
+			want: true,
+		},
+		{
+			in:   uintPtr(0),
+			want: false,
+		},
+		{
+			in:   float32(30),
+			want: true,
+		},
+		{
+			in:   float32(0),
+			want: false,
+		},
+		{
+			in:   float32Ptr(31),
+			want: true,
+		},
+		{
+			in:   float32Ptr(0),
+			want: false,
+		},
+		{
+			in:   float64(32),
+			want: true,
+		},
+		{
+			in:   float64(0),
+			want: false,
+		},
+		{
+			in:   float64Ptr(33.2),
+			want: true,
+		},
+		{
+			in:   float64Ptr(0),
+			want: false,
+		},
+		{
+			in:   "34",
+			want: true,
+		},
+		{
+			in:   "false",
+			want: false,
+		},
+		{
+			in:   stringPtr("true"),
+			want: true,
+		},
+		{
+			in:   stringPtr("false"),
+			want: false,
+		},
+		{
+			in:   "I'm some random string",
+			want: true,
+		},
+		{
+			in:   "",
+			want: false,
+		},
+		{
+			in:   int8(0),
+			want: false,
+		},
+		{
+			in:   make(map[string]interface{}),
+			want: false,
+		},
+	}
+
+	for i, tt := range tests {
+		if got, want := coerceBool(tt.in), tt.want; got != want {
+			t.Errorf("%d: in=%v, got=%v, want=%v", i, tt.in, got, want)
+		}
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func intPtr(n int) *int {
+	return &n
+}
+
+func int8Ptr(n int8) *int8 {
+	return &n
+}
+
+func int16Ptr(n int16) *int16 {
+	return &n
+}
+
+func int32Ptr(n int32) *int32 {
+	return &n
+}
+
+func int64Ptr(n int64) *int64 {
+	return &n
+}
+
+func uintPtr(n uint) *uint {
+	return &n
+}
+
+func uint8Ptr(n uint8) *uint8 {
+	return &n
+}
+
+func uint16Ptr(n uint16) *uint16 {
+	return &n
+}
+
+func uint32Ptr(n uint32) *uint32 {
+	return &n
+}
+
+func uint64Ptr(n uint64) *uint64 {
+	return &n
+}
+
+func float32Ptr(n float32) *float32 {
+	return &n
+}
+
+func float64Ptr(n float64) *float64 {
+	return &n
+}
+
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
#### Overview
- scalars: `coerceFloat` should return nil when coersion did not happen.
- Built on top of: https://github.com/graphql-go/graphql/pull/342

#### Test plan
- Unit test