### PR TITLE
Always call resolveFieldFinishFn even if an error occurs in resolve.

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -650,13 +650,13 @@ func resolveField(eCtx *executionContext, parentType *Object, source interface{}
 		Context: eCtx.Context,
 	})
 
-	if resolveFnError != nil {
-		panic(resolveFnError)
-	}
-
 	extErrs = resolveFieldFinishFn(result, resolveFnError)
 	if len(extErrs) != 0 {
 		eCtx.Errors = append(eCtx.Errors, extErrs...)
+	}
+
+	if resolveFnError != nil {
+		panic(resolveFnError)
 	}
 
 	completed := completeValueCatchingError(eCtx, returnType, fieldASTs, info, path, result)


### PR DESCRIPTION
Hello! We at New Relic are currently working to create an Extension for tracing GraphQL calls using this package.

One thing that I have noticed is that if your resolve field function returns an error, the `graphql.ResolveFieldFinishFunc` for that field is never called. This means that users will not see any metrics or data about this error or this work done despite it clearly having happened.

```go
"erred": &graphql.Field{
    Type: graphql.String,
    Resolve: func(p graphql.ResolveParams) (interface{}, error) {
        // because an error is returned here, the graphql.ResolveFieldFinishFunc
        // is never called and no segments or metrics are created for this work
        return "", errors.New("ooops")
    },
},
```

The fix is pretty simple, just call the finish func before panicking the error. This is similar to what is done for the other Extension methods (parse, validate, and execute) which all call their finish functions even if an error occurs.

Please let me know what you think. I'm happy to make any changes you request.