### PR TITLE
replace len(x)<=v with len(x)==v

### DIFF
--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -1600,7 +1600,7 @@ func reverse(parser *Parser, openKind int, parseFn parseFn, closeKind int, zinte
 		}
 		nodes = append(nodes, node)
 	}
-	if zinteger && len(nodes) <= 0 {
+	if zinteger && len(nodes) == 0 {
 		return nodes, unexpectedEmpty(parser, token.Start, openKind, closeKind)
 	}
 	return nodes, nil


### PR DESCRIPTION
Length can't be negative, so use more appropriate operator.

Found using https://go-critic.github.io/overview#sloppyLen-ref