### PR TITLE
Use Go Modules.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,43 @@
-defaults: &defaults
+test_with_go_modules: &test_with_go_modules
+  steps:
+    - checkout
+    - run: go test ./...
+    - run: go vet ./...
+
+test_without_go_modules: &test_without_go_modules
   working_directory: /go/src/github.com/graphql-go/graphql
   steps:
     - checkout
     - run: go get -v -t -d ./...
     - run: go test ./...
     - run: go vet ./...
- 
+
+defaults: &defaults
+  <<: *test_with_go_modules
+
 version: 2
 jobs:
   golang:1.8.7:
-    <<: *defaults
+    <<: *test_without_go_modules
     docker:
       - image: circleci/golang:1.8.7
   golang:1.9.7:
-    <<: *defaults
+    <<: *test_without_go_modules
     docker:
       - image: circleci/golang:1.9.7
+  golang:1.11:
+    <<: *defaults
+    docker:
+      - image: circleci/golang:1.11
   golang:latest:
     <<: *defaults
     docker:
       - image: circleci/golang:latest
   coveralls:
-    working_directory: /go/src/github.com/graphql-go/graphql
     docker:
       - image: circleci/golang:latest
     steps:
       - checkout
-      - run: go get -v -t -d ./...
       - run: go get github.com/mattn/goveralls
       - run: go test -v -cover -race -coverprofile=coverage.out
       - run: /go/bin/goveralls -coverprofile=coverage.out -service=circle-ci -repotoken $COVERALLS_TOKEN
@@ -37,5 +48,6 @@ workflows:
     jobs:
       - golang:1.8.7
       - golang:1.9.7
+      - golang:1.11
       - golang:latest
       - coveralls

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/graphql-go/graphql


### PR DESCRIPTION
#### Overview

- [x] Re-created from: https://github.com/graphql-go/graphql/pull/408 — thanks a lot @zonr :+1: 
- [x] Added `ci/circleci: golang:1.11` as required status check for every pull-request.

***

This is done via the following command with Go 1.11:

```
$ go mod init github.com/graphql-go/graphql
go: creating new go.mod: module github.com/graphql-go/graphql
$ go mod tidy
```

Using Go Modules removes the need to develop/build the project in a
`$GOPATH`-based location. More specifically, with latest Go, setting up
development environment can be as simple as:

```
/under/whatever/path $ git clone https://github.com/graphql-go/graphql # or your own fork
/under/whatever/path $ go test ./...
```

Also instruct CircleCI to run tests with Go Modules when latest Go is in
use. See https://circleci.com/blog/go-v1.11-modules-and-circleci/.