### PR TITLE
Emit descriptions as block strings in `printer.Print`

### DIFF
--- a/language/printer/printer.go
+++ b/language/printer/printer.go
@@ -82,6 +82,9 @@ func getDescription(raw interface{}) string {
 		desc = getMapValueString(node, "Description.Value")
 	}
 	if desc != "" {
+		if strings.ContainsRune(desc, '\n') {
+
+		}
 		desc = fmt.Sprintf(`"""%s"""`, desc)
 	}
 	return desc

--- a/language/printer/printer.go
+++ b/language/printer/printer.go
@@ -70,6 +70,22 @@ func getMapValueString(m map[string]interface{}, key string) string {
 	}
 	return ""
 }
+func getDescription(raw interface{}) string {
+	var desc string
+
+	switch node := raw.(type) {
+	case ast.DescribableNode:
+		if sval := node.GetDescription(); sval != nil {
+			desc = sval.Value
+		}
+	case map[string]interface{}:
+		desc = getMapValueString(node, "Description.Value")
+	}
+	if desc != "" {
+		desc = fmt.Sprintf(`"""%s"""`, desc)
+	}
+	return desc
+}
 
 func toSliceString(slice interface{}) []string {
 	if slice == nil {
@@ -506,6 +522,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				fmt.Sprintf("%v", node.Name),
 				join(directives, " "),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -518,6 +537,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				name,
 				join(directives, " "),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -539,6 +561,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -555,6 +580,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -570,6 +598,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				directives = append(directives, fmt.Sprintf("%v", directive.Name))
 			}
 			str := name + wrap("(", join(args, ", "), ")") + ": " + ttype + wrap(" ", join(directives, " "), "")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -580,6 +611,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				directives = append(directives, fmt.Sprintf("%v", directive))
 			}
 			str := name + wrap("(", join(args, ", "), ")") + ": " + ttype + wrap(" ", join(directives, " "), "")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -599,7 +633,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				wrap("= ", defaultValue, ""),
 				join(directives, " "),
 			}, " ")
-
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, " ")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -614,6 +650,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				wrap("= ", defaultValue, ""),
 				join(directives, " "),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, " ")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -633,6 +672,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -647,6 +689,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -666,6 +711,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				"= " + join(types, " | "),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -680,6 +728,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				"= " + join(types, " | "),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -699,6 +750,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(values),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -713,6 +767,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(values),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -729,6 +786,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				name,
 				join(directives, " "),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -740,6 +800,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				name,
 				join(directives, " "),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -759,6 +822,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -773,6 +839,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -782,10 +851,16 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 		case *ast.TypeExtensionDefinition:
 			definition := fmt.Sprintf("%v", node.Definition)
 			str := "extend " + definition
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			definition := getMapValueString(node, "Definition")
 			str := "extend " + definition
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -795,6 +870,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 		case *ast.DirectiveDefinition:
 			args := wrap("(", join(toSliceString(node.Arguments), ", "), ")")
 			str := fmt.Sprintf("directive @%v%v on %v", node.Name, args, join(toSliceString(node.Locations), " | "))
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -802,6 +880,9 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 			args := toSliceString(getMapValue(node, "Arguments"))
 			argsStr := wrap("(", join(args, ", "), ")")
 			str := fmt.Sprintf("directive @%v%v on %v", name, argsStr, join(locations, " | "))
+			if desc := getDescription(node); desc != "" {
+				str = join([]string{desc, str}, "\n")
+			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil

--- a/language/printer/printer.go
+++ b/language/printer/printer.go
@@ -70,25 +70,6 @@ func getMapValueString(m map[string]interface{}, key string) string {
 	}
 	return ""
 }
-func getDescription(raw interface{}) string {
-	var desc string
-
-	switch node := raw.(type) {
-	case ast.DescribableNode:
-		if sval := node.GetDescription(); sval != nil {
-			desc = sval.Value
-		}
-	case map[string]interface{}:
-		desc = getMapValueString(node, "Description.Value")
-	}
-	if desc != "" {
-		if strings.ContainsRune(desc, '\n') {
-
-		}
-		desc = fmt.Sprintf(`"""%s"""`, desc)
-	}
-	return desc
-}
 
 func toSliceString(slice interface{}) []string {
 	if slice == nil {
@@ -525,9 +506,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				fmt.Sprintf("%v", node.Name),
 				join(directives, " "),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -540,9 +518,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				name,
 				join(directives, " "),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -564,9 +539,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -583,9 +555,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -601,9 +570,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				directives = append(directives, fmt.Sprintf("%v", directive.Name))
 			}
 			str := name + wrap("(", join(args, ", "), ")") + ": " + ttype + wrap(" ", join(directives, " "), "")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -614,9 +580,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				directives = append(directives, fmt.Sprintf("%v", directive))
 			}
 			str := name + wrap("(", join(args, ", "), ")") + ": " + ttype + wrap(" ", join(directives, " "), "")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -636,9 +599,7 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				wrap("= ", defaultValue, ""),
 				join(directives, " "),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, " ")
