### PR TITLE
Further flush out ability to auto-bind to functions and types.

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -1,0 +1,187 @@
+package graphql
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+var ctxType = reflect.TypeOf((*context.Context)(nil)).Elem()
+var errType = reflect.TypeOf((*error)(nil)).Elem()
+
+/*
+	Bind will create a Field around a function formatted a certain way, or any value.
+
+	The input parameters can be, in any order,
+	- context.Context, or *context.Context (optional)
+	- An input struct, or pointer (optional)
+
+	The output parameters can be, in any order,
+	- A primitive, an output struct, or pointer (required for use in schema)
+	- error (optional)
+
+	Input or output types provided will be automatically bound using BindType.
+*/
+func Bind(bindTo interface{}) *Field {
+	val := reflect.ValueOf(bindTo)
+	tipe := reflect.TypeOf(bindTo)
+	if tipe.Kind() == reflect.Func {
+		in := tipe.NumIn()
+		out := tipe.NumOut()
+
+		var ctxIn *int
+		var inputIn *int
+
+		var errOut *int
+		var outputOut *int
+
+		queryArgs := FieldConfigArgument{}
+
+		if in > 2 {
+			panic(fmt.Sprintf("Mismatch on number of inputs. Expected 0, 1, or 2. got %d.", tipe.NumIn()))
+		}
+
+		if out > 2 {
+			panic(fmt.Sprintf("Mismatch on number of outputs. Expected 0, 1, or 2, got %d.", tipe.NumOut()))
+		}
+
+		// inTypes := make([]reflect.Type, in)
+		// outTypes := make([]reflect.Type, out)
+
+		for i := 0; i < in; i++ {
+			t := tipe.In(i)
+			if t.Kind() == reflect.Ptr {
+				t = t.Elem()
+			}
+			switch t {
+			case ctxType:
+				if ctxIn != nil {
+					panic(fmt.Sprintf("Unexpected multiple *context.Context inputs."))
+				}
+				ctxIn = intP(i)
+			default:
+				if inputIn != nil {
+					panic(fmt.Sprintf("Unexpected multiple inputs."))
+				}
+				inputType := tipe.In(i)
+				if inputType.Kind() == reflect.Ptr {
+					inputType = inputType.Elem()
+				}
+				inputFields := BindFields(reflect.New(inputType).Interface())
+				for key, inputField := range inputFields {
+					queryArgs[key] = &ArgumentConfig{
+						Type: inputField.Type,
+					}
+				}
+
+				inputIn = intP(i)
+			}
+		}
+
+		for i := 0; i < out; i++ {
+			t := tipe.Out(i)
+			switch t.String() {
+			case errType.String():
+				if errOut != nil {
+					panic(fmt.Sprintf("Unexpected multiple error outputs"))
+				}
+				errOut = intP(i)
+			default:
+				if outputOut != nil {
+					panic(fmt.Sprintf("Unexpected multiple outputs"))
+				}
+				outputOut = intP(i)
+			}
+		}
+
+		resolve := func(p ResolveParams) (output interface{}, err error) {
+			inputs := make([]reflect.Value, in)
+			if ctxIn != nil {
+				isPtr := tipe.In(*ctxIn).Kind() == reflect.Ptr
+				if isPtr {
+					inputs[*ctxIn] = reflect.ValueOf(&p.Context)
+				} else {
+					if p.Context == nil {
+						inputs[*ctxIn] = reflect.New(ctxType).Elem()
+					} else {
+						inputs[*ctxIn] = reflect.ValueOf(p.Context).Elem()
+					}
+				}
+			}
+			if inputIn != nil {
+				var inputType, baseType reflect.Type
+				inputType = tipe.In(*inputIn)
+				isPtr := tipe.In(*inputIn).Kind() == reflect.Ptr
+				if isPtr {
+					baseType = inputType.Elem()
+				} else {
+					baseType = inputType
+				}
+				input := reflect.New(baseType).Interface()
+				j, err := json.Marshal(p.Args)
+				if err == nil {
+					err = json.Unmarshal(j, &input)
+				}
+				if err != nil {
+					return nil, err
+				}
+
+				if isPtr {
+					inputs[*inputIn] = reflect.ValueOf(input)
+				} else {
+					if input == nil {
+						inputs[*inputIn] = reflect.New(baseType).Elem()
+					} else {
+						inputs[*inputIn] = reflect.ValueOf(input).Elem()
+					}
+				}
+			}
+
+			results := val.Call(inputs)
+			if errOut != nil {
+				val := results[*errOut].Interface()
+				if val != nil {
+					err = val.(error)
+				}
+			}
+			if outputOut != nil {
+				output = results[*outputOut].Interface()
+			}
+			return output, err
+		}
+
+		var outputType Output
+		if outputOut != nil {
+			outputType = BindType(tipe.Out(*outputOut))
+		}
+
+		field := &Field{
+			Type:    outputType,
+			Resolve: resolve,
+			Args:    queryArgs,
+		}
+
+		return field
+	} else if tipe.Kind() == reflect.Struct {
+		fieldType := BindType(reflect.TypeOf(bindTo))
+		field := &Field{
+			Type: fieldType,
+			Resolve: func(p ResolveParams) (data interface{}, err error) {
+				return bindTo, nil
+			},
+		}
+		return field
+	} else {
+		return &Field{
+			Type: getGraphType(tipe),
+			Resolve: func(p ResolveParams) (data interface{}, err error) {
+				return bindTo, nil
+			},
+		}
+	}
+}
+
+func intP(i int) *int {
+	return &i
+}

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,0 +1,214 @@
+package graphql_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/graphql-go/graphql"
+)
+
+type HelloOutput struct {
+	Message string `json:"message"`
+}
+
+func Hello(ctx *context.Context) (output *HelloOutput, err error) {
+	output = &HelloOutput{
+		Message: "Hello World",
+	}
+	return output, nil
+}
+
+type GreetingInput struct {
+	Name string `json:"name"`
+}
+
+type GreetingOutput struct {
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func GreetingPtr(ctx *context.Context, input *GreetingInput) (output *GreetingOutput, err error) {
+	return &GreetingOutput{
+		Message:   fmt.Sprintf("Hello %s.", input.Name),
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func Greeting(ctx context.Context, input GreetingInput) (output GreetingOutput, err error) {
+	return GreetingOutput{
+		Message:   fmt.Sprintf("Hello %s.", input.Name),
+		Timestamp: time.Now(),
+	}, nil
+}
+
+type FriendRecur struct {
+	Name    string        `json:"name"`
+	Friends []FriendRecur `json:"friends"`
+}
+
+func friends(ctx *context.Context) (output *FriendRecur) {
+	recursiveFriendRecur := FriendRecur{
+		Name: "Recursion",
+	}
+	recursiveFriendRecur.Friends = make([]FriendRecur, 2)
+	recursiveFriendRecur.Friends[0] = recursiveFriendRecur
+	recursiveFriendRecur.Friends[1] = recursiveFriendRecur
+
+	return &FriendRecur{
+		Name: "Alan",
+		Friends: []FriendRecur{
+			recursiveFriendRecur,
+			{
+				Name: "Samantha",
+				Friends: []FriendRecur{
+					{
+						Name: "Olivia",
+					},
+					{
+						Name: "Eric",
+					},
+				},
+			},
+			{
+				Name: "Brian",
+				Friends: []FriendRecur{
+					{
+						Name: "Windy",
+					},
+					{
+						Name: "Kevin",
+					},
+				},
+			},
+			{
+				Name: "Kevin",
+				Friends: []FriendRecur{
+					{
+						Name: "Sergei",
+					},
+					{
+						Name: "Michael",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestBindHappyPath(t *testing.T) {
+	// Schema
+	fields := graphql.Fields{
+		"hello":       graphql.Bind(Hello),
+		"greeting":    graphql.Bind(Greeting),
+		"greetingPtr": graphql.Bind(GreetingPtr),
+		"friends":     graphql.Bind(friends),
+		"string":      graphql.Bind("Hello World"),
+		"number":      graphql.Bind(12345),
+		"float":       graphql.Bind(123.45),
+		"anonymous": graphql.Bind(struct {
+			SomeField string `json:"someField"`
+		}{
+			SomeField: "Some Value",
+		}),
+		"simpleFunc": graphql.Bind(func() string {
+			return "Hello World"
+		}),
+	}
+	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: fields}
+	schemaConfig := graphql.SchemaConfig{Query: graphql.NewObject(rootQuery)}
+	schema, err := graphql.NewSchema(schemaConfig)
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Query
+	query := `
+		{
+			hello {
+				message
+			}
+			greeting(name:"Alan") {
+				message
+				timestamp
+			}
+			greetingPtr(name:"Alan") {
+				message
+				timestamp
+			}
+			friends {
+				name
+				friends {
+					name
+					friends {
+						name
+						friends {
+							name
+							friends {
+								name
+							}
+						}
+					}
+				}
+			}
+			string
+			number
+			float
+			anonymous {
+				someField
+			}
+			simpleFunc
+		}
+	`
+	params := graphql.Params{Schema: schema, RequestString: query}
+	r := graphql.Do(params)
+	if len(r.Errors) > 0 {
+		t.Errorf("failed to execute graphql operation, errors: %+v", r.Errors)
+	}
+}
+
+func TestBindPanicImproperInput(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected Bind to panic due to improper function signature")
+		}
+	}()
+	graphql.Bind(func(a, b, c string) {})
+}
+
+func TestBindPanicImproperOutput(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected Bind to panic due to improper function signature")
+		}
+	}()
+	graphql.Bind(func() (string, string) { return "Hello", "World" })
+}
+
+func TestBindWithRuntimeError(t *testing.T) {
+	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
+		"throwError": graphql.Bind(func() (string, error) {
+			return "", errors.New("Some Error")
+		}),
+	}}
+	schemaConfig := graphql.SchemaConfig{Query: graphql.NewObject(rootQuery)}
+	schema, err := graphql.NewSchema(schemaConfig)
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Query
+	query := `
+	{
+		throwError
+	}
+	`
+	params := graphql.Params{Schema: schema, RequestString: query}
+	r := graphql.Do(params)
+	if len(r.Errors) == 0 {
+		t.Error("Expected error")
+	}
+}

--- a/examples/bind-complex/main.go
+++ b/examples/bind-complex/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/graphql-go/graphql"
+)
+
+var people = []Person{
+	{
+		Name: "Alan",
+		Friends: []Person{
+			{
+				Name: "Nadeem",
+				Friends: []Person{
+					{
+						Name: "Heidi",
+					},
+				},
+			},
+		},
+	},
+}
+
+type Person struct {
+	Name    string   `json:"name"`
+	Friends []Person `json:"friends"`
+}
+
+type GetPersonInput struct {
+	Name string `json:"name"`
+}
+
+type GetPersonOutput struct {
+	Person
+}
+
+func GetPerson(ctx context.Context, input GetPersonInput) (*GetPersonOutput, error) {
+	for _, person := range people {
+		if person.Name == input.Name {
+			return &GetPersonOutput{
+				Person: person,
+			}, nil
+		}
+	}
+	return nil, errors.New("Could not find person.")
+}
+
+func main() {
+	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
+		"person": graphql.Bind(GetPerson),
+	}}
+
+	schemaConfig := graphql.SchemaConfig{Query: graphql.NewObject(rootQuery)}
+	schema, err := graphql.NewSchema(schemaConfig)
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Query
+	query := `
+	{
+		person(name: "Alan") {
+			name
+			friends {
+				name
+				friends {
+					name
+				}
+			}
+		}
+	}
+	`
+	params := graphql.Params{Schema: schema, RequestString: query}
+	r := graphql.Do(params)
+	if len(r.Errors) > 0 {
+		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
+	}
+	rJSON, _ := json.Marshal(r)
+	fmt.Printf("%s \n", rJSON)
+}

