### PR TITLE
Add Result.AppendErrors

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -36,7 +36,7 @@ func Execute(p ExecuteParams) (result *Result) {
 	go func(out chan<- *Result, done <-chan struct{}) {
 		defer func() {
 			if err := recover(); err != nil {
-				result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
+				result.AppendErrors(gqlerrors.FormatError(err.(error)))
 			}
 			select {
 			case out <- result:
@@ -54,7 +54,7 @@ func Execute(p ExecuteParams) (result *Result) {
 		})
 
 		if err != nil {
-			result.Errors = append(result.Errors, gqlerrors.FormatError(err))
+			result.AppendErrors(gqlerrors.FormatError(err))
 			return
 		}
 
@@ -67,7 +67,7 @@ func Execute(p ExecuteParams) (result *Result) {
 
 	select {
 	case <-ctx.Done():
-		result.Errors = append(result.Errors, gqlerrors.FormatError(ctx.Err()))
+		result.AppendErrors(gqlerrors.FormatError(ctx.Err()))
 	case r := <-resultChannel:
 		result = r
 	}

--- a/types.go
+++ b/types.go
@@ -1,6 +1,8 @@
 package graphql
 
 import (
+	"sync"
+
 	"github.com/graphql-go/graphql/gqlerrors"
 )
 
@@ -9,8 +11,18 @@ import (
 type Result struct {
 	Data   interface{}                `json:"data"`
 	Errors []gqlerrors.FormattedError `json:"errors,omitempty"`
+
+	errorsLock sync.Mutex
 }
 
 func (r *Result) HasErrors() bool {
 	return len(r.Errors) > 0
+}
+
+// AppendErrors is the thread-safe way to append error(s) to Result.Errors.
+func (r *Result) AppendErrors(errs ...gqlerrors.FormattedError) {
+	r.errorsLock.Lock()
+	defer r.errorsLock.Unlock()
+
+	r.Errors = append(r.Errors, errs...)
 }


### PR DESCRIPTION
This is a thread-safe way of appending errors into Result.Errors, as we
are currently doing it in different goroutines.

This fixes https://github.com/graphql-go/graphql/issues/429