### PR TITLE
Further flush out ability to auto-bind to functions and types.

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -1,0 +1,114 @@
+package graphql
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// Bind will create a Field around a function formatted a certain way, or any value.
+// The function can be formatted:
+// - func MyFunction(ctx *context.Context) (output *MyFunctionOutput, err error)
+// - func MyFunction(ctx *context.Context, input *MyFunctionInput) (output *MyFunctionOutput, err error)
+// The input type, if provided, will be bound to fields, and the output type will be automatically bound as well.
+func Bind(bindTo interface{}) *Field {
+	val := reflect.ValueOf(bindTo)
+	tipe := reflect.TypeOf(bindTo)
+	if tipe.Kind() == reflect.Func {
+		in := tipe.NumIn()
+		out := tipe.NumOut()
+
+		if in != 1 && in != 2 {
+			panic(fmt.Sprintf("Mismatch on number of arguments. Expected 1 or 2, got %d.", tipe.NumIn()))
+		}
+
+		if out != 1 && out != 2 {
+			panic(fmt.Sprintf("Mismatch on number of outputs. Expected 1 or 2, got %d.", tipe.NumOut()))
+		}
+
+		var inputType reflect.Type
+		if in == 1 {
+			inputType = reflect.TypeOf(struct{}{})
+		} else {
+			inputType = tipe.In(1)
+		}
+
+		if inputType.Kind() == reflect.Ptr {
+			inputType = inputType.Elem()
+		}
+		inputFields := BindFields(reflect.New(inputType).Interface())
+		queryArgs := FieldConfigArgument{}
+		for key, inputField := range inputFields {
+			queryArgs[key] = &ArgumentConfig{
+				Type: inputField.Type,
+			}
+		}
+
+		outputType := tipe.Out(0)
+		if outputType.Kind() == reflect.Ptr {
+			outputType = outputType.Elem()
+		}
+		output := BindType(outputType)
+
+		resolve := func(p ResolveParams) (data interface{}, err error) {
+			input := reflect.New(inputType).Interface()
+			j, err := json.Marshal(p.Args)
+
+			if err == nil {
+				err = json.Unmarshal(j, &input)
+			}
+
+			if err != nil {
+				return nil, err
+			}
+
+			var results []reflect.Value
+			if in == 1 {
+				// Simple field
+				results = val.Call([]reflect.Value{
+					reflect.ValueOf(&p.Context),
+				})
+			} else {
+				// Query with argument
+				results = val.Call([]reflect.Value{
+					reflect.ValueOf(&p.Context),
+					reflect.ValueOf(input),
+				})
+			}
+
+			if out == 2 && results[1].Interface() != nil {
+				// Error
+				err = results[1].Interface().(error)
+				return nil, err
+			} else {
+				// Success
+				result := results[0].Interface()
+				return result, nil
+			}
+		}
+
+		field := &Field{
+			Type:    output,
+			Resolve: resolve,
+			Args:    queryArgs,
+		}
+
+		return field
+	} else if tipe.Kind() == reflect.Struct {
+		fieldType := BindType(reflect.TypeOf(bindTo))
+		field := &Field{
+			Type: fieldType,
+			Resolve: func(p ResolveParams) (data interface{}, err error) {
+				return bindTo, nil
+			},
+		}
+		return field
+	} else {
+		return &Field{
+			Type: getGraphType(tipe),
+			Resolve: func(p ResolveParams) (data interface{}, err error) {
+				return bindTo, nil
+			},
+		}
+	}
+}

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,0 +1,156 @@
+package graphql_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/graphql-go/graphql"
+)
+
+type HelloOutput struct {
+	Message string `json:"message"`
+}
+
+func Hello(ctx *context.Context) (output *HelloOutput, err error) {
+	output = &HelloOutput{
+		Message: "Hello World",
+	}
+	return output, nil
+}
+
+type GreetingInput struct {
+	Name string `json:"name"`
+}
+
+type GreetingOutput struct {
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func Greeting(ctx *context.Context, input *GreetingInput) (output *GreetingOutput, err error) {
+	return &GreetingOutput{
+		Message:   fmt.Sprintf("Hello %s.", input.Name),
+		Timestamp: time.Now(),
+	}, nil
+}
+
+type FriendRecur struct {
+	Name    string        `json:"name"`
+	Friends []FriendRecur `json:"friends"`
+}
+
+func friends(ctx *context.Context) (output *FriendRecur) {
+	recursiveFriendRecur := FriendRecur{
+		Name: "Recursion",
+	}
+	recursiveFriendRecur.Friends = make([]FriendRecur, 2)
+	recursiveFriendRecur.Friends[0] = recursiveFriendRecur
+	recursiveFriendRecur.Friends[1] = recursiveFriendRecur
+
+	return &FriendRecur{
+		Name: "Alan",
+		Friends: []FriendRecur{
+			recursiveFriendRecur,
+			{
+				Name: "Samantha",
+				Friends: []FriendRecur{
+					{
+						Name: "Olivia",
+					},
+					{
+						Name: "Eric",
+					},
+				},
+			},
+			{
+				Name: "Brian",
+				Friends: []FriendRecur{
+					{
+						Name: "Windy",
+					},
+					{
+						Name: "Kevin",
+					},
+				},
+			},
+			{
+				Name: "Kevin",
+				Friends: []FriendRecur{
+					{
+						Name: "Sergei",
+					},
+					{
+						Name: "Michael",
+					},
+				},
+			},
+		},
+	}
+}
+
+func main() {
+	// Schema
+	fields := graphql.Fields{
+		"hello":    graphql.Bind(Hello),
+		"greeting": graphql.Bind(Greeting),
+		"friends":  graphql.Bind(friends),
+		"string":   graphql.Bind("Hello World"),
+		"number":   graphql.Bind(12345),
+		"float":    graphql.Bind(123.45),
+		"anonymous": graphql.Bind(struct {
+			SomeField string `json:"someField"`
+		}{
+			SomeField: "Some Value",
+		}),
+	}
+	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: fields}
+	schemaConfig := graphql.SchemaConfig{Query: graphql.NewObject(rootQuery)}
+	schema, err := graphql.NewSchema(schemaConfig)
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Query
+	query := `
+		{
+			hello {
+				message
+			}
+			greeting(name:"Alan") {
+				message
+				timestamp
+			}
+			friends {
+				name
+				friends {
+					name
+					friends {
+						name
+						friends {
+							name
+							friends {
+								name
+							}
+						}
+					}
+				}
+			}
+			string
+			number
+			float
+			anonymous {
+				someField
+			}
+		}
+	`
+	params := graphql.Params{Schema: schema, RequestString: query}
+	r := graphql.Do(params)
+	if len(r.Errors) > 0 {
+		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
+	}
+	rJSON, _ := json.MarshalIndent(r, "", "  ")
+	fmt.Printf("%s \n", rJSON)
+}

