### PR TITLE
Link to First Part of "Golang + GraphQL + Relay" Blog Posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ For more complex examples, refer to the [examples/](https://github.com/graphql-g
 | [dataloader](https://github.com/nicksrandall/dataloader) | [Nick Randall](https://github.com/nicksrandall) | [DataLoader](https://github.com/facebook/dataloader) implementation in Go. |
 
 ### Blog Posts
-- [Golang + GraphQL + Relay](http://wehavefaces.net/)
+- [Golang + GraphQL + Relay](https://wehavefaces.net/learn-golang-graphql-relay-1-e59ea174a902)
 


### PR DESCRIPTION
I noticed that this just links to the blog, and a couple of times, it made me think the link was broken and I ended up leaving not knowing to scroll down and still find the relevant blog.

I think it would be helpful to change this to link to the first post of the relevant blog series instead.