### PR TITLE
Add NullValue to allow sending null in a value literal

### DIFF
--- a/language/ast/values.go
+++ b/language/ast/values.go
@@ -19,6 +19,7 @@ var _ Value = (*BooleanValue)(nil)
 var _ Value = (*EnumValue)(nil)
 var _ Value = (*ListValue)(nil)
 var _ Value = (*ObjectValue)(nil)
+var _ Value = (*NullValue)(nil)
 
 // Variable implements Node, Value
 type Variable struct {
@@ -299,4 +300,32 @@ func (f *ObjectField) GetLoc() *Location {
 
 func (f *ObjectField) GetValue() interface{} {
 	return f.Value
+}
+
+// NullField implements Node, Value
+type NullValue struct {
+	Kind string
+	Loc  *Location
+}
+
+func NewNullValue(v *NullValue) *NullValue {
+	if v == nil {
+		v = &NullValue{}
+	}
+	return &NullValue{
+		Kind: kinds.NullValue,
+		Loc:  v.Loc,
+	}
+}
+
+func (v *NullValue) GetKind() string {
+	return v.Kind
+}
+
+func (v *NullValue) GetLoc() *Location {
+	return v.Loc
+}
+
+func (v *NullValue) GetValue() interface{} {
+	return nil
 }

--- a/language/kinds/kinds.go
+++ b/language/kinds/kinds.go
@@ -27,6 +27,7 @@ const (
 	ListValue    = "ListValue"
 	ObjectValue  = "ObjectValue"
 	ObjectField  = "ObjectField"
+	NullValue    = "NullValue"
 
 	// Directives
 	Directive = "Directive"

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -610,15 +610,21 @@ func parseValueLiteral(parser *Parser, isConst bool) (ast.Value, error) {
 				Value: value,
 				Loc:   loc(parser, token.Start),
 			}), nil
-		} else if token.Value != "null" {
+		} else if token.Value == "null" {
 			if err := advance(parser); err != nil {
 				return nil, err
 			}
-			return ast.NewEnumValue(&ast.EnumValue{
-				Value: token.Value,
-				Loc:   loc(parser, token.Start),
+			return ast.NewNullValue(&ast.NullValue{
+				Loc: loc(parser, token.Start),
 			}), nil
 		}
+		if err := advance(parser); err != nil {
+			return nil, err
+		}
+		return ast.NewEnumValue(&ast.EnumValue{
+			Value: token.Value,
+			Loc:   loc(parser, token.Start),
+		}), nil
 	case lexer.DOLLAR:
 		if !isConst {
 			return parseVariable(parser)


### PR DESCRIPTION
I noticed `null` was not a valid value to return anywhere in a ParseLiteral, so I took a look at the way the parsing was done with graphql-js and tried reimplementing their NullValue.

There may be other stuff to do, for example fixing #457 to allow sending null to any scalar type as an argument.

Feel free to tell me if anything looks bad or whatever 🙂 