### PR TITLE
use type switch with var binding

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -403,9 +403,8 @@ func (gt *Object) AddFieldConfig(fieldName string, fieldConfig *Field) {
 	if fieldName == "" || fieldConfig == nil {
 		return
 	}
-	switch gt.typeConfig.Fields.(type) {
-	case Fields:
-		gt.typeConfig.Fields.(Fields)[fieldName] = fieldConfig
+	if fields, ok := gt.typeConfig.Fields.(Fields); ok {
+		fields[fieldName] = fieldConfig
 		gt.initialisedFields = false
 	}
 }
@@ -424,11 +423,11 @@ func (gt *Object) Fields() FieldDefinitionMap {
 	}
 
 	var configureFields Fields
-	switch gt.typeConfig.Fields.(type) {
+	switch fields := gt.typeConfig.Fields.(type) {
 	case Fields:
-		configureFields = gt.typeConfig.Fields.(Fields)
+		configureFields = fields
 	case FieldsThunk:
-		configureFields = gt.typeConfig.Fields.(FieldsThunk)()
+		configureFields = fields()
 	}
 
 	gt.fields, gt.err = defineFieldMap(gt, configureFields)
@@ -442,11 +441,11 @@ func (gt *Object) Interfaces() []*Interface {
 	}
 
 	var configInterfaces []*Interface
-	switch gt.typeConfig.Interfaces.(type) {
+	switch iface := gt.typeConfig.Interfaces.(type) {
 	case InterfacesThunk:
-		configInterfaces = gt.typeConfig.Interfaces.(InterfacesThunk)()
+		configInterfaces = iface()
 	case []*Interface:
-		configInterfaces = gt.typeConfig.Interfaces.([]*Interface)
+		configInterfaces = iface
 	case nil:
 	default:
 		gt.err = fmt.Errorf("Unknown Object.Interfaces type: %T", gt.typeConfig.Interfaces)
@@ -721,9 +720,8 @@ func (it *Interface) AddFieldConfig(fieldName string, fieldConfig *Field) {
 	if fieldName == "" || fieldConfig == nil {
 		return
 	}
-	switch it.typeConfig.Fields.(type) {
-	case Fields:
-		it.typeConfig.Fields.(Fields)[fieldName] = fieldConfig
+	if fields, ok := it.typeConfig.Fields.(Fields); ok {
+		fields[fieldName] = fieldConfig
 		it.initialisedFields = false
 	}
 }
@@ -742,11 +740,11 @@ func (it *Interface) Fields() (fields FieldDefinitionMap) {
 	}
 
 	var configureFields Fields
-	switch it.typeConfig.Fields.(type) {
+	switch fields := it.typeConfig.Fields.(type) {
 	case Fields:
-		configureFields = it.typeConfig.Fields.(Fields)
+		configureFields = fields
 	case FieldsThunk:
-		configureFields = it.typeConfig.Fields.(FieldsThunk)()
+		configureFields = fields()
 	}
 
 	it.fields, it.err = defineFieldMap(it, configureFields)
@@ -1113,11 +1111,11 @@ func (gt *InputObject) defineFieldMap() InputObjectFieldMap {
 		fieldMap InputObjectConfigFieldMap
 		err      error
 	)
-	switch gt.typeConfig.Fields.(type) {
+	switch fields := gt.typeConfig.Fields.(type) {
 	case InputObjectConfigFieldMap:
-		fieldMap = gt.typeConfig.Fields.(InputObjectConfigFieldMap)
+		fieldMap = fields
 	case InputObjectConfigFieldMapThunk:
-		fieldMap = gt.typeConfig.Fields.(InputObjectConfigFieldMapThunk)()
+		fieldMap = fields()
 	}
 	resultFieldMap := InputObjectFieldMap{}
 

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -61,9 +61,9 @@ type Parser struct {
 
 func Parse(p ParseParams) (*ast.Document, error) {
 	var sourceObj *source.Source
-	switch p.Source.(type) {
+	switch src := p.Source.(type) {
 	case *source.Source:
-		sourceObj = p.Source.(*source.Source)
+		sourceObj = src
 	default:
 		body, _ := p.Source.(string)
 		sourceObj = source.NewSource(&source.Source{Body: []byte(body)})
@@ -83,9 +83,9 @@ func Parse(p ParseParams) (*ast.Document, error) {
 func parseValue(p ParseParams) (ast.Value, error) {
 	var value ast.Value
 	var sourceObj *source.Source
-	switch p.Source.(type) {
+	switch src := p.Source.(type) {
 	case *source.Source:
-		sourceObj = p.Source.(*source.Source)
+		sourceObj = src
 	default:
 		body, _ := p.Source.(string)
 		sourceObj = source.NewSource(&source.Source{Body: []byte(body)})


### PR DESCRIPTION
Allows to remove redundant type assertions inside case clauses.

Found using https://go-critic.github.io/overview.html#typeSwitchVar-ref