### PR TITLE
More easier to extend error

### DIFF
--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -52,11 +52,16 @@ func FormatError(err error) FormattedError {
 	case Error:
 		return FormatError(&err)
 	default:
-		return FormattedError{
+		ret := FormattedError{
 			Message:       err.Error(),
 			Locations:     []location.SourceLocation{},
 			originalError: err,
 		}
+
+		if extended, ok := err.(ExtendedError); ok {
+			ret.Extensions = extended.Extensions()
+		}
+		return ret
 	}
 }
 


### PR DESCRIPTION
we can return our custom error which imply interface gqlerrors.ExtendedError instead of new a sqlerrors.Error.