### PR TITLE
replace regexp.Compile with regexp.MustCompile

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -1283,7 +1283,7 @@ func (gl *NonNull) Error() error {
 	return gl.err
 }
 
-var NameRegExp, _ = regexp.Compile("^[_a-zA-Z][_a-zA-Z0-9]*$")
+var NameRegExp = regexp.MustCompile("^[_a-zA-Z][_a-zA-Z0-9]*$")
 
 func assertValidName(name string) error {
 	return invariantf(


### PR DESCRIPTION
Since error is ignored, it's better to use MustCompile.

Found using https://go-critic.github.io/overview#regexpMust-ref