### PR TITLE
Yet another PR for async execution and batching. Defer calling thunks until as late as possible during execution.

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -245,6 +245,7 @@ func executeFieldsSerially(p executeFieldsParams) *Result {
 		}
 		finalResults[responseName] = resolved
 	}
+	dethunkMap(finalResults)
 
 	return &Result{
 		Data:   finalResults,
@@ -254,6 +255,16 @@ func executeFieldsSerially(p executeFieldsParams) *Result {
 
 // Implements the "Evaluating selection sets" section of the spec for "read" mode.
 func executeFields(p executeFieldsParams) *Result {
+	finalResults := executeSubFields(p)
+	dethunkMap(finalResults)
+
+	return &Result{
+		Data:   finalResults,
+		Errors: p.ExecutionContext.Errors,
+	}
+}
+
+func executeSubFields(p executeFieldsParams) map[string]interface{} {
 	if p.Source == nil {
 		p.Source = map[string]interface{}{}
 	}
@@ -271,9 +282,42 @@ func executeFields(p executeFieldsParams) *Result {
 		finalResults[responseName] = resolved
 	}
 
-	return &Result{
-		Data:   finalResults,
-		Errors: p.ExecutionContext.Errors,
+	return finalResults
+}
+
+// dethunkMap performs a breadth-first descent of the map, calling any thunks
+// in the map values and replacing each thunk with that thunk's return value.
+func dethunkMap(m map[string]interface{}) {
+	for k, v := range m {
+		if f, ok := v.(func() interface{}); ok {
+			m[k] = f()
+		}
+	}
+	for _, v := range m {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			dethunkMap(val)
+		case []interface{}:
+			dethunkList(val)
+		}
+	}
+}
+
+// dethunkList iterates through the list, calling any thunks in the list
+// and replacing each thunk with that thunk's return value.
+func dethunkList(list []interface{}) {
+	for i, v := range list {
+		if f, ok := v.(func() interface{}); ok {
+			list[i] = f()
+		}
+	}
+	for _, v := range list {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			dethunkMap(val)
+		case []interface{}:
+			dethunkList(val)
+		}
 	}
 }
 
@@ -558,13 +602,9 @@ func completeValueCatchingError(eCtx *executionContext, returnType Type, fieldAS
 func completeValue(eCtx *executionContext, returnType Type, fieldASTs []*ast.Field, info ResolveInfo, path *responsePath, result interface{}) interface{} {
 
 	resultVal := reflect.ValueOf(result)
-	for resultVal.IsValid() && resultVal.Type().Kind() == reflect.Func {
-		if propertyFn, ok := result.(func() interface{}); ok {
-			result = propertyFn()
-			resultVal = reflect.ValueOf(result)
-		} else {
-			err := gqlerrors.NewFormattedError("Error resolving func. Expected `func() interface{}` signature")
-			panic(gqlerrors.FormatError(err))
+	if resultVal.IsValid() && resultVal.Kind() == reflect.Func {
+		return func() interface{} {
+			return completeThunkValueCatchingError(eCtx, returnType, fieldASTs, info, path, result)
 		}
 	}
 
@@ -624,6 +664,30 @@ func completeValue(eCtx *executionContext, returnType Type, fieldASTs []*ast.Fie
 		panic(gqlerrors.FormatError(err))
 	}
 	return nil
+}
+
+func completeThunkValueCatchingError(eCtx *executionContext, returnType Type, fieldASTs []*ast.Field, info ResolveInfo, path *responsePath, result interface{}) (completed interface{}) {
+
+	// catch any panic invoked from the propertyFn (thunk)
+	defer func() {
+		if r := recover(); r != nil {
+			handleFieldError(r, FieldASTsToNodeASTs(fieldASTs), path, returnType, eCtx)
+		}
+	}()
+
+	propertyFn, ok := result.(func() interface{})
+	if !ok {
+		err := gqlerrors.NewFormattedError("Error resolving func. Expected `func() interface{}` signature")
+		panic(gqlerrors.FormatError(err))
+	}
+	result = propertyFn()
+
+	if returnType, ok := returnType.(*NonNull); ok {
+		completed := completeValue(eCtx, returnType, fieldASTs, info, path, result)
+		return completed
+	}
+	completed = completeValue(eCtx, returnType, fieldASTs, info, path, result)
+	return completed
 }
 
 // completeAbstractValue completes value of an Abstract type (Union / Interface) by determining the runtime type
@@ -709,10 +773,7 @@ func completeObjectValue(eCtx *executionContext, returnType *Object, fieldASTs [
 		Fields:           subFieldASTs,
 		Path:             path,
 	}
-	results := executeFields(executeFieldsParams)
-
-	return results.Data
-
+	return executeSubFields(executeFieldsParams)
 }
 
 // completeLeafValue complete a leaf value (Scalar / Enum) by serializing to a valid value, returning nil if serialization is not possible.

--- a/lists_test.go
+++ b/lists_test.go
@@ -579,11 +579,18 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": nil,
+		/*
+			// TODO: Because thunks are called after the result map has been assembled,
+			// we are not able to traverse up the tree until we find a nullable type,
+			// so in this case the entire data is nil. Will need some significant code
+			// restructure to restore this.
+			Data: map[string]interface{}{
+				"nest": map[string]interface{}{
+					"test": nil,
+				},
 			},
-		},
+		*/
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",

--- a/lists_test.go
+++ b/lists_test.go
@@ -810,9 +810,16 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 		},
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		/*
+			// TODO: Because thunks are called after the result map has been assembled,
+			// we are not able to traverse up the tree until we find a nullable type,
+			// so in this case the entire data is nil. Will need some significant code
+			// restructure to restore this.
+			Data: map[string]interface{}{
+				"nest": nil,
+			},
+		*/
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",


### PR DESCRIPTION
Here is yet another PR that provides support for batching queries and asynchronous execution. It proposes an alternative approach to other async PRs including #357 and #132.

It's a difficult problem, and there are clearly a number of different approaches to consider. Hopefully this PR will help. The features of the approach in this PR are:

* No change to the public API.
* Bare minimum change to the existing code.
* No additional goroutines in the graphql code

### Thunks

My thinking is that staying with the use of thunks is the way to go, both for batching and for asynchronous execution.  (This is in comparison with introducing the concept of a promise, or using channels in the API). 

The approach taken in this PR is to delay calling any thunks until as late as possible in the execution sequence.

### Batching

Batching of queries (for example, to an SQL database) can be implemented using the dataloader pattern and do not require the use of additional goroutines. The important thing for batching is that the resolver functions are all called first; only once all available thunks have been returned are any of these thunk functions actually called.

### Async Execution 

My thinking is that if the resolver function wants to operate asynchronously, it should be in control of any goroutines, not the `graphql` package. So if a resolver function were to run asynchronously, it might look something like  the following:

```go
func (params graphql.ResolveParams) (interface{}, error) {
    type result struct {
        data interface{}
        err  error
    }
    ch := make(chan result)
    go func() {
        // ... perform async operation here ...
        ch <- resultFromAsyncOperation()
    }()

    f := func() interface{} {
        r := <-ch
        if r.err != nil {
            panic(r.err)
        }
        return r.data
    }

    return f, nil
}
```
