### PR TITLE
errors: consolidates original error for re-usability

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -491,7 +491,6 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
       }
     }`
 
-	originalError := gqlerrors.NewFormattedError(`Runtime Object type "Human" is not a possible type for "Pet".`)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"pets": []interface{}{
@@ -506,31 +505,28 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 				nil,
 			},
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(gqlerrors.Error{
-			Message: originalError.Message,
-			Locations: []location.SourceLocation{
-				{
-					Line:   2,
-					Column: 7,
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: `Runtime Object type "Human" is not a possible type for "Pet".`,
+				Locations: []location.SourceLocation{
+					{
+						Line:   2,
+						Column: 7,
+					},
+				},
+				Path: []interface{}{
+					"pets",
+					2,
 				},
 			},
-			Path: []interface{}{
-				"pets",
-				2,
-			},
-			OriginalError: originalError,
-		})},
+		},
 	}
 
 	result := graphql.Do(graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
-
-	if len(result.Errors) == 0 {
-		t.Fatalf("wrong result, expected errors: %v, got: %v", len(expected.Errors), len(result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -619,7 +615,6 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
       }
     }`
 
-	originalError := gqlerrors.NewFormattedError(`Runtime Object type "Human" is not a possible type for "Pet".`)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"pets": []interface{}{
@@ -635,8 +630,8 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			},
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Message,
+			{
+				Message: `Runtime Object type "Human" is not a possible type for "Pet".`,
 				Locations: []location.SourceLocation{
 					{
 						Line:   2,
@@ -647,8 +642,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 					"pets",
 					2,
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 
@@ -656,10 +650,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		Schema:        schema,
 		RequestString: query,
 	})
-	if len(result.Errors) == 0 {
-		t.Fatalf("wrong result, expected errors: %v, got: %v", len(expected.Errors), len(result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/directives_test.go
+++ b/directives_test.go
@@ -1,12 +1,11 @@
 package graphql_test
 
 import (
-	"reflect"
+	"errors"
 	"testing"
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
 )
 
@@ -56,12 +55,10 @@ func TestDirectives_DirectivesMustBeNamed(t *testing.T) {
 		}),
 		Directives: []*graphql.Directive{invalidDirective},
 	})
-	expectedErr := gqlerrors.FormattedError{
-		Message:   "Directive must be named.",
-		Locations: []location.SourceLocation{},
-	}
-	if !reflect.DeepEqual(expectedErr, err) {
-		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, err))
+	actualErr := gqlerrors.FormatError(err)
+	expectedErr := gqlerrors.FormatError(errors.New("Directive must be named."))
+	if !testutil.EqualFormattedError(expectedErr, actualErr) {
+		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, actualErr))
 	}
 }
 
@@ -83,12 +80,10 @@ func TestDirectives_DirectiveNameMustBeValid(t *testing.T) {
 		}),
 		Directives: []*graphql.Directive{invalidDirective},
 	})
-	expectedErr := gqlerrors.FormattedError{
-		Message:   `Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "123invalid name" does not.`,
-		Locations: []location.SourceLocation{},
-	}
-	if !reflect.DeepEqual(expectedErr, err) {
-		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, err))
+	actualErr := gqlerrors.FormatError(err)
+	expectedErr := gqlerrors.FormatError(errors.New(`Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "123invalid name" does not.`))
+	if !testutil.EqualFormattedError(expectedErr, actualErr) {
+		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, actualErr))
 	}
 }
 
@@ -107,12 +102,10 @@ func TestDirectives_DirectiveNameMustProvideLocations(t *testing.T) {
 		}),
 		Directives: []*graphql.Directive{invalidDirective},
 	})
-	expectedErr := gqlerrors.FormattedError{
-		Message:   `Must provide locations for directive.`,
-		Locations: []location.SourceLocation{},
-	}
-	if !reflect.DeepEqual(expectedErr, err) {
-		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, err))
+	actualErr := gqlerrors.FormatError(err)
+	expectedErr := gqlerrors.FormatError(errors.New(`Must provide locations for directive.`))
+	if !testutil.EqualFormattedError(expectedErr, actualErr) {
+		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, actualErr))
 	}
 }
 
@@ -144,12 +137,10 @@ func TestDirectives_DirectiveArgNamesMustBeValid(t *testing.T) {
 		}),
 		Directives: []*graphql.Directive{invalidDirective},
 	})
