### PR TITLE
Another asynchronous resolution PR. But using JS-like promises instead of goroutines.

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -592,6 +592,16 @@ type ResolveInfo struct {
 	VariableValues map[string]interface{}
 }
 
+type ResolveResult struct {
+	Value interface{}
+	Error error
+}
+
+// When returned from a resolve function, ResolvePromise indicates that the resolution will be done
+// asynchronously. When used, an IdleHandler should be specified. This handler must fulfill one or
+// more promises each time it is invoked.
+type ResolvePromise chan *ResolveResult
+
 type Fields map[string]*Field
 
 type Field struct {

--- a/graphql.go
+++ b/graphql.go
@@ -28,6 +28,11 @@ type Params struct {
 	// one operation.
 	OperationName string
 
+	// IdleHandler is invoked when asynchronous resolution is used and no more work can be completed
+	// until asynchronous resolution progresses. At least some values must be resolved prior to this
+	// function's return.
+	IdleHandler func()
+
 	// Context may be provided to pass application-specific per-request
 	// information to resolve functions.
 	Context context.Context
@@ -58,6 +63,7 @@ func Do(p Params) *Result {
 		AST:           AST,
 		OperationName: p.OperationName,
 		Args:          p.VariableValues,
+		IdleHandler:   p.IdleHandler,
 		Context:       p.Context,
 	})
 }

--- a/promise/promise.go
+++ b/promise/promise.go
@@ -1,0 +1,185 @@
+package promise
+
+import "reflect"
+
+type Promise struct {
+	isFullfilled bool
+	value        interface{}
+
+	isRejected bool
+	err        error
+
+	next         []*Promise
+	dependencies []*Promise
+
+	source func(resolve func(interface{}), reject func(error))
+
+	parent      *Promise
+	onFulfilled func(value interface{}) interface{}
+	onRejected  func(value error) interface{}
+}
+
+// New returns a new Promise, which is very much like the JavaScript equivalent, but with one
+// exception: the function given to New should not actually perform any work asynchronously (or if
+// it does, it should be done transparently). The function will be invoked when the promise is
+// scheduled. If the promise cannot be fulfilled yet, simply don't invoke resolve until the next
+// time the function is called.
+func New(f func(resolve func(interface{}), reject func(error))) *Promise {
+	return &Promise{
+		source: f,
+	}
+}
+
+type Thenable interface {
+	Then(f func(value interface{}) interface{}) *Promise
+}
+
+// Then appends a handler to be promise, invoking it when the promise is fulfilled. If the handler
+// returns a value, it'll be passed as input to the next handler in the chain. If the handler
+// returns another promise, the next handler in the chain will receive that promise's value when it
+// is fulfilled.
+func (p *Promise) Then(onFulfilled func(value interface{}) interface{}) *Promise {
+	newPromise := &Promise{
+		parent:      p,
+		onFulfilled: onFulfilled,
+	}
+	p.next = append(p.next, newPromise)
+	return newPromise
+}
+
+// Returns a Promise and deals with rejected cases only. The Promise returned by Catch is rejected
+// if onRejected throws an error or returns a Promise which is itself rejected; otherwise, it is
+// resolved.
+func (p *Promise) Catch(onRejected func(err error) interface{}) *Promise {
+	newPromise := &Promise{
+		parent:     p,
+		onRejected: onRejected,
+	}
+	p.next = append(p.next, newPromise)
+	return newPromise
+}
+
+// Schedule invokes pending functions for unfulfilled promises and returns true if any progress was
+// made.
+func (p *Promise) Schedule() (didProgress bool) {
+	for i := 0; ; i++ {
+		didProgress := false
+		for _, dependency := range p.dependencies {
+			if !dependency.isFullfilled {
+				if dependency.Schedule() {
+					didProgress = true
+				}
+			}
+		}
+		if !p.isFullfilled && !p.isRejected {
+			if p.source != nil {
+				p.source(func(value interface{}) {
+					p.isFullfilled = true
+					p.value = value
+					didProgress = true
+				}, func(err error) {
+					p.isRejected = true
+					p.err = err
+					didProgress = true
+				})
+			} else if p.parent != nil {
+				if p.parent.isFullfilled || p.parent.isRejected {
+					if p.parent.isFullfilled {
+						p.isFullfilled = true
+						p.value = p.parent.value
+						if p.onFulfilled != nil {
+							p.value = p.onFulfilled(p.value)
+						}
+					} else {
+						if p.onRejected != nil {
+							p.isFullfilled = true
+							p.value = p.onRejected(p.parent.err)
+						} else {
+							p.isRejected = true
+							p.err = p.parent.err
+						}
+					}
+					didProgress = true
+					if promise, ok := p.value.(*Promise); ok {
+						for _, next := range p.next {
+							next.parent = promise
+						}
+						promise.next = append(promise.next, p.next...)
+						p.next = []*Promise{promise}
+					}
+				} else {
+					didProgress = p.parent.Schedule()
+				}
+			}
+		}
+		if p.isFullfilled {
+			for _, next := range p.next {
+				if next.Schedule() {
+					didProgress = true
+				}
+			}
+		}
+		if !didProgress {
+			return i > 0
+		}
+	}
+}
+
+// Returns a Promise object that is resolved with the given value. If the value is a Thenable (i.e.
+// has a Then method), the returned promise will "follow" that thenable, adopting its eventual
+// state; otherwise the returned promise will be fulfilled with the value.
+func Resolve(value interface{}) *Promise {
+	if thenable, ok := value.(Thenable); ok {
+		return thenable.Then(func(value interface{}) interface{} {
+			return value
+		})
+	}
+	return New(func(resolve func(interface{}), reject func(error)) {
+		resolve(value)
+	})
+}
+
+// Returns a Promise that is rejected with the given reason.
+func Reject(reason error) *Promise {
+	return New(func(resolve func(interface{}), reject func(error)) {
+		reject(reason)
+	})
+}
+
+// All returns a single Promise that resolves when all of the promises in the argument have resolved
+// or when the iterable argument contains no promises. It rejects with the reason of the first
+// promise that rejects.
+func All(iterable interface{}) *Promise {
+	v := reflect.ValueOf(iterable)
+	result := make([]interface{}, v.Len())
+	var rejectReason error
+	remaining := 0
+	all := New(func(resolve func(interface{}), reject func(error)) {
+		if rejectReason != nil {
+			reject(rejectReason)
+		} else if remaining == 0 {
+			resolve(result)
+		}
+	})
+	for i := 0; i < v.Len(); i++ {
+		value := v.Index(i).Interface()
+		promise, ok := value.(*Promise)
+		if !ok {
+			result[i] = value
+			continue
+		} else if promise == nil {
+			continue
+		}
+		i := i
+		remaining++
+		all.dependencies = append(all.dependencies, promise.Then(func(value interface{}) interface{} {
+			result[i] = value
+			remaining--
+			return nil
+		}).Catch(func(err error) interface{} {
+			rejectReason = err
+			return nil
+		}))
+	}
+	return all
+}

