### PR TITLE
add nodejs express-graphql for playground example

### DIFF
--- a/examples/playground/.gitignore
+++ b/examples/playground/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*-lock.json

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -1,0 +1,48 @@
+# Express GraphQL playground
+
+This just to run an Express GraphQL client which uses proxy to call the go graphql server.
+Just an easy hack to show beautiful user interface.
+
+## Pre-Requisites
+
+Nodejs and NPM
+
+## How it works
+
+```bash
+cd examples/playground
+npm install
+
+go run main.go
+```
+
+## Complex Sample
+
+modify PLAYGROUND_PORT or GRAPHQL_PORT if you want:
+
+```go
+// main.go
+cmd.Env = append(os.Environ(),
+  fmt.Sprintf("GRAPHQL_PORT=%d", GRAPHQL_PORT),       // GRAPHQL_PORT
+  fmt.Sprintf("PLAYGROUND_PORT=%d", PLAYGROUND_PORT), // this value is used
+)
+```
+
+You can pass query schema:
+
+```go
+query := `
+  type Query {
+    hello: String
+  }
+`
+cmd := exec.Command("node", "index.js", query)
+```
+
+Once playground server will run you will see output like
+
+🚀 GraphQL Express playground server is running on: <http://localhost:8081/graphql>
+
+Open in browser:  [playground](http://localhost:8081/graphql)
+
+

--- a/examples/playground/index.js
+++ b/examples/playground/index.js
@@ -1,0 +1,43 @@
+const express = require("express");
+const axios = require("axios");
+const bodyparser = require("body-parser");
+const cors = require("cors");
+const { buildSchema } = require("graphql");
+const graphqlHTTP = require("express-graphql");
+let [query = ""] = process.argv.slice(2);
+if (!query.trim()) {
+  query = `
+  type Query {
+    hello: String
+  }
+`;
+}
+const schema = buildSchema(query);
+const PLAYGROUND_PORT = process.env.PLAYGROUND_PORT || 4000;
+const GRAPHQL_PORT = process.env.GRAPHQL_PORT || 8080;
+
+const app = express();
+
+app.use(cors());
+app.get(
+  "/graphql",
+  graphqlHTTP({
+    schema: schema,
+    rootValue: {},
+    graphiql: true,
+  })
+);
+app.post("/*", bodyparser.json(), (req, res) => {
+  const options = {
+    url: req.path,
+    baseURL: `http://localhost:${GRAPHQL_PORT}/`,
+    method: "get",
+    params: req.body,
+  };
+  axios(options).then(({ data }) => res.send(data));
+});
+app.listen(PLAYGROUND_PORT, () => {
+  console.log(
+    `🚀 GraphQL Express playground server is running on: http://localhost:${PLAYGROUND_PORT}/graphql`
+  );
+});

--- a/examples/playground/main.go
+++ b/examples/playground/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/testutil"
+)
+
+func main() {
+	GRAPHQL_PORT := 8080
+	PLAYGROUND_PORT := 8081
+	query := `
+  type Query {
+    hello: String
+  }
+`
+	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		result := graphql.Do(graphql.Params{
+			Schema:        testutil.StarWarsSchema,
+			RequestString: query,
+		})
+		json.NewEncoder(w).Encode(result)
+	})
+
+	cmd := exec.Command("node", "index.js", query)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("GRAPHQL_PORT=%d", GRAPHQL_PORT),       // GRAPHQL_PORT
+		fmt.Sprintf("PLAYGROUND_PORT=%d", PLAYGROUND_PORT), // this value is used
+	)
+	cmd.Stdout = os.Stdout
+	err := cmd.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("🚀 GraphQL Express playground server is running on: http://localhost:%d/graphql\n", PLAYGROUND_PORT)
+	fmt.Println("Now server is running on port 8080")
+	fmt.Println("Test with Get      : curl -g 'http://localhost:8080/graphql?query={hero{name}}'")
+
+	http.ListenAndServe(fmt.Sprintf(":%d", GRAPHQL_PORT), nil)
+
+	// if err := cmd.Run(); err != nil {
+	// 	log.Fatal(err)
+	// 	fmt.Printf("🚀 GraphQL Express playground server is running on: http://localhost:%d/graphql\n", PLAYGROUND_PORT)
+	// }
+	// 	// fmt.Printf("in all caps: %q\n", out.String())
+}

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "graphql-playground",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node .",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.19.2",
+    "body-parser": "^1.19.0",
+    "cors": "^2.8.5",
+    "express": "^4.17.1",
+    "express-graphql": "^0.9.0",
+    "graphql": "^15.0.0"
+  }
+}


### PR DESCRIPTION
This just an example to run an Express GraphQL client which uses proxy to call the go graphql server.
Just an easy hack to show beautiful user interface.﻿
