### PR TITLE
Added Custom Error Formatter

### DIFF
--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -54,9 +54,17 @@ func FormatError(err error) FormattedError {
 }
 
 func FormatErrors(errs ...error) []FormattedError {
-	formattedErrors := []FormattedError{}
+	formattedErrors := make([]FormattedError, 0)
 	for _, err := range errs {
 		formattedErrors = append(formattedErrors, FormatError(err))
+	}
+	return formattedErrors
+}
+
+func FormatErrorsFunc(f func (err error) FormattedError, errs ...error) []FormattedError {
+	formattedErrors := make([]FormattedError, 0)
+	for _, err := range errs {
+		formattedErrors = append(formattedErrors, f(err))
 	}
 	return formattedErrors
 }


### PR DESCRIPTION
I added support for a custom error formatter. Sometimes you come with custom `error` objects that might need special parsing to add correct `extensions` in a generic way by object type.

This implementation doesn't change anything to the flow if no Custom Handler is specified since it uses by default the `FormatError` method. However if you specify, it will run your custom function expecting a `FormattedError` to return.

Just a quick example:

```go
func CustomFormat(err error) gqlerrors.FormattedError {
	switch err := err.(type) {
	case *gqlerrors.Error:
                // My custom error object returned in the mutation / query is encapsulated as OriginalError
		cf := CustomFormat(err.OriginalError)
		cf.Locations = err.Locations
		cf.Path = err.Path
		return cf
	case *QuantoError.ErrorObject:
                // Here I can call my custom ErrorObject ToFormattedError that will return an FormattedError with proper extensions set.
		return err.ToFormattedError()
	default:
		return gqlerrors.FormatError(err)
	}
}
```

Then you can use something like: 
```
	// execute graphql query
	params := graphql.Params{
		Schema:         		*h.Schema,
		RequestString:  		opts.Query,
		VariableValues: 		opts.Variables,
		OperationName:  		opts.OperationName,
		Context:        		ctx,
		CustomErrorFomatter: 	CustomFormat,
	}
	result := graphql.Do(params)
```
And everything will work.

I'm also opening a PR in graphql-go/handler since it also benefits in this custom handler. I will put a example there as well.