### PR TITLE
Add extensions to Result

### DIFF
--- a/types.go
+++ b/types.go
@@ -4,11 +4,10 @@ import (
 	"github.com/graphql-go/graphql/gqlerrors"
 )
 
-// type Schema interface{}
-
 type Result struct {
-	Data   interface{}                `json:"data"`
-	Errors []gqlerrors.FormattedError `json:"errors,omitempty"`
+	Data       interface{}                `json:"data"`
+	Errors     []gqlerrors.FormattedError `json:"errors,omitempty"`
+	Extensions map[string]interface{}     `json:"extensions,omitempty"`
 }
 
 func (r *Result) HasErrors() bool {


### PR DESCRIPTION
add extensions key to result as mentioned in specification https://facebook.github.io/graphql/June2018/#sec-Response-Format

also may be make Errors a first member of Result as proposed in spec?
