### PR TITLE
Compare all args when testing for overlap

### DIFF
--- a/rules_known_argument_names_test.go
+++ b/rules_known_argument_names_test.go
@@ -111,7 +111,7 @@ func TestValidate_KnownArgumentNames_UnknownArgsAmongstKnownArgsWithSuggestions(
       }
     `, []gqlerrors.FormattedError{
 		testutil.RuleError(`Unknown argument "ddogCommand" on field "doesKnowCommand" of type "Dog". `+
-			`Did you mean "dogCommand"?`, 3, 25),
+			`Did you mean "dogCommand" or "nextDogCommand"?`, 3, 25),
 	})
 }
 func TestValidate_KnownArgumentNames_UnknownArgsDeeply(t *testing.T) {

--- a/rules_overlapping_fields_can_be_merged.go
+++ b/rules_overlapping_fields_can_be_merged.go
@@ -623,8 +623,8 @@ func sameArguments(args1 []*ast.Argument, args2 []*ast.Argument) bool {
 			}
 			if arg1Name == arg2Name {
 				foundArgs2 = arg2
+				break
 			}
-			break
 		}
 		if foundArgs2 == nil {
 			return false

--- a/rules_overlapping_fields_can_be_merged_test.go
+++ b/rules_overlapping_fields_can_be_merged_test.go
@@ -32,6 +32,14 @@ func TestValidate_OverlappingFieldsCanBeMerged_IdenticalFieldsWithIdenticalArgs(
       }
     `)
 }
+func TestValidate_OverlappingFieldsCanBeMerged_IdenticalFieldsWithMultipleIdenticalArgs(t *testing.T) {
+	testutil.ExpectPassesRule(t, graphql.OverlappingFieldsCanBeMergedRule, `
+      fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
+        doesKnowCommand(dogCommand: SIT nextDogCommand: DOWN)
+        doesKnowCommand(dogCommand: SIT nextDogCommand: DOWN)
+      }
+    `)
+}
 func TestValidate_OverlappingFieldsCanBeMerged_IdenticalFieldsWithIdenticalDirectives(t *testing.T) {
 	testutil.ExpectPassesRule(t, graphql.OverlappingFieldsCanBeMergedRule, `
       fragment mergeSameFieldsWithSameDirectives on Dog {

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -96,6 +96,9 @@ func init() {
 					"dogCommand": &graphql.ArgumentConfig{
 						Type: dogCommandEnum,
 					},
+					"nextDogCommand": &graphql.ArgumentConfig{
+						Type: dogCommandEnum,
+					},
 				},
 			},
 			"isHousetrained": &graphql.Field{


### PR DESCRIPTION
Testing for overlapping arguments was only correctly testing fields with a single argument, and invariably failing for fields with multiple arguments. I've added an additional test for comparing two fields w/ two identical arguments, and a tiny fix to the `sameArguments()` function within `rules_overlapping_fields_can_be_merged.go`.