### PR TITLE
Scalar nil pointer safety

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -22,6 +22,9 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return 0
 	case *bool:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	case int:
 		if value < int(math.MinInt32) || value > int(math.MaxInt32) {
@@ -29,18 +32,30 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return value
 	case *int:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	case int8:
 		return int(value)
 	case *int8:
+		if value == nil {
+			return nil
+		}
 		return int(*value)
 	case int16:
 		return int(value)
 	case *int16:
+		if value == nil {
+			return nil
+		}
 		return int(*value)
 	case int32:
 		return int(value)
 	case *int32:
+		if value == nil {
+			return nil
+		}
 		return int(*value)
 	case int64:
 		if value < int64(math.MinInt32) || value > int64(math.MaxInt32) {
@@ -48,6 +63,9 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return int(value)
 	case *int64:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	case uint:
 		if value > math.MaxInt32 {
@@ -55,14 +73,23 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return int(value)
 	case *uint:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	case uint8:
 		return int(value)
 	case *uint8:
+		if value == nil {
+			return nil
+		}
 		return int(*value)
 	case uint16:
 		return int(value)
 	case *uint16:
+		if value == nil {
+			return nil
+		}
 		return int(*value)
 	case uint32:
 		if value > uint32(math.MaxInt32) {
@@ -70,6 +97,9 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return int(value)
 	case *uint32:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	case uint64:
 		if value > uint64(math.MaxInt32) {
@@ -77,6 +107,9 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return int(value)
 	case *uint64:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	case float32:
 		if value < float32(math.MinInt32) || value > float32(math.MaxInt32) {
@@ -84,6 +117,9 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return int(value)
 	case *float32:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	case float64:
 		if value < float64(math.MinInt32) || value > float64(math.MaxInt32) {
@@ -91,6 +127,9 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return int(value)
 	case *float64:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	case string:
 		val, err := strconv.ParseFloat(value, 0)
@@ -99,6 +138,9 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return coerceInt(val)
 	case *string:
+		if value == nil {
+			return nil
+		}
 		return coerceInt(*value)
 	}
 
@@ -133,54 +175,93 @@ func coerceFloat(value interface{}) interface{} {
 		}
 		return 0.0
 	case *bool:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case int:
 		return float64(value)
 	case *int:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case int8:
 		return float64(value)
 	case *int8:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case int16:
 		return float64(value)
 	case *int16:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case int32:
 		return float64(value)
 	case *int32:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case int64:
 		return float64(value)
 	case *int64:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case uint:
 		return float64(value)
 	case *uint:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case uint8:
 		return float64(value)
 	case *uint8:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case uint16:
 		return float64(value)
 	case *uint16:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case uint32:
 		return float64(value)
 	case *uint32:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case uint64:
 		return float64(value)
 	case *uint64:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case float32:
 		return value
 	case *float32:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case float64:
 		return value
 	case *float64:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	case string:
 		val, err := strconv.ParseFloat(value, 0)
@@ -189,6 +270,9 @@ func coerceFloat(value interface{}) interface{} {
 		}
 		return val
 	case *string:
+		if value == nil {
+			return nil
+		}
 		return coerceFloat(*value)
 	}
 
@@ -222,6 +306,9 @@ var Float = NewScalar(ScalarConfig{
 
 func coerceString(value interface{}) interface{} {
 	if v, ok := value.(*string); ok {
+		if v == nil {
+			return nil
+		}
 		return *v
 	}
 	return fmt.Sprintf("%v", value)
@@ -249,6 +336,9 @@ func coerceBool(value interface{}) interface{} {
 	case bool:
 		return value
 	case *bool:
+		if value == nil {
+			return nil
+		}
 		return *value
 	case string:
 		switch value {
@@ -257,6 +347,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return true
 	case *string:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case float64:
 		if value != 0 {
@@ -264,6 +357,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *float64:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case float32:
 		if value != 0 {
@@ -271,6 +367,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *float32:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case int:
 		if value != 0 {
@@ -278,6 +377,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *int:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case int8:
 		if value != 0 {
@@ -285,6 +387,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *int8:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case int16:
 		if value != 0 {
@@ -292,6 +397,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *int16:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case int32:
 		if value != 0 {
@@ -299,6 +407,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *int32:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case int64:
 		if value != 0 {
@@ -306,6 +417,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *int64:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case uint:
 		if value != 0 {
@@ -313,6 +427,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *uint:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case uint8:
 		if value != 0 {
@@ -320,6 +437,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *uint8:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case uint16:
 		if value != 0 {
@@ -327,6 +447,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *uint16:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case uint32:
 		if value != 0 {
@@ -334,6 +457,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *uint32:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	case uint64:
 		if value != 0 {
@@ -341,6 +467,9 @@ func coerceBool(value interface{}) interface{} {
 		}
 		return false
 	case *uint64:
+		if value == nil {
+			return nil
+		}
 		return coerceBool(*value)
 	}
 	return false
@@ -392,6 +521,9 @@ func serializeDateTime(value interface{}) interface{} {
 
 		return string(buff)
 	case *time.Time:
+		if value == nil {
+			return nil
+		}
 		return serializeDateTime(*value)
 	default:
 		return nil
@@ -411,6 +543,9 @@ func unserializeDateTime(value interface{}) interface{} {
 	case string:
 		return unserializeDateTime([]byte(value))
 	case *string:
+		if value == nil {
+			return nil
+		}
 		return unserializeDateTime([]byte(*value))
 	default:
 		return nil

--- a/scalars_parsevalue_test.go
+++ b/scalars_parsevalue_test.go
@@ -13,6 +13,7 @@ func TestTypeSystem_Scalar_ParseValueOutputDateTime(t *testing.T) {
 	tests := []dateTimeSerializationTest{
 		{nil, nil},
 		{"", nil},
+		{(*string)(nil), nil},
 		{"2017-07-23", nil},
 		{"2017-07-23T03:46:56.647Z", t1},
 	}

--- a/scalars_test.go
+++ b/scalars_test.go
@@ -27,6 +27,10 @@ func TestCoerceInt(t *testing.T) {
 			want: 1,
 		},
 		{
+			in:   (*bool)(nil),
+			want: nil,
+		},
+		{
 			in:   int(math.MinInt32) - 1,
 			want: nil,
 		},
@@ -85,12 +89,20 @@ func TestCoerceInt(t *testing.T) {
 			want: 12,
 		},
 		{
+			in:   (*int)(nil),
+			want: nil,
+		},
+		{
 			in:   int8(13),
 			want: int(13),
 		},
 		{
 			in:   int8Ptr(14),
 			want: int(14),
+		},
+		{
+			in:   (*int8)(nil),
+			want: nil,
 		},
 		{
 			in:   int16(15),
@@ -101,12 +113,20 @@ func TestCoerceInt(t *testing.T) {
 			want: int(16),
 		},
 		{
+			in:   (*int16)(nil),
+			want: nil,
+		},
+		{
 			in:   int32(17),
 			want: int(17),
 		},
 		{
 			in:   int32Ptr(18),
 			want: int(18),
+		},
+		{
+			in:   (*int32)(nil),
+			want: nil,
 		},
 		{
 			in:   int64(19),
@@ -117,12 +137,20 @@ func TestCoerceInt(t *testing.T) {
 			want: int(20),
 		},
 		{
+			in:   (*int64)(nil),
+			want: nil,
+		},
+		{
 			in:   uint8(21),
 			want: int(21),
 		},
 		{
 			in:   uint8Ptr(22),
 			want: int(22),
+		},
+		{
+			in:   (*uint8)(nil),
+			want: nil,
 		},
 		{
 			in:   uint16(23),
@@ -133,12 +161,20 @@ func TestCoerceInt(t *testing.T) {
 			want: int(24),
 		},
 		{
+			in:   (*uint16)(nil),
+			want: nil,
+		},
+		{
 			in:   uint32(25),
 			want: int(25),
 		},
 		{
 			in:   uint32Ptr(26),
 			want: int(26),
+		},
+		{
+			in:   (*uint32)(nil),
+			want: nil,
 		},
 		{
 			in:   uint64(27),
@@ -149,8 +185,16 @@ func TestCoerceInt(t *testing.T) {
 			want: int(28),
 		},
 		{
+			in:   (*uint64)(nil),
+			want: nil,
+		},
+		{
 			in:   uintPtr(29),
 			want: int(29),
+		},
+		{
+			in:   (*uint)(nil),
+			want: nil,
 		},
 		{
 			in:   float32(30.1),
@@ -161,6 +205,10 @@ func TestCoerceInt(t *testing.T) {
 			want: int(31),
 		},
 		{
+			in:   (*float32)(nil),
+			want: nil,
+		},
+		{
 			in:   float64(32),
 			want: int(32),
 		},
@@ -169,12 +217,20 @@ func TestCoerceInt(t *testing.T) {
 			want: int(33),
 		},
 		{
+			in:   (*float64)(nil),
+			want: nil,
+		},
+		{
 			in:   "34",
 			want: int(34),
 		},
 		{
 			in:   stringPtr("35"),
 			want: int(35),
+		},
+		{
+			in:   (*string)(nil),
+			want: nil,
 		},
 		{
 			in:   "I'm not a number",
@@ -215,6 +271,10 @@ func TestCoerceFloat(t *testing.T) {
 			want: 1.0,
 		},
 		{
+			in:   (*bool)(nil),
+			want: nil,
+		},
+		{
 			in:   int(math.MinInt32),
 			want: float64(math.MinInt32),
 		},
@@ -227,12 +287,20 @@ func TestCoerceFloat(t *testing.T) {
 			want: float64(12),
 		},
 		{
+			in:   (*int)(nil),
+			want: nil,
+		},
+		{
 			in:   int8(13),
 			want: float64(13),
 		},
 		{
 			in:   int8Ptr(14),
 			want: float64(14),
+		},
+		{
+			in:   (*int8)(nil),
+			want: nil,
 		},
 		{
 			in:   int16(15),
@@ -243,12 +311,20 @@ func TestCoerceFloat(t *testing.T) {
 			want: float64(16),
 		},
 		{
+			in:   (*int16)(nil),
+			want: nil,
+		},
+		{
 			in:   int32(17),
 			want: float64(17),
 		},
 		{
 			in:   int32Ptr(18),
 			want: float64(18),
+		},
+		{
+			in:   (*int32)(nil),
+			want: nil,
 		},
 		{
 			in:   int64(19),
@@ -259,12 +335,20 @@ func TestCoerceFloat(t *testing.T) {
 			want: float64(20),
 		},
 		{
+			in:   (*int64)(nil),
+			want: nil,
+		},
+		{
 			in:   uint8(21),
 			want: float64(21),
 		},
 		{
 			in:   uint8Ptr(22),
 			want: float64(22),
+		},
+		{
+			in:   (*uint8)(nil),
+			want: nil,
 		},
 		{
 			in:   uint16(23),
@@ -275,12 +359,20 @@ func TestCoerceFloat(t *testing.T) {
 			want: float64(24),
 		},
 		{
+			in:   (*uint16)(nil),
+			want: nil,
+		},
+		{
 			in:   uint32(25),
 			want: float64(25),
 		},
 		{
 			in:   uint32Ptr(26),
 			want: float64(26),
+		},
+		{
+			in:   (*uint32)(nil),
+			want: nil,
 		},
 		{
 			in:   uint64(27),
@@ -291,8 +383,16 @@ func TestCoerceFloat(t *testing.T) {
 			want: float64(28),
 		},
 		{
+			in:   (*uint64)(nil),
+			want: nil,
+		},
+		{
 			in:   uintPtr(29),
 			want: float64(29),
+		},
+		{
+			in:   (*uint)(nil),
+			want: nil,
 		},
 		{
 			in:   float32(30),
@@ -303,6 +403,10 @@ func TestCoerceFloat(t *testing.T) {
 			want: float32(31),
 		},
 		{
+			in:   (*float32)(nil),
+			want: nil,
+		},
+		{
 			in:   float64(32),
 			want: float64(32),
 		},
@@ -311,12 +415,20 @@ func TestCoerceFloat(t *testing.T) {
 			want: float64(33.2),
 		},
 		{
+			in:   (*float64)(nil),
+			want: nil,
+		},
+		{
 			in:   "34",
 			want: float64(34),
 		},
 		{
 			in:   stringPtr("35.2"),
 			want: float64(35.2),
+		},
+		{
+			in:   (*string)(nil),
+			want: nil,
 		},
 		{
 			in:   "I'm not a number",
@@ -357,6 +469,10 @@ func TestCoerceBool(t *testing.T) {
 			want: true,
 		},
 		{
+			in:   (*bool)(nil),
+			want: nil,
+		},
+		{
 			in:   int(math.MinInt32),
 			want: true,
 		},
@@ -377,6 +493,10 @@ func TestCoerceBool(t *testing.T) {
 			want: false,
 		},
 		{
+			in:   (*int)(nil),
+			want: nil,
+		},
+		{
 			in:   int8(13),
 			want: true,
 		},
@@ -391,6 +511,10 @@ func TestCoerceBool(t *testing.T) {
 		{
 			in:   int8Ptr(0),
 			want: false,
+		},
+		{
+			in:   (*int8)(nil),
+			want: nil,
 		},
 		{
 			in:   int16(15),
@@ -409,6 +533,10 @@ func TestCoerceBool(t *testing.T) {
 			want: false,
 		},
 		{
+			in:   (*int16)(nil),
+			want: nil,
+		},
+		{
 			in:   int32(17),
 			want: true,
 		},
@@ -423,6 +551,10 @@ func TestCoerceBool(t *testing.T) {
 		{
 			in:   int32Ptr(0),
 			want: false,
+		},
+		{
+			in:   (*int32)(nil),
+			want: nil,
 		},
 		{
 			in:   int64(19),
@@ -441,6 +573,10 @@ func TestCoerceBool(t *testing.T) {
 			want: false,
 		},
 		{
+			in:   (*int64)(nil),
+			want: nil,
+		},
+		{
 			in:   uint8(21),
 			want: true,
 		},
@@ -455,6 +591,10 @@ func TestCoerceBool(t *testing.T) {
 		{
 			in:   uint8Ptr(0),
 			want: false,
+		},
+		{
+			in:   (*uint8)(nil),
+			want: nil,
 		},
 		{
 			in:   uint16(23),
@@ -473,6 +613,10 @@ func TestCoerceBool(t *testing.T) {
 			want: false,
 		},
 		{
+			in:   (*uint16)(nil),
+			want: nil,
+		},
+		{
 			in:   uint32(25),
 			want: true,
 		},
@@ -489,6 +633,10 @@ func TestCoerceBool(t *testing.T) {
 			want: false,
 		},
 		{
+			in:   (*uint32)(nil),
+			want: nil,
+		},
+		{
 			in:   uint64(27),
 			want: true,
 		},
@@ -503,6 +651,10 @@ func TestCoerceBool(t *testing.T) {
 		{
 			in:   uint64Ptr(0),
 			want: false,
+		},
+		{
+			in:   (*uint64)(nil),
+			want: nil,
 		},
 		{
 			in:   uintPtr(29),
@@ -529,6 +681,10 @@ func TestCoerceBool(t *testing.T) {
 			want: false,
 		},
 		{
+			in:   (*float32)(nil),
+			want: nil,
+		},
+		{
 			in:   float64(32),
 			want: true,
 		},
@@ -545,6 +701,10 @@ func TestCoerceBool(t *testing.T) {
 			want: false,
 		},
 		{
+			in:   (*float64)(nil),
+			want: nil,
+		},
+		{
 			in:   "34",
 			want: true,
 		},
@@ -559,6 +719,10 @@ func TestCoerceBool(t *testing.T) {
 		{
 			in:   stringPtr("false"),
 			want: false,
+		},
+		{
+			in:   (*string)(nil),
+			want: nil,
 		},
 		{
 			in:   "I'm some random string",


### PR DESCRIPTION
This fixes a regression when trying to serialize nil pointer values in scalars reported in #365.

The regression was introduced by the merge of #363 because previously the panic in the coercion functions was ignored in `completeValueCatchingError` and set the field to nil/null.

The change introduces explicit handling for the nil pointers in the scalar coercion functions to prevent the panic from happening.