### PR TITLE
Fix incorrect context hierarchy when using extensions

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -111,6 +111,14 @@ type executionContext struct {
 	Context        context.Context
 }
 
+// WithContext creates a shallow copy of the executionContext and replaces the embedded context.Context of the copy with ctx
+func (eCtx *executionContext) WithContext(ctx context.Context) *executionContext {
+	eCtx2 := new(executionContext)
+	*eCtx2 = *eCtx
+	eCtx2.Context = ctx
+	return eCtx2
+}
+
 func buildExecutionContext(p buildExecutionCtxParams) (*executionContext, error) {
 	eCtx := &executionContext{}
 	var operation *ast.OperationDefinition
@@ -638,7 +646,7 @@ func resolveField(eCtx *executionContext, parentType *Object, source interface{}
 
 	var resolveFnError error
 
-	extErrs, resolveFieldFinishFn := handleExtensionsResolveFieldDidStart(eCtx.Schema.extensions, eCtx, &info)
+	eCtx, extErrs, resolveFieldFinishFn := handleExtensionsResolveFieldDidStart(eCtx.Schema.extensions, eCtx, &info)
 	if len(extErrs) != 0 {
 		eCtx.Errors = append(eCtx.Errors, extErrs...)
 	}


### PR DESCRIPTION
When using an extension that creates new child contexts in `ResolveFieldDidStart` the resulting context hierarchy is wrong.

Given the query

```
query {
  a {
    foo
    bar
    baz
  }
}
```

the following context hierarchy would be created

```
a
|
+-> foo
    |
    +-> bar
        |
        +-> baz
```

So each context has the context of the previously executed field as a parent context.

This PR changes this so that the context in each field has the parent context of the parent field:

```
a
|
+-> foo
|    
+-> bar
|
+-> baz
```