### PR TITLE
Add a new Duration scalar

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -566,3 +566,51 @@ var DateTime = NewScalar(ScalarConfig{
 		return nil
 	},
 })
+
+var Duration = NewScalar(ScalarConfig{
+	Name:        "Duration",
+	Description: "The `Duration` scalar type represents a window or span of time like 1h30m10s",
+	Serialize:   serializeDuration,
+	ParseValue:  unserializeDuration,
+	ParseLiteral: func(valueAST ast.Value) interface{} {
+		switch valueAST := valueAST.(type) {
+		case *ast.StringValue:
+			return valueAST.Value
+		}
+		return nil
+	},
+})
+
+func serializeDuration(v interface{}) interface{} {
+	switch value := v.(type) {
+	case time.Duration:
+		return value.String()
+	case *time.Duration:
+		if value == nil {
+			return nil
+		}
+		return value.String()
+	}
+	return nil
+}
+
+func unserializeDuration(v interface{}) interface{} {
+	switch val := v.(type) {
+	case int64:
+		return time.Duration(val)
+	case float64:
+		return unserializeDuration(fmt.Sprintf("%fs", val))
+	case string:
+		if d, err := time.ParseDuration(val); err == nil {
+			return d
+		}
+	case *string:
+		if val == nil {
+			return nil
+		}
+
+		return unserializeDuration(*val)
+	}
+
+	return nil
+}

--- a/scalars_parsevalue_test.go
+++ b/scalars_parsevalue_test.go
@@ -25,3 +25,30 @@ func TestTypeSystem_Scalar_ParseValueOutputDateTime(t *testing.T) {
 		}
 	}
 }
+
+func TestTypeSystem_Scalar_ParseValueOutputDuration(t *testing.T) {
+	str := "1h30m10s"
+	d, _ := time.ParseDuration(str)
+
+	tests := []struct {
+		in  interface{}
+		out interface{}
+	}{
+		{nil, nil},
+		{"", nil},
+		{(*string)(nil), nil},
+		{"2017-07-23", nil},
+		{str, d},
+		{&str, d},
+		{int64(5410000000000), d},
+		{d.Seconds(), d},
+	}
+
+	for _, test := range tests {
+		val := graphql.Duration.ParseValue(test.in)
+		if val != test.out {
+			reflectedValue := reflect.ValueOf(test.in)
+			t.Fatalf("failed Duration.ParseValue(%v(%v)), expected: %v, got %v", reflectedValue.Type(), test.in, test.out, val)
+		}
+	}
+}

--- a/scalars_serialization_test.go
+++ b/scalars_serialization_test.go
@@ -197,3 +197,34 @@ func TestTypeSystem_Scalar_SerializeOutputDateTime(t *testing.T) {
 		}
 	}
 }
+
+func TestTypeSystem_Scalar_SerializesOutputDuration(t *testing.T) {
+	d, err := time.ParseDuration("2h34m9s340ms9ns")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		in  interface{}
+		out interface{}
+	}{
+		{"string", nil},
+		{int(1), nil},
+		{float64(-1.1), nil},
+		{true, nil},
+		{false, nil},
+		{30 * time.Minute, "30m0s"},
+		{1*time.Hour + 30*time.Minute, "1h30m0s"},
+		{d, d.String()},
+		{&d, d.String()},
+		{(*time.Duration)(nil), nil},
+	}
+
+	for _, test := range tests {
+		val := graphql.Duration.Serialize(test.in)
+		if val != test.out {
+			reflectedValue := reflect.ValueOf(test.in)
+			t.Fatalf("Failed Duration.Serialize(%v(%v)), expected: %v, got %v", reflectedValue.Type(), test.in, test.out, val)
+		}
+	}
+}


### PR DESCRIPTION
@chris-ramon 

Similar to what was done for `DateTime` objects, I've added a new scalar type (`Duration`) to handle ser(de) of `time.Duration` values. The values are serialized to the string form of Duration (e.g. `2h34m5s900ns` or `1h30m0s`). 

Durations can be deserialized from `string`, `int64`, and `float64` types which makes these all passable as input values (all equivalent):

* `"1h30m15s"`
* `int64(5415000000000)`
* `float64(5415.000000)`