### PR TITLE
Spec conformance for errors

### DIFF
--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -13,7 +13,7 @@ type ExtendedError interface {
 
 type FormattedError struct {
 	Message       string                    `json:"message"`
-	Locations     []location.SourceLocation `json:"locations"`
+	Locations     []location.SourceLocation `json:"locations,omitempty"`
 	Path          []interface{}             `json:"path,omitempty"`
 	Extensions    map[string]interface{}    `json:"extensions,omitempty"`
 	originalError error


### PR DESCRIPTION
Do not emit JSON when there is no error locations

Just conform to the spec :
7.1.2 If an error can be associated to a particular point in the
requested GraphQL document, it should contain an entry with the key
locations....