-	expectedErr := gqlerrors.FormattedError{
-		Message:   `Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "123if" does not.`,
-		Locations: []location.SourceLocation{},
-	}
-	if !reflect.DeepEqual(expectedErr, err) {
-		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, err))
+	actualErr := gqlerrors.FormatError(err)
+	expectedErr := gqlerrors.FormatError(errors.New(`Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "123if" does not.`))
+	if !testutil.EqualFormattedError(expectedErr, actualErr) {
+		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, actualErr))
 	}
 }
 
@@ -162,10 +153,7 @@ func TestDirectivesWorksWithoutDirectives(t *testing.T) {
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -179,10 +167,7 @@ func TestDirectivesWorksOnScalarsIfTrueIncludesScalar(t *testing.T) {
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -195,10 +180,7 @@ func TestDirectivesWorksOnScalarsIfFalseOmitsOnScalar(t *testing.T) {
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -212,10 +194,7 @@ func TestDirectivesWorksOnScalarsUnlessFalseIncludesScalar(t *testing.T) {
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -228,10 +207,7 @@ func TestDirectivesWorksOnScalarsUnlessTrueOmitsScalar(t *testing.T) {
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -252,10 +228,7 @@ func TestDirectivesWorksOnFragmentSpreadsIfFalseOmitsFragmentSpread(t *testing.T
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -277,10 +250,7 @@ func TestDirectivesWorksOnFragmentSpreadsIfTrueIncludesFragmentSpread(t *testing
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -302,10 +272,7 @@ func TestDirectivesWorksOnFragmentSpreadsUnlessFalseIncludesFragmentSpread(t *te
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -326,10 +293,7 @@ func TestDirectivesWorksOnFragmentSpreadsUnlessTrueOmitsFragmentSpread(t *testin
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -349,10 +313,7 @@ func TestDirectivesWorksOnInlineFragmentIfFalseOmitsInlineFragment(t *testing.T)
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -373,10 +334,7 @@ func TestDirectivesWorksOnInlineFragmentIfTrueIncludesInlineFragment(t *testing.
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -397,10 +355,7 @@ func TestDirectivesWorksOnInlineFragmentUnlessFalseIncludesInlineFragment(t *tes
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -420,10 +375,7 @@ func TestDirectivesWorksOnInlineFragmentUnlessTrueIncludesInlineFragment(t *test
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -443,10 +395,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentIfFalseOmitsAnonymousInlineFrag
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -467,10 +416,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentIfTrueIncludesAnonymousInlineFr
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -491,10 +437,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentUnlessFalseIncludesAnonymousInl
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -514,10 +457,7 @@ func TestDirectivesWorksOnAnonymousInlineFragmentUnlessTrueIncludesAnonymousInli
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -531,10 +471,7 @@ func TestDirectivesWorksWithSkipAndIncludeDirectives_IncludeAndNoSkip(t *testing
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -547,10 +484,7 @@ func TestDirectivesWorksWithSkipAndIncludeDirectives_IncludeAndSkip(t *testing.T
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -563,10 +497,7 @@ func TestDirectivesWorksWithSkipAndIncludeDirectives_NoIncludeAndSkip(t *testing
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -579,10 +510,7 @@ func TestDirectivesWorksWithSkipAndIncludeDirectives_NoIncludeOrSkip(t *testing.
 		},
 	}
 	result := executeDirectivesTestQuery(t, query)
-	if len(result.Errors) != 0 {
-		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -41,7 +41,7 @@ func FormatError(err error) FormattedError {
 			Message:       err.Error(),
 			Locations:     err.Locations,
 			Path:          err.Path,
-			originalError: err.OriginalError,
+			originalError: err,
 		}
 		if err := err.OriginalError; err != nil {
 			if extended, ok := err.(ExtendedError); ok {
@@ -53,8 +53,9 @@ func FormatError(err error) FormattedError {
 		return FormatError(&err)
 	default:
 		return FormattedError{
-			Message:   err.Error(),
-			Locations: []location.SourceLocation{},
+			Message:       err.Error(),
+			Locations:     []location.SourceLocation{},
+			originalError: err,
 		}
 	}
 }

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -1,7 +1,6 @@
 package graphql_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/graphql-go/graphql"
@@ -980,7 +979,7 @@ func TestIntrospection_SupportsThe__TypeRootField(t *testing.T) {
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1314,7 +1313,7 @@ func TestIntrospection_FailsAsExpectedOnThe__TypeRootFieldWithoutAnArg(t *testin
 		Schema:        schema,
 		RequestString: query,
 	})
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/lists_test.go
+++ b/lists_test.go
@@ -1,7 +1,6 @@
 package graphql_test
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 
@@ -50,10 +49,7 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 		Root:   data,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(expected.Errors) != len(result.Errors) {
-		t.Fatalf("wrong result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 
@@ -253,32 +249,24 @@ func TestLists_NonNullListOfNullableObjectsContainsNull(t *testing.T) {
 }
 func TestLists_NonNullListOfNullableObjectsReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+				},
+			},
 		},
 	}
 	checkList(t, ttype, nil, expected)
@@ -335,32 +323,24 @@ func TestLists_NonNullListOfNullableFunc_ReturnsNull(t *testing.T) {
 	data := func() interface{} {
 		return nil
 	}
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+				},
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)
@@ -441,35 +421,27 @@ func TestLists_NullableListOfNonNullObjects_ContainsNull(t *testing.T) {
 	data := []interface{}{
 		1, nil, 2,
 	}
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-			1,
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
 			},
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+					1,
+				},
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)
@@ -519,35 +491,27 @@ func TestLists_NullableListOfNonNullFunc_ContainsNull(t *testing.T) {
 			1, nil, 2,
 		}
 	}
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-			1,
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
 			},
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+					1,
+				},
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)
@@ -611,22 +575,6 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 			return 2, nil
 		},
 	}
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-			1,
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		/*
 			// TODO: Because thunks are called after the result map has been assembled,
@@ -640,13 +588,21 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 			},
 		*/
 		Data: nil,
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+					1,
+				},
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)
@@ -674,65 +630,49 @@ func TestLists_NonNullListOfNonNullObjects_ContainsNull(t *testing.T) {
 	data := []interface{}{
 		1, nil, 2,
 	}
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-			1,
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+					1,
+				},
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNonNullObjects_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+				},
+			},
 		},
 	}
 	checkList(t, ttype, nil, expected)