-			}
+
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -653,9 +614,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				wrap("= ", defaultValue, ""),
 				join(directives, " "),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, " ")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -675,9 +633,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -692,9 +647,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -714,9 +666,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				"= " + join(types, " | "),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -731,9 +680,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				"= " + join(types, " | "),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -753,9 +699,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(values),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -770,9 +713,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(values),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -789,9 +729,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				name,
 				join(directives, " "),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -803,9 +740,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				name,
 				join(directives, " "),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -825,9 +759,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -842,9 +773,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 				join(directives, " "),
 				block(fields),
 			}, " ")
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -854,16 +782,10 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 		case *ast.TypeExtensionDefinition:
 			definition := fmt.Sprintf("%v", node.Definition)
 			str := "extend " + definition
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			definition := getMapValueString(node, "Definition")
 			str := "extend " + definition
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil
@@ -873,9 +795,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 		case *ast.DirectiveDefinition:
 			args := wrap("(", join(toSliceString(node.Arguments), ", "), ")")
 			str := fmt.Sprintf("directive @%v%v on %v", node.Name, args, join(toSliceString(node.Locations), " | "))
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		case map[string]interface{}:
 			name := getMapValueString(node, "Name")
@@ -883,9 +802,6 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 			args := toSliceString(getMapValue(node, "Arguments"))
 			argsStr := wrap("(", join(args, ", "), ")")
 			str := fmt.Sprintf("directive @%v%v on %v", name, argsStr, join(locations, " | "))
-			if desc := getDescription(node); desc != "" {
-				str = join([]string{desc, str}, "\n")
-			}
 			return visitor.ActionUpdate, str
 		}
 		return visitor.ActionNoChange, nil

--- a/language/printer/schema_printer_test.go
+++ b/language/printer/schema_printer_test.go
@@ -124,3 +124,184 @@ directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, results))
 	}
 }
+
+func TestSchemaPrinter_PrintsAllDescriptions(t *testing.T) {
+	b, err := ioutil.ReadFile("../../schema-all-descriptions.graphql")
+	if err != nil {
+		t.Fatalf("unable to load schema-all-descriptions.graphql")
+	}
+
+	query := string(b)
+	astDoc := parse(t, query)
+	expected := `"""single line scalar description"""
+scalar ScalarSingleLine
+
+"""
+multi line
+
+scalar description
+"""
+scalar ScalarMultiLine
+
+"""single line object description"""
+type ObjectSingleLine {
+  no_description: ID
+  
+  """single line field description"""
+  single_line(a: ID, b: ID, c: ID, d: ID): ID
+  
+  """
+  multi line
+  
+  field description
+  """
+  multi_line(
+    a: ID
+    
+    """single line argument description"""
+    b: ID
+    
+    """
+    multi line
+    
+    field description
+    """
+    c: ID
+    d: ID
+  ): ID
+}
+
+"""
+multi line
+
+object description
+"""
+type ObjectMultiLine {
+  foo: ID
+}
+
+"""single line interface description"""
+interface InterfaceSingleLine {
+  no_description: ID
+  
+  """single line field description"""
+  single_line(a: ID, b: ID, c: ID, d: ID): ID
+  
+  """
+  multi line
+  
+  field description
+  """
+  multi_line(
+    a: ID
+    
+    """single line argument description"""
+    b: ID
+    
+    """
+    multi line
+    
+    argument description
+    """
+    c: ID
+    d: ID
+  ): ID
+}
+
+"""
+multi line
+
+interface description
+"""
+interface InterfaceMultiLine {
+  foo: ID
+}
+
+"""single line union description"""
+union UnionSingleLine = String | Int | Float | ID
+
+"""
+multi line
+
+union description
+"""
+union UnionSingleLine = String | Int | Float | ID
+
+"""single line enum description"""
+enum EnumSingleLine {
+  no_description
+  
+  """single line enum description"""
+  single_line
+  
+  """
+  multi line
+  
+  enum description
+  """
+  multi_line
+  again_no_description
+}
+
+"""
+multi line
+
+enum description
+"""
+enum EnumMultiLine {
+  foo
+}
+
+"""single line input description"""
+input InputSingleLine {
+  a: ID
+  
+  """single line argument description"""
+  b: ID
+  
+  """
+  multi line
+  
+  argument description
+  """
+  c: ID
+  d: ID
+}
+
+"""
+multi line
+
+input description
+"""
+input InputMultiLine {
+  foo: ID
+}
+
+"""single line directive description"""
+directive @DirectiveSingleLine(
+  a: ID
+  
+  """single line argument description"""
+  b: ID
+  
+  """
+  multi line
+  
+  argument description
+  """
+  c: ID
+  d: ID
+) on SCALAR
+
+"""
+multi line
+
+directive description
+"""
+directive @DirectiveMultiLine on SCALAR
+`
+	results := printer.Print(astDoc)
+	if !reflect.DeepEqual(expected, results) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, results))
+	}
+}

