### PR TITLE
gqlerrors: removes error prefix for clarity

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -1934,7 +1934,7 @@ type extendedError struct {
 	extensions map[string]interface{}
 }
 
-func (err extendedError) ErrorExtensions() map[string]interface{} {
+func (err extendedError) Extensions() map[string]interface{} {
 	return err.extensions
 }
 

--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -8,7 +8,7 @@ import (
 
 type ExtendedError interface {
 	error
-	ErrorExtensions() map[string]interface{}
+	Extensions() map[string]interface{}
 }
 
 type FormattedError struct {
@@ -39,7 +39,7 @@ func FormatError(err error) FormattedError {
 		}
 		if err := err.OriginalError; err != nil {
 			if extended, ok := err.(ExtendedError); ok {
-				ret.Extensions = extended.ErrorExtensions()
+				ret.Extensions = extended.Extensions()
 			}
 		}
 		return ret


### PR DESCRIPTION
#### Overview
- built on top of: https://github.com/graphql-go/graphql/pull/363
- gqlerrors: removes extra error prefix

#### Test plan
- Unit test