### PR TITLE
Fix panic when a blockstring has only 1 line and blank

### DIFF
--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -427,10 +427,10 @@ func blockStringValue(in string) string {
 
 	// Remove leading blank lines.
 	for {
-		if len(lines) == 1 {
+		if isBlank := lineIsBlank(lines[0]); !isBlank {
 			break
 		}
-		if isBlank := lineIsBlank(lines[0]); !isBlank {
+		if len(lines) == 1 {
 			break
 		}
 		lines = lines[1:]
@@ -440,6 +440,9 @@ func blockStringValue(in string) string {
 	for {
 		i := len(lines) - 1
 		if isBlank := lineIsBlank(lines[i]); !isBlank {
+			break
+		}
+		if len(lines) == 1 {
 			break
 		}
 		lines = append(lines[:i], lines[i+1:]...)

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -427,6 +427,9 @@ func blockStringValue(in string) string {
 
 	// Remove leading blank lines.
 	for {
+		if len(lines) == 1 {
+			break
+		}
 		if isBlank := lineIsBlank(lines[0]); !isBlank {
 			break
 		}

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -450,6 +450,15 @@ func TestLexer_ReportsUsefulStringErrors(t *testing.T) {
 func TestLexer_LexesBlockStrings(t *testing.T) {
 	tests := []Test{
 		{
+			Body: `""""""`,
+			Expected: Token{
+				Kind:  TokenKind[BLOCK_STRING],
+				Start: 0,
+				End:   6,
+				Value: "",
+			},
+		},
+		{
 			Body: `"""simple"""`,
 			Expected: Token{
 				Kind:  TokenKind[BLOCK_STRING],


### PR DESCRIPTION
When I send a blockstring that has only 1 line and blank...

```
""""""
```

`language/lexer.go` panics.

```
panic: runtime error: index out of range [recovered]
        panic: runtime error: index out of range
```

This PR fix that.