### PR TITLE
Add GetName to TypeDefinition

### DIFF
--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -11,6 +11,7 @@ type DescribableNode interface {
 
 type TypeDefinition interface {
 	DescribableNode
+	GetName() *Name
 	GetOperation() string
 	GetVariableDefinitions() []*VariableDefinition
 	GetSelectionSet() *SelectionSet


### PR DESCRIPTION
This appears to be an oversight, as every type that implements TypeDefinition also already implemented GetName.