### PR TITLE
Compare all args when testing for Overlapping Fields

### DIFF
--- a/rules_known_argument_names_test.go
+++ b/rules_known_argument_names_test.go
@@ -111,7 +111,7 @@ func TestValidate_KnownArgumentNames_UnknownArgsAmongstKnownArgsWithSuggestions(
       }
     `, []gqlerrors.FormattedError{
 		testutil.RuleError(`Unknown argument "ddogCommand" on field "doesKnowCommand" of type "Dog". `+
-			`Did you mean "dogCommand"?`, 3, 25),
+			`Did you mean "dogCommand" or "nextDogCommand"?`, 3, 25),
 	})
 }
 func TestValidate_KnownArgumentNames_UnknownArgsDeeply(t *testing.T) {

--- a/rules_overlapping_fields_can_be_merged.go
+++ b/rules_overlapping_fields_can_be_merged.go
@@ -623,8 +623,8 @@ func sameArguments(args1 []*ast.Argument, args2 []*ast.Argument) bool {
 			}
 			if arg1Name == arg2Name {
 				foundArgs2 = arg2
+				break
 			}
-			break
 		}
 		if foundArgs2 == nil {
 			return false

--- a/rules_overlapping_fields_can_be_merged_test.go
+++ b/rules_overlapping_fields_can_be_merged_test.go
@@ -32,6 +32,14 @@ func TestValidate_OverlappingFieldsCanBeMerged_IdenticalFieldsWithIdenticalArgs(
       }
     `)
 }
+func TestValidate_OverlappingFieldsCanBeMerged_IdenticalFieldsWithMultipleIdenticalArgs(t *testing.T) {
+	testutil.ExpectPassesRule(t, graphql.OverlappingFieldsCanBeMergedRule, `
+      fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
+        doesKnowCommand(dogCommand: SIT nextDogCommand: DOWN)
+        doesKnowCommand(dogCommand: SIT nextDogCommand: DOWN)
+      }
+    `)
+}
 func TestValidate_OverlappingFieldsCanBeMerged_IdenticalFieldsWithIdenticalDirectives(t *testing.T) {
 	testutil.ExpectPassesRule(t, graphql.OverlappingFieldsCanBeMergedRule, `
       fragment mergeSameFieldsWithSameDirectives on Dog {

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -96,6 +96,9 @@ func init() {
 					"dogCommand": &graphql.ArgumentConfig{
 						Type: dogCommandEnum,
 					},
+					"nextDogCommand": &graphql.ArgumentConfig{
+						Type: dogCommandEnum,
+					},
 				},
 			},
 			"isHousetrained": &graphql.Field{


### PR DESCRIPTION
This is primarily a fix for the way an old version of relay will sometimes arrange duplicate fragments (in my understanding... which may be wrong - I've just cherry picked this back onto master today)

We (myself and @bencallaway) have run this for almost a year now and are trying to get back onto upstream and port some of our changes back.

Without this change, this is an example of the error we encounter (apologies for the very blurry screenshot).

![1571770211](https://user-images.githubusercontent.com/10286538/67319693-cd9c0180-f4fc-11e9-9e42-2fc7e031c650.png)