@@ -770,33 +710,25 @@ func TestLists_NonNullListOfNonNullFunc_ContainsNull(t *testing.T) {
 			1, nil, 2,
 		}
 	}
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-			1,
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+					1,
+				},
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)
@@ -809,32 +741,24 @@ func TestLists_NonNullListOfNonNullFunc_ReturnsNull(t *testing.T) {
 	data := func() interface{} {
 		return nil
 	}
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+				},
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)
@@ -881,22 +805,6 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 			return 2, nil
 		},
 	}
-	rootError := errors.New("Cannot return null for non-nullable field DataType.test.")
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{
-				Line:   1,
-				Column: 10,
-			},
-		},
-		Path: []interface{}{
-			"nest",
-			"test",
-			1,
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		/*
 			// TODO: Because thunks are called after the result map has been assembled,
@@ -908,13 +816,21 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 			},
 		*/
 		Data: nil,
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "Cannot return null for non-nullable field DataType.test.",
+				Locations: []location.SourceLocation{
+					{
+						Line:   1,
+						Column: 10,
+					},
+				},
+				Path: []interface{}{
+					"nest",
+					"test",
+					1,
+				},
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)
@@ -923,16 +839,15 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 func TestLists_UserErrorExpectIterableButDidNotGetOne(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 	data := "Not an iterable"
-	originalError := gqlerrors.NewFormattedError("User Error: expected iterable, but did not find one for field DataType.test.")
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
 			},
 		},