--- a/promise/promise_test.go
+++ b/promise/promise_test.go
@@ -1,0 +1,144 @@
+package promise
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPromiseValueChaining(t *testing.T) {
+	n := 0
+	Resolve(1).Then(func(v interface{}) interface{} {
+		n = v.(int)
+		if n != 1 {
+			t.Fatalf("expected 1, got %v", n)
+		}
+		return n + 1
+	}).Then(func(v interface{}) interface{} {
+		n = v.(int)
+		if n != 2 {
+			t.Fatalf("expected 2, got %v", n)
+		}
+		return n + 1
+	}).Then(func(v interface{}) interface{} {
+		n = v.(int)
+		if n != 3 {
+			t.Fatalf("expected 3, got %v", n)
+		}
+		return nil
+	}).Schedule()
+	if n != 3 {
+		t.Fatalf("expected 3, got %v", n)
+	}
+}
+
+func TestCatch(t *testing.T) {
+	var val interface{}
+	var err error
+	Resolve(1).Then(func(interface{}) interface{} {
+		return Reject(errors.New("reject"))
+	}).Then(func(interface{}) interface{} {
+		return nil
+	}).Catch(func(caught error) interface{} {
+		err = caught
+		return "foo"
+	}).Then(func(value interface{}) interface{} {
+		val = value
+		return nil
+	}).Schedule()
+	if err == nil {
+		t.Fatalf("expected non-nil error")
+	}
+	if val != "foo" {
+		t.Fatalf("expected \"foo\", got %v", val)
+	}
+}
+
+func TestAll(t *testing.T) {
+	p1 := Resolve(1)
+	var p2 *Promise
+	p3 := Resolve(3)
+	var result []interface{}
+	All([]interface{}{p1, p2, p3, 4}).Then(func(value interface{}) interface{} {
+		result = value.([]interface{})
+		return nil
+	}).Schedule()
+	if len(result) != 4 {
+		t.Fatalf("expected 4 results, got %v", len(result))
+	}
+	if n, _ := result[0].(int); n != 1 {
+		t.Fatalf("expected 1, got %v", n)
+	}
+	if result[1] != nil {
+		t.Fatalf("expected nil, got %v", result[1])
+	}
+	if n, _ := result[2].(int); n != 3 {
+		t.Fatalf("expected 3, got %v", n)
+	}
+	if n, _ := result[3].(int); n != 4 {
+		t.Fatalf("expected 4, got %v", n)
+	}
+}
+
+func TestAll_Reject(t *testing.T) {
+	p1 := Resolve(1)
+	p2 := Reject(errors.New("foo"))
+	p3 := Resolve(3)
+	var result []interface{}
+	var rejectReason error
+	All([]interface{}{p1, p2, p3, 4}).Then(func(value interface{}) interface{} {
+		result = value.([]interface{})
+		return nil
+	}).Catch(func(err error) interface{} {
+		rejectReason = err
+		return nil
+	}).Schedule()
+	if result != nil {
+		t.Fatalf("expected nil result, got %v", result)
+	}
+	if rejectReason == nil {
+		t.Fatalf("expected non-nil reject reason")
+	}
+}
+
+func TestAll_Schedule(t *testing.T) {
+	step := 0
+	p1 := New(func(resolve func(interface{}), reject func(error)) {
+		if step > 1 {
+			resolve(1)
+		}
+	})
+	p2 := New(func(resolve func(interface{}), reject func(error)) {
+		if step > 0 {
+			resolve(2)
+		}
+	})
+	var result []interface{}
+	all := All([]interface{}{p1, p2}).Then(func(value interface{}) interface{} {
+		result = value.([]interface{})
+		return nil
+	})
+
+	if all.Schedule() {
+		t.Fatalf("expected false")
+	}
+
+	step++
+	if !all.Schedule() {
+		t.Fatalf("expected true")
+	}
+
+	step++
+	if !all.Schedule() {
+		t.Fatalf("expected true")
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 results, got %v", len(result))
+	}
+	if n, _ := result[0].(int); n != 1 {
+		t.Fatalf("expected 1, got %v", n)
+	}
+	if n, _ := result[1].(int); n != 2 {
+		t.Fatalf("expected 2, got %v", n)
+	}
+}

