### PR TITLE
Don't format the error message unless it is really needed.

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -769,11 +769,10 @@ func completeAbstractValue(eCtx *executionContext, returnType Abstract, fieldAST
 		runtimeType = defaultResolveTypeFn(resolveTypeParams, returnType)
 	}
 
-	err := invariant(runtimeType != nil,
-		fmt.Sprintf(`Abstract type %v must resolve to an Object type at runtime `+
+	err := invariantf(runtimeType != nil,
+		`Abstract type %v must resolve to an Object type at runtime `+
 			`for field %v.%v with value "%v", received "%v".`,
-			returnType, info.ParentType, info.FieldName, result, runtimeType),
-	)
+		returnType, info.ParentType, info.FieldName, result, runtimeType)
 	if err != nil {
 		panic(err)
 	}

--- a/schema.go
+++ b/schema.go
@@ -1,9 +1,5 @@
 package graphql
 
-import (
-	"fmt"
-)
-
 type SchemaConfig struct {
 	Query        *Object
 	Mutation     *Object
@@ -391,13 +387,12 @@ func assertObjectImplementsInterface(schema *Schema, object *Object, iface *Inte
 
 		// Assert interface field type is satisfied by object field type, by being
 		// a valid subtype. (covariant)
-		err = invariant(
+		err = invariantf(
 			isTypeSubTypeOf(schema, objectField.Type, ifaceField.Type),
-			fmt.Sprintf(`%v.%v expects type "%v" but `+
+			`%v.%v expects type "%v" but `+
 				`%v.%v provides type "%v".`,
-				iface, fieldName, ifaceField.Type,
-				object, fieldName, objectField.Type),
-		)
+			iface, fieldName, ifaceField.Type,
+			object, fieldName, objectField.Type)
 		if err != nil {
 			return err
 		}
@@ -413,28 +408,25 @@ func assertObjectImplementsInterface(schema *Schema, object *Object, iface *Inte
 				}
 			}
 			// Assert interface field arg exists on object field.
-			err = invariant(
+			err = invariantf(
 				objectArg != nil,
-				fmt.Sprintf(`%v.%v expects argument "%v" but `+
+				`%v.%v expects argument "%v" but `+
 					`%v.%v does not provide it.`,
-					iface, fieldName, argName,
-					object, fieldName),
-			)
+				iface, fieldName, argName,
+				object, fieldName)
 			if err != nil {
 				return err
 			}
 
 			// Assert interface field arg type matches object field arg type.
 			// (invariant)
-			err = invariant(
+			err = invariantf(
 				isEqualType(ifaceArg.Type, objectArg.Type),
-				fmt.Sprintf(
-					`%v.%v(%v:) expects type "%v" `+
-						`but %v.%v(%v:) provides `+
-						`type "%v".`,
-					iface, fieldName, argName, ifaceArg.Type,
-					object, fieldName, argName, objectArg.Type),
-			)
+				`%v.%v(%v:) expects type "%v" `+
+					`but %v.%v(%v:) provides `+
+					`type "%v".`,
+				iface, fieldName, argName, ifaceArg.Type,
+				object, fieldName, argName, objectArg.Type)
 			if err != nil {
 				return err
 			}
@@ -452,13 +444,12 @@ func assertObjectImplementsInterface(schema *Schema, object *Object, iface *Inte
 
 			if ifaceArg == nil {
 				_, ok := objectArg.Type.(*NonNull)
-				err = invariant(
+				err = invariantf(
 					!ok,
-					fmt.Sprintf(`%v.%v(%v:) is of required type `+
+					`%v.%v(%v:) is of required type `+
 						`"%v" but is not also provided by the interface %v.%v.`,
-						object, fieldName, argName,
-						objectArg.Type, iface, fieldName),
-				)
+					object, fieldName, argName,
+					objectArg.Type, iface, fieldName)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Replace all
`invariant(condition, fmt.Sprintf("format", v1, v2))`
by
`invariantf(condition, "format", v1, v2)`

Unnecessary error message formating in`graphql.completeAbstractValue()` slows my graphql server down and run out of server RAM.