--- a/examples/bind-complex/main.go
+++ b/examples/bind-complex/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/graphql-go/graphql"
+)
+
+var people = []Person{
+	{
+		Name: "Alan",
+		Friends: []Person{
+			{
+				Name: "Nadeem",
+				Friends: []Person{
+					{
+						Name: "Heidi",
+					},
+				},
+			},
+		},
+	},
+}
+
+type Person struct {
+	Name    string   `json:"name"`
+	Friends []Person `json:"friends"`
+}
+
+type GetPersonInput struct {
+	Name string `json:"name"`
+}
+
+type GetPersonOutput struct {
+	Person
+}
+
+func GetPerson(ctx context.Context, input GetPersonInput) (*GetPersonOutput, error) {
+	for _, person := range people {
+		if person.Name == input.Name {
+			return &GetPersonOutput{
+				Person: person,
+			}, nil
+		}
+	}
+	return nil, errors.New("Could not find person.")
+}
+
+func main() {
+	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
+		"person": graphql.Bind(GetPerson),
+	}}
+
+	schemaConfig := graphql.SchemaConfig{Query: graphql.NewObject(rootQuery)}
+	schema, err := graphql.NewSchema(schemaConfig)
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Query
+	query := `
+	{
+		person(name: "Alan") {
+			name
+			friends {
+				name
+				friends {
+					name
+				}
+			}
+		}
+	}
+	`
+	params := graphql.Params{Schema: schema, RequestString: query}
+	r := graphql.Do(params)
+	if len(r.Errors) > 0 {
+		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
+	}
+	rJSON, _ := json.Marshal(r)
+	fmt.Printf("%s \n", rJSON)
+}

--- a/examples/bind-simple/main.go
+++ b/examples/bind-simple/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/graphql-go/graphql"
+)
+
+type GreetingInput struct {
+	Name string `json:"name"`
+}
+
+func Greeting(input GreetingInput) string {
+	return fmt.Sprintf("Hello %s", input.Name)
+}
+
+func main() {
+	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
+		"greeting": graphql.Bind(Greeting),
+	}}
+
+	schemaConfig := graphql.SchemaConfig{Query: graphql.NewObject(rootQuery)}
+	schema, err := graphql.NewSchema(schemaConfig)
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Query
+	query := `
+	{
+		greeting(name: "Alan")
+	}
+	`
+	params := graphql.Params{Schema: schema, RequestString: query}
+	r := graphql.Do(params)
+	if len(r.Errors) > 0 {
+		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
+	}
+	rJSON, _ := json.Marshal(r)
+	fmt.Printf("%s \n", rJSON)
+}