--- a/examples/bind-simple/main.go
+++ b/examples/bind-simple/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/graphql-go/graphql"
+)
+
+type GreetingInput struct {
+	Name string `json:"name"`
+}
+
+func Greeting(input GreetingInput) string {
+	return fmt.Sprintf("Hello %s", input.Name)
+}
+
+func main() {
+	rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
+		"greeting": graphql.Bind(Greeting),
+	}}
+
+	schemaConfig := graphql.SchemaConfig{Query: graphql.NewObject(rootQuery)}
+	schema, err := graphql.NewSchema(schemaConfig)
+	if err != nil {
+		log.Fatalf("failed to create new schema, error: %v", err)
+	}
+
+	// Query
+	query := `
+	{
+		greeting(name: "Alan")
+	}
+	`
+	params := graphql.Params{Schema: schema, RequestString: query}
+	r := graphql.Do(params)
+	if len(r.Errors) > 0 {
+		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
+	}
+	rJSON, _ := json.Marshal(r)
+	fmt.Printf("%s \n", rJSON)
+}


### PR DESCRIPTION
Hello, graphql-go authors. 

I began this PR because I encountered a bug in `BindFields` where the name given to a type would be the JSON field name, which resulted in conflicts. I was using that function to automatically bind functions, and create types, so that the resolver functions themselves could be reused as regular exported functions. 

I migrated that code into this project as well, as I feel it offers a significant improvement to dev experience. 

```go
type GreetingInput struct {
	Name string `json:"name"`
}

func Greeting(input GreetingInput) string {
	return fmt.Sprintf("Hello %s", input.Name)
}
...
rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
	"greeting": graphql.Bind(Greeting),
}}
```

or almost any manner of function along these lines:

```go
func MyFunction(ctx context.Context, input MyFunctionInput) (output MyFunctionOutput, error) ...
func MyFunction(ctx *context.Context, input *MyFunctionInput) (output *MyFunctionOutput, error) ...
func MyFunction(ctx context.Context) (output MyFunctionOutput, error) ...
func MyFunction(input MyFunctionInput) (output MyFunctionOutput, error) ...
func MyFunction(input MyFunctionInput) (output MyFunctionOutput) ...
func MyFunction() (output MyFunctionOutput) ...
func MyFunction() (output string) ...
```

or constant

```go
rootQuery := graphql.ObjectConfig{Name: "RootQuery", Fields: graphql.Fields{
	"version": graphql.Bind(1.1),
}}
```

Cheers!

-Alan 🤖