### PR TITLE
Implement Object.Definition()

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -412,7 +412,7 @@ func (gt *Object) Name() string {
 	return gt.PrivateName
 }
 func (gt *Object) Description() string {
-	return ""
+	return gt.PrivateDescription
 }
 func (gt *Object) String() string {
 	return gt.PrivateName

--- a/definition_test.go
+++ b/definition_test.go
@@ -47,7 +47,8 @@ var blogAuthor = graphql.NewObject(graphql.ObjectConfig{
 	},
 })
 var blogArticle = graphql.NewObject(graphql.ObjectConfig{
-	Name: "Article",
+	Name:        "Article",
+	Description: "Blog article description",
 	Fields: graphql.Fields{
 		"id": &graphql.Field{
 			Type: graphql.String,
@@ -664,5 +665,17 @@ func TestTypeSystem_DefinitionExample_CanAddInputObjectField(t *testing.T) {
 	}
 	if _, ok := fieldMap["newValue"]; !ok {
 		t.Fatal("Unexpected result, inputObject should have a field named 'newValue'")
+	}
+}
+
+func TestTypeSystem_DefinitionExample_GetsObjectProperties(t *testing.T) {
+	if blogArticle.Name() != "Article" {
+		t.Fatalf("blogArticle.Name() expected to equal `Article`, got: %v", blogArticle.Name())
+	}
+	if blogArticle.String() != "Article" {
+		t.Fatalf("blogArticle.String() expected to equal `Article`, got: %v", blogArticle.String())
+	}
+	if blogArticle.Description() != "Blog article description" {
+		t.Fatalf("blogArticle.Description() expected to equal `Article`, got: %v", blogArticle.Description())
 	}
 }


### PR DESCRIPTION
The `Object.Definition()` method was stubbed to return an empty string. This PR makes it return `gt.PrivateDescription`.