--- a/util.go
+++ b/util.go
@@ -13,7 +13,25 @@ var boundTypes = map[string]*Object{}
 var anonTypes = 0
 var timeType = reflect.TypeOf(time.Time{})
 
-func BindType(tipe reflect.Type) *Object {
+func BindType(tipe reflect.Type) Type {
+	if tipe.Kind() == reflect.Ptr {
+		tipe = tipe.Elem()
+	}
+
+	kind := tipe.Kind()
+	switch kind {
+	case reflect.String:
+		return String
+	case reflect.Int, reflect.Int8, reflect.Int32, reflect.Int64:
+		return Int
+	case reflect.Float32, reflect.Float64:
+		return Float
+	case reflect.Bool:
+		return Boolean
+	case reflect.Slice:
+		return getGraphList(tipe)
+	}
+
 	typeName := safeName(tipe)
 	object, ok := boundTypes[typeName]
 	if !ok {

--- a/util.go
+++ b/util.go
@@ -4,16 +4,41 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 )
 
 const TAG = "json"
 
-// can't take recursive slice type
-// e.g
-// type Person struct{
-//	Friends []Person
-// }
-// it will throw panic stack-overflow
+var boundTypes = map[string]*Object{}
+var anonTypes = 0
+var timeType = reflect.TypeOf(time.Time{})
+
+func BindType(tipe reflect.Type) *Object {
+	typeName := safeName(tipe)
+	object, ok := boundTypes[typeName]
+	if !ok {
+		// Allows for recursion
+		object = &Object{}
+		boundTypes[typeName] = object
+		*object = *NewObject(ObjectConfig{
+			Name:   typeName,
+			Fields: BindFields(reflect.New(tipe).Interface()),
+		})
+	}
+	return object
+}
+
+func safeName(tipe reflect.Type) string {
+	name := fmt.Sprint(tipe)
+	if strings.HasPrefix(name, "struct ") {
+		anonTypes++
+		name = fmt.Sprintf("Anon%d", anonTypes)
+	} else {
+		name = strings.Replace(fmt.Sprint(tipe), ".", "_", -1)
+	}
+	return name
+}
+
 func BindFields(obj interface{}) Fields {
 	t := reflect.TypeOf(obj)
 	v := reflect.ValueOf(obj)
@@ -39,17 +64,14 @@ func BindFields(obj interface{}) Fields {
 		}
 
 		var graphType Output
-		if fieldType.Kind() == reflect.Struct {
-			structFields := BindFields(v.Field(i).Interface())
-
+		if fieldType == timeType {
+			graphType = DateTime
+		} else if fieldType.Kind() == reflect.Struct {
 			if tag == "" {
-				fields = appendFields(fields, structFields)
+				fields = appendFields(fields, BindFields(v.Field(i).Interface()))
 				continue
 			} else {
-				graphType = NewObject(ObjectConfig{
-					Name:   tag,
-					Fields: structFields,
-				})
+				graphType = BindType(fieldType)
 			}
 		}
 
@@ -102,11 +124,7 @@ func getGraphList(tipe reflect.Type) *List {
 	}
 	// finally bind object
 	t := reflect.New(tipe.Elem())
-	name := strings.Replace(fmt.Sprint(tipe.Elem()), ".", "_", -1)
-	obj := NewObject(ObjectConfig{
-		Name:   name,
-		Fields: BindFields(t.Elem().Interface()),
-	})
+	obj := BindType(t.Elem().Type())
 	return NewList(obj)
 }
 


### PR DESCRIPTION
Hello, graphql-go authors. 

I began this PR because I encountered a bug in `BindFields` where the name given to a type would be the JSON field name, which resulted in conflicts. I was using that function to automatically bind functions, and create types, so that the resolver functions themselves could be reused as regular exported functions. 

I migrated that code into this project as well, as I feel it offers a significant improvement to dev experience. 

```go
type GreetingInput struct {
	Name string `json:"name"`
}

func Greeting(input GreetingInput) string {
	return fmt.Sprintf("Hello %s", input.Name)
}
...
rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
	"greeting": graphql.Bind(Greeting),
}}
```

or almost any manner of function along these lines:

```go
func MyFunction(ctx context.Context, input MyFunctionInput) (output MyFunctionOutput, error) ...
func MyFunction(ctx *context.Context, input *MyFunctionInput) (output *MyFunctionOutput, error) ...
func MyFunction(ctx context.Context) (output MyFunctionOutput, error) ...
func MyFunction(input MyFunctionInput) (output MyFunctionOutput, error) ...
func MyFunction(input MyFunctionInput) (output MyFunctionOutput) ...
func MyFunction() (output MyFunctionOutput) ...
func MyFunction() (output string) ...
```

or constant

```go
rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
	"version": graphql.Bind(1.1),
}}
```

Cheers!

-Alan 🤖