### PR TITLE
Enum nil pointer safety

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -964,7 +964,10 @@ func (gt *Enum) Values() []*EnumValueDefinition {
 }
 func (gt *Enum) Serialize(value interface{}) interface{} {
 	v := value
-	if reflect.ValueOf(v).Kind() == reflect.Ptr {
+	rv := reflect.ValueOf(v)
+	if kind := rv.Kind(); kind == reflect.Ptr && rv.IsNil() {
+		return nil
+	} else if kind == reflect.Ptr {
 		v = reflect.Indirect(reflect.ValueOf(v)).Interface()
 	}
 	if enumValue, ok := gt.getValueLookup()[v]; ok {

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -421,3 +421,42 @@ func TestTypeSystem_EnumValues_EnumValueMayBePointer(t *testing.T) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
+
+func TestTypeSystem_EnumValues_EnumValueMayBeNilPointer(t *testing.T) {
+	var enumTypeTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
+		Query: graphql.NewObject(graphql.ObjectConfig{
+			Name: "Query",
+			Fields: graphql.Fields{
+				"query": &graphql.Field{
+					Type: graphql.NewObject(graphql.ObjectConfig{
+						Name: "query",
+						Fields: graphql.Fields{
+							"color": &graphql.Field{
+								Type: enumTypeTestColorType,
+							},
+						},
+					}),
+					Resolve: func(_ graphql.ResolveParams) (interface{}, error) {
+						return struct {
+							Color *int `graphql:"color"`
+						}{nil}, nil
+					},
+				},
+			},
+		}),
+	})
+	query := "{ query { color } }"
+	expected := &graphql.Result{
+		Data: map[string]interface{}{
+			"query": map[string]interface{}{
+				"color": nil,
+			}},
+	}
+	result := g(t, graphql.Params{
+		Schema:        enumTypeTestSchema,
+		RequestString: query,
+	})
+	if !reflect.DeepEqual(expected, result) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	}
+}

--- a/lists_test.go
+++ b/lists_test.go
@@ -870,3 +870,32 @@ func TestLists_ArrayOfNullableObjects_ContainsValues(t *testing.T) {
 	}
 	checkList(t, ttype, data, expected)
 }
+
+func TestLists_ValueMayBeNilPointer(t *testing.T) {
+	var listTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
+		Query: graphql.NewObject(graphql.ObjectConfig{
+			Name: "Query",
+			Fields: graphql.Fields{
+				"list": &graphql.Field{
+					Type: graphql.NewList(graphql.Int),
+					Resolve: func(_ graphql.ResolveParams) (interface{}, error) {
+						return []int(nil), nil
+					},
+				},
+			},
+		}),
+	})
+	query := "{ list }"
+	expected := &graphql.Result{
+		Data: map[string]interface{}{
+			"list": []interface{}{},
+		},
+	}
+	result := g(t, graphql.Params{
+		Schema:        listTestSchema,
+		RequestString: query,
+	})
+	if !reflect.DeepEqual(expected, result) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	}
+}


### PR DESCRIPTION
Similar to #369 this fixes another issue where Enum values would panic when trying to be resolved on a nil pointer.

I've also added tests for the Union, Interface and List types for their nil pointer handling but they did not need any fixes.