### PR TITLE
examples/sql-nullstring: fix dropped error

### DIFF
--- a/examples/sql-nullstring/main.go
+++ b/examples/sql-nullstring/main.go
@@ -192,6 +192,9 @@ query {
 		log.Fatal(r1)
 	}
 	b1, err := json.MarshalIndent(r1, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
 	b2, err := json.MarshalIndent(r2, "", "  ")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This fixes a single dropped error variable.