### PR TITLE
Updated the link to the latest pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supports: queries, mutations & subscriptions.
 
 ### Documentation
 
-godoc: https://godoc.org/github.com/graphql-go/graphql
+godoc: https://pkg.go.dev/github.com/graphql-go/graphql
 
 ### Getting Started
 


### PR DESCRIPTION
As in https://blog.golang.org/godoc.org-redirect states that the new documentation link will be redirected.