### PR TITLE
fix: error detection

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -1143,7 +1143,7 @@ func (gt *InputObject) defineFieldMap() InputObjectFieldMap {
 		if gt.err = invariantf(
 			fieldConfig.Type != nil,
 			`%v.%v field type must be Input Type but got: %v.`, gt, fieldName, fieldConfig.Type,
-		); err != nil {
+		); gt.err != nil {
 			return resultFieldMap
 		}
 		field := &InputObjectField{}


### PR DESCRIPTION
should check nullability of `gt.err` instead of local variable `err` which was checked before