--- a/language/printer/schema_printer_test.go
+++ b/language/printer/schema_printer_test.go
@@ -58,10 +58,13 @@ func TestSchemaPrinter_PrintsKitchenSink(t *testing.T) {
   mutation: MutationType
 }
 
+"""object description"""
 type Foo implements Bar & Baz {
+  """one field description"""
   one: Type
   two(argument: InputType!): Type
-  three(argument: InputType, other: String): Int
+  three(argument: InputType, """arg description""" other: String): Int
+  """four field description"""
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
   six(argument: InputType = {key: "value"}): Type
@@ -71,6 +74,9 @@ type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
 
+"""interface description
+
+multiple lines"""
 interface Bar {
   one: Type
   four(argument: String = "string"): String
@@ -82,14 +88,18 @@ interface AnnotatedInterface @onInterface {
 
 union Feed = Story | Article | Advert
 
+"""union description"""
 union AnnotatedUnion @onUnion = A | B
 
+"""scalar description"""
 scalar CustomScalar
 
 scalar AnnotatedScalar @onScalar
 
+"""enum description"""
 enum Site {
   DESKTOP
+  """enum member description"""
   MOBILE
 }
 
@@ -98,8 +108,10 @@ enum AnnotatedEnum @onEnum {
   OTHER_VALUE
 }
 
+"""input description"""
 input InputType {
   key: String!
+  """input value description"""
   answer: Int = 42
 }
 
@@ -115,6 +127,7 @@ extend type Foo @onType {}
 
 type NoFields {}
 
+"""directive description"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/language/printer/schema_printer_test.go
+++ b/language/printer/schema_printer_test.go
@@ -58,13 +58,10 @@ func TestSchemaPrinter_PrintsKitchenSink(t *testing.T) {
   mutation: MutationType
 }
 
-"""object description"""
 type Foo implements Bar & Baz {
-  """one field description"""
   one: Type
   two(argument: InputType!): Type
-  three(argument: InputType, """arg description""" other: String): Int
-  """four field description"""
+  three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
   six(argument: InputType = {key: "value"}): Type
@@ -74,9 +71,6 @@ type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
 
-"""interface description
-
-multiple lines"""
 interface Bar {
   one: Type
   four(argument: String = "string"): String
@@ -88,18 +82,14 @@ interface AnnotatedInterface @onInterface {
 
 union Feed = Story | Article | Advert
 
-"""union description"""
 union AnnotatedUnion @onUnion = A | B
 
-"""scalar description"""
 scalar CustomScalar
 
 scalar AnnotatedScalar @onScalar
 
-"""enum description"""
 enum Site {
   DESKTOP
-  """enum member description"""
   MOBILE
 }
 
@@ -108,10 +98,8 @@ enum AnnotatedEnum @onEnum {
   OTHER_VALUE
 }
 
-"""input description"""
 input InputType {
   key: String!
-  """input value description"""
   answer: Int = 42
 }
 
@@ -127,7 +115,6 @@ extend type Foo @onType {}
 
 type NoFields {}
 
-"""directive description"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/schema-all-descriptions.graphql
+++ b/schema-all-descriptions.graphql
@@ -1,0 +1,170 @@
+# File: schema-all-descriptions.graphql
+
+"""single line scalar description"""
+scalar ScalarSingleLine
+
+"""
+multi line
+
+scalar description
+"""
+scalar ScalarMultiLine
+
+"""single line object description"""
+type ObjectSingleLine {
+  no_description: ID
+
+  """single line field description"""
+  single_line(a: ID, b: ID, c: ID, d: ID): ID
+
+  """
+  multi line
+
+  field description
+  """
+  multi_line(
+    a: ID
+
+    """single line argument description"""
+    b: ID
+
+    """
+    multi line
+
+    field description
+    """
+    c: ID
+    d: ID
+  ): ID
+}
+
+"""
+multi line
+
+object description
+"""
+type ObjectMultiLine {
+  foo: ID
+}
+
+"""single line interface description"""
+interface InterfaceSingleLine {
+  no_description: ID
+
+  """single line field description"""
+  single_line(a: ID, b: ID, c: ID, d: ID): ID
+
+  """
+  multi line
+
+  field description
+  """
+  multi_line(
+    a: ID
+
+    """single line argument description"""
+    b: ID
+
+    """
+    multi line
+
+    argument description
+    """
+    c: ID
+    d: ID
+  ): ID
+}
+
+"""
+multi line
+
+interface description
+"""
+interface InterfaceMultiLine {
+  foo: ID
+}
+
+"""single line union description"""
+union UnionSingleLine = String | Int | Float | ID
+
+"""
+multi line
+
+union description
+"""
+union UnionSingleLine = String | Int | Float | ID
+
+"""single line enum description"""
+enum EnumSingleLine {
+  no_description
+
+  """single line enum description"""
+  single_line
+
+  """
+  multi line
+
+  enum description
+  """
+  multi_line
+  again_no_description
+}
+
+"""
+multi line
+
+enum description
+"""
+enum EnumMultiLine {
+  foo
+}
+
+"""single line input description"""
+input InputSingleLine {
+  a: ID
+
+  """single line argument description"""
+  b: ID
+  
+  """
+  multi line
+
+  argument description
+  """
+  c: ID
+  d: ID
+}
+
+"""
+multi line
+
+input description
+"""
+input InputMultiLine {
+  foo: ID
+}
+
+"""single line directive description"""
+directive @DirectiveSingleLine(
+  a: ID
+
+  """single line argument description"""
+  b: ID
+
+  """
+  multi line
+
+  argument description
+  """
+  c: ID
+  d: ID
+) on SCALAR
+
+"""
+multi line
+
+directive description
+"""
+directive @DirectiveMultiLine on SCALAR
+
+

--- a/schema-all-descriptions.graphql
+++ b/schema-all-descriptions.graphql
@@ -166,5 +166,3 @@ multi line
 directive description
 """
 directive @DirectiveMultiLine on SCALAR
-
-

--- a/schema-kitchen-sink.graphql
+++ b/schema-kitchen-sink.graphql
@@ -5,10 +5,15 @@ schema {
   mutation: MutationType
 }
 
+"""
+object description
+"""
 type Foo implements Bar & Baz {
+  """one field description"""
   one: Type
   two(argument: InputType!): Type
-  three(argument: InputType, other: String): Int
+  three(argument: InputType, """arg description""" other: String): Int
+  """four field description"""
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
   six(argument: InputType = {key: "value"}): Type
@@ -18,6 +23,9 @@ type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
 
+"""interface description
+
+multiple lines"""
 interface Bar {
   one: Type
   four(argument: String = "string"): String
@@ -29,14 +37,18 @@ interface AnnotatedInterface @onInterface {
 
 union Feed = Story | Article | Advert
 
+"""union description"""
 union AnnotatedUnion @onUnion = A | B
 
+"""scalar description"""
 scalar CustomScalar
 
 scalar AnnotatedScalar @onScalar
 
+"""enum description"""
 enum Site {
   DESKTOP
+  """enum member description"""
   MOBILE
 }
 
@@ -45,8 +57,10 @@ enum AnnotatedEnum @onEnum {
   OTHER_VALUE
 }
 
+"""input description"""
 input InputType {
   key: String!
+  """input value description"""
   answer: Int = 42
 }
 
@@ -62,6 +76,7 @@ extend type Foo @onType {}
 
 type NoFields {}
 
+"""directive description"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include(if: Boolean!)

--- a/schema-kitchen-sink.graphql
+++ b/schema-kitchen-sink.graphql
@@ -5,15 +5,10 @@ schema {
   mutation: MutationType
 }
 
-"""
-object description
-"""
 type Foo implements Bar & Baz {
-  """one field description"""
   one: Type
   two(argument: InputType!): Type
-  three(argument: InputType, """arg description""" other: String): Int
-  """four field description"""
+  three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
   six(argument: InputType = {key: "value"}): Type
@@ -23,9 +18,6 @@ type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
 
-"""interface description
-
-multiple lines"""
 interface Bar {
   one: Type
   four(argument: String = "string"): String
@@ -37,18 +29,14 @@ interface AnnotatedInterface @onInterface {
 
 union Feed = Story | Article | Advert
 
-"""union description"""
 union AnnotatedUnion @onUnion = A | B
 
-"""scalar description"""
 scalar CustomScalar
 
 scalar AnnotatedScalar @onScalar
 
-"""enum description"""
 enum Site {
   DESKTOP
-  """enum member description"""
   MOBILE
 }
 
@@ -57,10 +45,8 @@ enum AnnotatedEnum @onEnum {
   OTHER_VALUE
 }
 
-"""input description"""
 input InputType {
   key: String!
-  """input value description"""
   answer: Int = 42
 }
 
@@ -76,7 +62,6 @@ extend type Foo @onType {}
 
 type NoFields {}
 
-"""directive description"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include(if: Boolean!)


### PR DESCRIPTION
Fixes https://github.com/graphql-go/graphql/issues/484

Adds description printing to the `printer.Print` method, with tests to verify.
Seeks to keep field/directive arguments inline if none among all siblings have a description.