### PR TITLE
exposing Path in ResolveInfo to follow the reference implementation

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -582,6 +582,7 @@ type FieldResolveFn func(p ResolveParams) (interface{}, error)
 type ResolveInfo struct {
 	FieldName      string
 	FieldASTs      []*ast.Field
+	Path           *ResponsePath
 	ReturnType     Output
 	ParentType     Composite
 	Schema         Schema
@@ -1289,21 +1290,21 @@ func assertValidName(name string) error {
 
 }
 
-type responsePath struct {
-	Prev *responsePath
+type ResponsePath struct {
+	Prev *ResponsePath
 	Key  interface{}
 }
 
 // WithKey returns a new responsePath containing the new key.
-func (p *responsePath) WithKey(key interface{}) *responsePath {
-	return &responsePath{
+func (p *ResponsePath) WithKey(key interface{}) *ResponsePath {
+	return &ResponsePath{
 		Prev: p,
 		Key:  key,
 	}
 }
 
 // AsArray returns an array of path keys.
-func (p *responsePath) AsArray() []interface{} {
+func (p *ResponsePath) AsArray() []interface{} {
 	if p == nil {
 		return nil
 	}


### PR DESCRIPTION
This pull request exposes the response path in the ResolveInfo as Path to match the reference implementation (https://github.com/graphql/graphql-js/blob/master/src/type/definition.js#L792-L803) and changes ResponsePath to an exported struct. 