-		Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(
-			gqlerrors.Error{
-				Message: originalError.Message,
+		Errors: []gqlerrors.FormattedError{
+			{
+				Message: "User Error: expected iterable, but did not find one for field DataType.test.",
 				Locations: []location.SourceLocation{
 					{
 						Line:   1,
@@ -943,8 +858,7 @@ func TestLists_UserErrorExpectIterableButDidNotGetOne(t *testing.T) {
 					"nest",
 					"test",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	checkList(t, ttype, data, expected)

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -1,9 +1,6 @@
 package graphql_test
 
 import (
-	"errors"
-	"fmt"
-	"reflect"
 	"sort"
 	"testing"
 
@@ -11,7 +8,6 @@ import (
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/location"
 	"github.com/graphql-go/graphql/testutil"
-	"github.com/kr/pretty"
 )
 
 var syncError = "sync"
@@ -119,14 +115,13 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
         sync
       }
 	`
-	originalError := errors.New(syncError)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"sync": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Error(),
+			{
+				Message: syncError,
 				Locations: []location.SourceLocation{
 					{
 						Line: 3, Column: 9,
@@ -135,8 +130,7 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
 				Path: []interface{}{
 					"sync",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	// parse query
@@ -149,11 +143,7 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	fmt.Printf("%v\n", pretty.Diff(expected, result))
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -163,14 +153,13 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
         promise
       }
 	`
-	originalError := errors.New(promiseError)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"promise": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Error(),
+			{
+				Message: promiseError,
 				Locations: []location.SourceLocation{
 					{
 						Line: 3, Column: 9,
@@ -179,8 +168,7 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
 				Path: []interface{}{
 					"promise",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	// parse query
@@ -193,10 +181,7 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -208,14 +193,13 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
         }
       }
 	`
-	originalError := errors.New(nonNullSyncError)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Error(),
+			{
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					{
 						Line: 4, Column: 11,
@@ -225,8 +209,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
 					"nest",
 					"nonNullSync",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	// parse query
@@ -239,10 +222,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -254,14 +234,13 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
         }
       }
 	`
-	originalError := errors.New(nonNullPromiseError)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Error(),
+			{
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					{
 						Line: 4, Column: 11,
@@ -271,8 +250,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 					"nest",
 					"nonNullPromise",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	// parse query
@@ -285,10 +263,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -300,14 +275,13 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
         }
       }
 	`
-	originalError := errors.New(nonNullSyncError)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"promiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Error(),
+			{
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					{
 						Line: 4, Column: 11,
@@ -317,8 +291,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 					"promiseNest",
 					"nonNullSync",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	// parse query
@@ -331,10 +304,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -346,14 +316,13 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
         }
       }
 	`
-	originalError := errors.New(nonNullPromiseError)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"promiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Error(),
+			{
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					{
 						Line: 4, Column: 11,
@@ -363,8 +332,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 					"promiseNest",
 					"nonNullPromise",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	// parse query
@@ -377,10 +345,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -414,8 +379,6 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
         }
       }
 	`
-	syncOriginalError := errors.New(syncError)
-	promiseOriginalError := errors.New(promiseError)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
@@ -445,124 +408,112 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 		},
 		Errors: []gqlerrors.FormattedError{
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: syncOriginalError.Error(),
+				Message: syncError,
 				Locations: []location.SourceLocation{
 					{Line: 4, Column: 11},
 				},
 				Path: []interface{}{
 					"nest", "sync",
 				},
-				OriginalError: syncOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: syncOriginalError.Error(),
+				Message: syncError,
 				Locations: []location.SourceLocation{
 					{Line: 7, Column: 13},
 				},
 				Path: []interface{}{
 					"nest", "nest", "sync",
 				},
-				OriginalError: syncOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: syncOriginalError.Error(),
+				Message: syncError,
 				Locations: []location.SourceLocation{
 					{Line: 11, Column: 13},
 				},
 				Path: []interface{}{
 					"nest", "promiseNest", "sync",
 				},
-				OriginalError: syncOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: syncOriginalError.Error(),
+				Message: syncError,
 				Locations: []location.SourceLocation{
 					{Line: 16, Column: 11},
 				},
 				Path: []interface{}{
 					"promiseNest", "sync",
 				},
-				OriginalError: syncOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: syncOriginalError.Error(),
+				Message: syncError,
 				Locations: []location.SourceLocation{
 					{Line: 19, Column: 13},
 				},
 				Path: []interface{}{
 					"promiseNest", "nest", "sync",
 				},
-				OriginalError: syncOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: syncOriginalError.Error(),
+				Message: syncError,
 				Locations: []location.SourceLocation{
 					{Line: 23, Column: 13},
 				},
 				Path: []interface{}{
 					"promiseNest", "promiseNest", "sync",
 				},
-				OriginalError: syncOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: promiseOriginalError.Error(),
+				Message: promiseError,
 				Locations: []location.SourceLocation{
 					{Line: 5, Column: 11},
 				},
 				Path: []interface{}{
 					"nest", "promise",
 				},
-				OriginalError: promiseOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: promiseOriginalError.Error(),
+				Message: promiseError,
 				Locations: []location.SourceLocation{
 					{Line: 8, Column: 13},
 				},
 				Path: []interface{}{
 					"nest", "nest", "promise",
 				},
-				OriginalError: promiseOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: promiseOriginalError.Error(),
+				Message: promiseError,
 				Locations: []location.SourceLocation{
 					{Line: 12, Column: 13},
 				},
 				Path: []interface{}{
 					"nest", "promiseNest", "promise",
 				},
-				OriginalError: promiseOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: promiseOriginalError.Error(),
+				Message: promiseError,
 				Locations: []location.SourceLocation{
 					{Line: 17, Column: 11},
 				},
 				Path: []interface{}{
 					"promiseNest", "promise",
 				},
-				OriginalError: promiseOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: promiseOriginalError.Error(),
+				Message: promiseError,
 				Locations: []location.SourceLocation{
 					{Line: 20, Column: 13},
 				},
 				Path: []interface{}{
 					"promiseNest", "nest", "promise",
 				},
-				OriginalError: promiseOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: promiseOriginalError.Error(),
+				Message: promiseError,
 				Locations: []location.SourceLocation{
 					{Line: 24, Column: 13},
 				},
 				Path: []interface{}{
 					"promiseNest", "promiseNest", "promise",
 				},
-				OriginalError: promiseOriginalError,
 			}),
 		},
 	}
@@ -576,15 +527,9 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected.Data, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
-	}
 	sort.Sort(gqlerrors.FormattedErrors(expected.Errors))
 	sort.Sort(gqlerrors.FormattedErrors(result.Errors))
-	if !reflect.DeepEqual(expected.Errors, result.Errors) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }
@@ -637,8 +582,6 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
         }
       }
 	`
-	nonNullSyncOriginalError := errors.New(nonNullSyncError)
-	onNullPromiseOriginalError := errors.New(nonNullPromiseError)
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest":               nil,
@@ -648,7 +591,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 		},
 		Errors: []gqlerrors.FormattedError{
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: nonNullSyncOriginalError.Error(),
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					{Line: 8, Column: 19},
 				},
@@ -656,10 +599,9 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 					"nest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullSync",
 				},
-				OriginalError: nonNullSyncOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: nonNullSyncOriginalError.Error(),
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					{Line: 19, Column: 19},
 				},
@@ -667,10 +609,9 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 					"promiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullSync",
 				},
-				OriginalError: nonNullSyncOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: onNullPromiseOriginalError.Error(),
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					{Line: 30, Column: 19},
 				},
@@ -678,10 +619,9 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 					"anotherNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullPromise",
 				},
-				OriginalError: onNullPromiseOriginalError,
 			}),
 			gqlerrors.FormatError(gqlerrors.Error{
-				Message: onNullPromiseOriginalError.Error(),
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					{Line: 41, Column: 19},
 				},
@@ -689,7 +629,6 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 					"anotherPromiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
 					"nonNullPromiseNest", "nonNullPromise",
 				},
-				OriginalError: onNullPromiseOriginalError,
 			}),
 		},
 	}