--- a/values.go
+++ b/values.go
@@ -13,6 +13,7 @@ import (
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/kinds"
 	"github.com/graphql-go/graphql/language/printer"
+	"github.com/graphql-go/graphql/promise"
 )
 
 // Prepares an object map of variableValues of the correct type based on the
@@ -337,6 +338,12 @@ func isNullish(src interface{}) bool {
 		return math.IsNaN(float64(value.Float()))
 	}
 	return false
+}
+
+// Returns true if src is a *promise.Promise
+func isPromise(src interface{}) bool {
+	_, ok := src.(*promise.Promise)
+	return ok
 }
 
 // Returns true if src is a slice or an array


### PR DESCRIPTION
Like everyone else, I'm in need of batching, deduplication, and concurrency in my query execution.

But the other pull requests all look like they utilize goroutine-based approaches. This pull request does not use goroutines. Instead, it works a bit more like the JavaScript reference implementation using a notion of promises. Here's how it works in terms of usage:

Resolvers that can execute asynchronously return a channel. To be explicit, a `graphql.ResolvePromise`. So you might have a loader that creates and returns a new `graphql.ResolvePromise` like so:

```go
{
  Resolve: func(p graphql.ResolveParams) (interface{}, error) {
    id, _ := p.Args["id"].(string)
    loader := p.Context.Value("loader").(*Loader)
    return loader.LoadNodeByGlobalId(id)
  },
}
```

```go
func (l *Loader) LoadNodeByGlobalId(id string) (graphql.ResolvePromise, error) {
  promise := make(graphql.ResolvePromise, 1)
  ...
  l.pendingNodes[id].Promises = append(l.pendingNodes[id].Promises, promise)
  return promise, nil
}
```

How does the loader fulfill the promise without a goroutine? When the query execution gets "stuck" and there are no more resolvers that it can invoke, it invokes an "idle handler" to let it know that one or more pending promises need to be fulfilled before it can continue. So your params can now specify a scheduler for your loader like so:

```go
p.IdleHandler = loader.Schedule
```

When the handler is invoked, it expects one or more promises to be fulfilled. Afterwards, it'll resume resolving values until it gets stuck again.

So your loader implementation might at a high level do something like this:

* If one or more pending node is cached, fulfill its promises, then return.
* If one or more pending node is for whatever reason not batchable, fulfill its promises, then return.
* Fulfill promises for a batch of nodes, then return.

And so in this way, you can really control when and how your resolutions happen. And there are no goroutines involved or multithreading concerns. Of course, you can use goroutines if you want to though.