### PR TITLE
language/lexer: fixes panic on empty blockstrings

### DIFF
--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -427,10 +427,10 @@ func blockStringValue(in string) string {
 
 	// Remove leading blank lines.
 	for {
-		if len(lines) == 1 {
+		if isBlank := lineIsBlank(lines[0]); !isBlank {
 			break
 		}
-		if isBlank := lineIsBlank(lines[0]); !isBlank {
+		if len(lines) == 1 {
 			break
 		}
 		lines = lines[1:]
@@ -440,6 +440,9 @@ func blockStringValue(in string) string {
 	for {
 		i := len(lines) - 1
 		if isBlank := lineIsBlank(lines[i]); !isBlank {
+			break
+		}
+		if len(lines) == 1 {
 			break
 		}
 		lines = append(lines[:i], lines[i+1:]...)

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -404,25 +404,13 @@ func blockStringValue(in string) string {
 	}
 
 	// Remove leading blank lines.
-	for {
-		if isBlank := lineIsBlank(lines[0]); !isBlank {
-			break
-		}
-		if len(lines) == 1 {
-			break
-		}
+	for len(lines) > 0 && lineIsBlank(lines[0]) {
 		lines = lines[1:]
 	}
 
 	// Remove trailing blank lines.
-	for {
+	for len(lines) > 0 && lineIsBlank(lines[len(lines)-1]) {
 		i := len(lines) - 1
-		if isBlank := lineIsBlank(lines[i]); !isBlank {
-			break
-		}
-		if len(lines) == 1 {
-			break
-		}
 		lines = append(lines[:i], lines[i+1:]...)
 	}
 

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -427,6 +427,9 @@ func blockStringValue(in string) string {
 
 	// Remove leading blank lines.
 	for {
+		if len(lines) == 1 {
+			break
+		}
 		if isBlank := lineIsBlank(lines[0]); !isBlank {
 			break
 		}

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -452,7 +452,7 @@ func TestLexer_LexesBlockStrings(t *testing.T) {
 		{
 			Body: `""""""`,
 			Expected: Token{
-				Kind:  TokenKind[BLOCK_STRING],
+				Kind:  BLOCK_STRING,
 				Start: 0,
 				End:   6,
 				Value: "",

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -450,6 +450,15 @@ func TestLexer_ReportsUsefulStringErrors(t *testing.T) {
 func TestLexer_LexesBlockStrings(t *testing.T) {
 	tests := []Test{
 		{
+			Body: `""""""`,
+			Expected: Token{
+				Kind:  TokenKind[BLOCK_STRING],
+				Start: 0,
+				End:   6,
+				Value: "",
+			},
+		},
+		{
 			Body: `"""simple"""`,
 			Expected: Token{
 				Kind:  TokenKind[BLOCK_STRING],


### PR DESCRIPTION
#### Overview
- Built on top of: https://github.com/graphql-go/graphql/pull/441 — Thanks a lot @miiton :+1: 

#### Test plan
- `go test ./...`