@@ -703,15 +642,9 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected.Data, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
-	}
 	sort.Sort(gqlerrors.FormattedErrors(expected.Errors))
 	sort.Sort(gqlerrors.FormattedErrors(result.Errors))
-	if !reflect.DeepEqual(expected.Errors, result.Errors) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 
@@ -737,14 +670,8 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNull(t *testing.T) {
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected.Data, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
-	}
-	if !reflect.DeepEqual(expected.Errors, result.Errors) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
+	if !testutil.EqualResults(expected, result) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
 func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNullInAPromise(t *testing.T) {
@@ -768,14 +695,8 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNullInAPromise(t *te
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected.Data, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
-	}
-	if !reflect.DeepEqual(expected.Errors, result.Errors) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
+	if !testutil.EqualResults(expected, result) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
 func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldThatReturnsNullSynchronously(t *testing.T) {
@@ -786,29 +707,21 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
         }
       }
 	`
-	rootError := errors.New(`Cannot return null for non-nullable field DataType.nonNullSync.`)
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 4, Column: 11},
-		},
-		Path: []interface{}{
-			"nest",
-			"nonNullSync",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Locations: []location.SourceLocation{
+					{Line: 4, Column: 11},
+				},
+				Path: []interface{}{
+					"nest",
+					"nonNullSync",
+				},
+			},
 		},
 	}
 	// parse query
@@ -821,10 +734,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -836,29 +746,21 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
         }
       }
 	`
-	rootError := errors.New(`Cannot return null for non-nullable field DataType.nonNullPromise.`)
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 4, Column: 11},
-		},
-		Path: []interface{}{
-			"nest",
-			"nonNullPromise",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Locations: []location.SourceLocation{
+					{Line: 4, Column: 11},
+				},
+				Path: []interface{}{
+					"nest",
+					"nonNullPromise",
+				},
+			},
 		},
 	}
 	// parse query
@@ -871,10 +773,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -887,29 +786,21 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
         }
       }
 	`
-	rootError := errors.New(`Cannot return null for non-nullable field DataType.nonNullSync.`)
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 4, Column: 11},
-		},
-		Path: []interface{}{
-			"promiseNest",
-			"nonNullSync",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"promiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Locations: []location.SourceLocation{
+					{Line: 4, Column: 11},
+				},
+				Path: []interface{}{
+					"promiseNest",
+					"nonNullSync",
+				},
+			},
 		},
 	}
 	// parse query
@@ -922,10 +813,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -937,29 +825,21 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
         }
       }
 	`
-	rootError := errors.New(`Cannot return null for non-nullable field DataType.nonNullPromise.`)
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 4, Column: 11},
-		},
-		Path: []interface{}{
-			"promiseNest",
-			"nonNullPromise",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"promiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Locations: []location.SourceLocation{
+					{Line: 4, Column: 11},
+				},
+				Path: []interface{}{
+					"promiseNest",
+					"nonNullPromise",
+				},
+			},
 		},
 	}
 	// parse query
@@ -972,10 +852,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1046,14 +923,8 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatReturnNull(t *testing.T) {
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected.Data, result.Data) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
-	}
-	if !reflect.DeepEqual(expected.Errors, result.Errors) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }
 func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOfFieldsThatAreNonNull(t *testing.T) {
@@ -1105,52 +976,6 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
         }
       }
 	`
-	nonNullSyncRootError := errors.New(`Cannot return null for non-nullable field DataType.nonNullSync.`)
-	nonNullSyncOriginalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: nonNullSyncRootError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 8, Column: 19},
-		},
-		Path: []interface{}{
-			"nest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
-			"nonNullPromiseNest", "nonNullSync",
-		},
-		OriginalError: nonNullSyncRootError,
-	})
-	nonNullSyncOriginalError2 := gqlerrors.FormatError(gqlerrors.Error{
-		Message: nonNullSyncRootError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 19, Column: 19},
-		},
-		Path: []interface{}{
-			"promiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
-			"nonNullPromiseNest", "nonNullSync",
-		},
-		OriginalError: nonNullSyncRootError,
-	})
-	nonNullPromiseError := errors.New(`Cannot return null for non-nullable field DataType.nonNullPromise.`)
-	nonNullPromiseOriginalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: nonNullPromiseError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 30, Column: 19},
-		},
-		Path: []interface{}{
-			"anotherNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
-			"nonNullPromiseNest", "nonNullPromise",
-		},
-		OriginalError: nonNullPromiseError,
-	})
-	nonNullPromiseOriginalError2 := gqlerrors.FormatError(gqlerrors.Error{
-		Message: nonNullPromiseError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 41, Column: 19},
-		},
-		Path: []interface{}{
-			"anotherPromiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
-			"nonNullPromiseNest", "nonNullPromise",
-		},
-		OriginalError: nonNullPromiseError,
-	})
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest":               nil,
@@ -1159,30 +984,46 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 			"anotherPromiseNest": nil,
 		},
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       nonNullSyncOriginalError.Message,
-				Locations:     nonNullSyncOriginalError.Locations,
-				Path:          nonNullSyncOriginalError.Path,
-				OriginalError: nonNullSyncOriginalError,
-			}),
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       nonNullSyncOriginalError2.Message,
-				Locations:     nonNullSyncOriginalError2.Locations,
-				Path:          nonNullSyncOriginalError2.Path,
-				OriginalError: nonNullSyncOriginalError2,
-			}),
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       nonNullPromiseOriginalError.Message,
-				Locations:     nonNullPromiseOriginalError.Locations,
-				Path:          nonNullPromiseOriginalError.Path,
-				OriginalError: nonNullPromiseOriginalError,
-			}),
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       nonNullPromiseOriginalError2.Message,
-				Locations:     nonNullPromiseOriginalError2.Locations,
-				Path:          nonNullPromiseOriginalError2.Path,
-				OriginalError: nonNullPromiseOriginalError2,
-			}),
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Locations: []location.SourceLocation{
+					{Line: 8, Column: 19},
+				},
+				Path: []interface{}{
+					"nest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
+					"nonNullPromiseNest", "nonNullSync",
+				},
+			},
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Locations: []location.SourceLocation{
+					{Line: 19, Column: 19},
+				},
+				Path: []interface{}{
+					"promiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
+					"nonNullPromiseNest", "nonNullSync",
+				},
+			},
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Locations: []location.SourceLocation{
+					{Line: 30, Column: 19},
+				},
+				Path: []interface{}{
+					"anotherNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
+					"nonNullPromiseNest", "nonNullPromise",
+				},
+			},
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Locations: []location.SourceLocation{
+					{Line: 41, Column: 19},
+				},
+				Path: []interface{}{
+					"anotherPromiseNest", "nonNullNest", "nonNullPromiseNest", "nonNullNest",
+					"nonNullPromiseNest", "nonNullPromise",
+				},
+			},
 		},
 	}
 	// parse query
@@ -1195,16 +1036,10 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected.Data, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
-	}
 	sort.Sort(gqlerrors.FormattedErrors(expected.Errors))
 	sort.Sort(gqlerrors.FormattedErrors(result.Errors))
-	if !reflect.DeepEqual(expected.Errors, result.Errors) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
+	if !testutil.EqualResults(expected, result) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
 
@@ -1212,20 +1047,18 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldThrows(t *testing.T) {
 	doc := `
       query Q { nonNullSync }
 	`
-	originalError := errors.New(nonNullSyncError)
 	expected := &graphql.Result{
 		Data: nil,
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Error(),
+			{
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					{Line: 2, Column: 17},
 				},
 				Path: []interface{}{
 					"nonNullSync",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	// parse query
@@ -1238,10 +1071,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldThrows(t *testing.T) {
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1249,20 +1079,18 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
 	doc := `
       query Q { nonNullPromise }
 	`
-	originalError := errors.New(nonNullPromiseError)
 	expected := &graphql.Result{
 		Data: nil,
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message: originalError.Error(),
+			{
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					{Line: 2, Column: 17},
 				},
 				Path: []interface{}{
 					"nonNullPromise",
 				},
-				OriginalError: originalError,
-			}),
+			},
 		},
 	}
 	// parse query
@@ -1275,10 +1103,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
 		Root:   throwingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1286,26 +1111,18 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldReturnsNull(t *testing.T)
 	doc := `
       query Q { nonNullSync }
 	`
-	rootError := errors.New(`Cannot return null for non-nullable field DataType.nonNullSync.`)
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 2, Column: 17},
-		},
-		Path: []interface{}{
-			"nonNullSync",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: nil,
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Locations: []location.SourceLocation{
+					{Line: 2, Column: 17},
+				},
+				Path: []interface{}{
+					"nonNullSync",
+				},
+			},
 		},
 	}
 	// parse query
@@ -1318,10 +1135,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldReturnsNull(t *testing.T)
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1329,26 +1143,18 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldResolvesNull(t *testing.T
 	doc := `
       query Q { nonNullPromise }
 	`
-	rootError := errors.New(`Cannot return null for non-nullable field DataType.nonNullPromise.`)
-	originalError := gqlerrors.FormatError(gqlerrors.Error{
-		Message: rootError.Error(),
-		Locations: []location.SourceLocation{
-			{Line: 2, Column: 17},
-		},
-		Path: []interface{}{
-			"nonNullPromise",
-		},
-		OriginalError: rootError,
-	})
 	expected := &graphql.Result{
 		Data: nil,
 		Errors: []gqlerrors.FormattedError{
-			gqlerrors.FormatError(gqlerrors.Error{
-				Message:       originalError.Message,
-				Locations:     originalError.Locations,
-				Path:          originalError.Path,
-				OriginalError: originalError,
-			}),
+			{
+				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Locations: []location.SourceLocation{
+					{Line: 2, Column: 17},
+				},
+				Path: []interface{}{
+					"nonNullPromise",
+				},
+			},
 		},
 	}
 	// parse query
@@ -1361,10 +1167,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldResolvesNull(t *testing.T
 		Root:   nullingData,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -3,8 +3,6 @@ package testutil
 import (
 	"testing"
 
-	"reflect"
-
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/location"
@@ -579,7 +577,7 @@ func expectInvalidRule(t *testing.T, schema *graphql.Schema, rules []graphql.Val
 	for _, expectedErr := range expectedErrors {
 		found := false
 		for _, err := range result.Errors {
-			if reflect.DeepEqual(expectedErr, err) {
+			if EqualFormattedError(expectedErr, err) {
 				found = true
 				break
 			}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/parser"
 )
@@ -465,4 +466,39 @@ func ContainSubset(super map[string]interface{}, sub map[string]interface{}) boo
 
 func EqualErrorMessage(expected, result *graphql.Result, i int) bool {
 	return expected.Errors[i].Message == result.Errors[i].Message
+}
+
+func EqualFormattedError(exp, act gqlerrors.FormattedError) bool {
+	if exp.Message != act.Message {
+		return false
+	}
+	if !reflect.DeepEqual(exp.Locations, act.Locations) {
+		return false
+	}
+	if !reflect.DeepEqual(exp.Path, act.Path) {
+		return false
+	}
+	if !reflect.DeepEqual(exp.Extensions, act.Extensions) {
+		return false
+	}
+	return true
+}
+
+func EqualFormattedErrors(expected, actual []gqlerrors.FormattedError) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	for i := range expected {
+		if !EqualFormattedError(expected[i], actual[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func EqualResults(expected, result *graphql.Result) bool {
+	if !reflect.DeepEqual(expected.Data, result.Data) {
+		return false
+	}
+	return EqualFormattedErrors(expected.Errors, result.Errors)
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,7 +1,6 @@
 package graphql_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/graphql-go/graphql"
@@ -92,7 +91,7 @@ func TestValidator_SupportsFullValidation_ValidatesUsingACustomTypeInfo(t *testi
 			},
 		},
 	}
-	if !reflect.DeepEqual(expectedErrors, errors) {
+	if !testutil.EqualFormattedErrors(expectedErrors, errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, errors))
 	}
 }

--- a/variables_test.go
+++ b/variables_test.go
@@ -438,10 +438,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnNullForNestedNon
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -472,10 +469,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnIncorrectType(t 
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -510,10 +504,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnOmissionOfNested
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -555,10 +546,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnDeepNestedErrors
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -595,10 +583,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnAdditionOfUnknow
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -804,10 +789,7 @@ func TestVariables_NonNullableScalars_DoesNotAllowNonNullableInputsToBeOmittedIn
 		AST:    ast,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -844,10 +826,7 @@ func TestVariables_NonNullableScalars_DoesNotAllowNonNullableInputsToBeSetToNull
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1070,10 +1049,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListsToBeNull(t *testi
 		AST:    ast,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1230,10 +1206,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowListOfNonNullsToContainNull(t
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1268,10 +1241,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListOfNonNullsToBeNull
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1338,10 +1308,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListOfNonNullsToContai
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1381,7 +1348,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowInvalidTypesToBeUsedAsValues(
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
@@ -1416,10 +1383,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowUnknownTypesToBeUsedAsValues(
 		Args:   params,
 	}
 	result := testutil.TestExecute(t, ep)
-	if len(result.Errors) != len(expected.Errors) {
-		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
-	}
-	if !reflect.DeepEqual(expected, result) {
+	if !testutil.EqualResults(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }


### PR DESCRIPTION
#### Overview
- Follow up PR from: https://github.com/graphql-go/graphql/pull/423
- Related: https://github.com/graphql-go/handler/pull/58#issuecomment-444846017
- Consolidates `FormattedError.originalError` for re-usability, so we allow lib users to opt-in custom error formatting.


#### Breaking Changes
- No breaking changes for non-users of `FormattedError.OriginalError()`.
- If using `FormattedError.OriginalError()`:
  - Now `FormattedError.OriginalError()` returns the actual error that was pass to `gqlerrors.FormatError`.

#### Test plan
- Unit tests