### PR TITLE
Support thunks for Union.Types definitions

### DIFF
--- a/definition_test.go
+++ b/definition_test.go
@@ -519,6 +519,7 @@ func TestTypeSystem_DefinitionExample_ProhibitsNilTypeInUnions(t *testing.T) {
 		Name:  "BadUnion",
 		Types: []*graphql.Object{nil},
 	})
+	ttype.Types()
 	expected := `BadUnion may only contain Object types, it cannot contain: <nil>.`
 	if ttype.Error().Error() != expected {
 		t.Fatalf(`expected %v , got: %v`, expected, ttype.Error())
@@ -664,5 +665,44 @@ func TestTypeSystem_DefinitionExample_CanAddInputObjectField(t *testing.T) {
 	}
 	if _, ok := fieldMap["newValue"]; !ok {
 		t.Fatal("Unexpected result, inputObject should have a field named 'newValue'")
+	}
+}
+
+func TestTypeSystem_DefinitionExample_IncludesUnionTypesThunk(t *testing.T) {
+	someObject := graphql.NewObject(graphql.ObjectConfig{
+		Name: "SomeObject",
+		Fields: graphql.Fields{
+			"f": &graphql.Field{
+				Type: graphql.Int,
+			},
+		},
+	})
+
+	someOtherObject := graphql.NewObject(graphql.ObjectConfig{
+		Name: "SomeOtherObject",
+		Fields: graphql.Fields{
+			"g": &graphql.Field{
+				Type: graphql.Int,
+			},
+		},
+	})
+
+	someUnion := graphql.NewUnion(graphql.UnionConfig{
+		Name: "SomeUnion",
+		Types: (graphql.UnionTypesThunk)(func() []*graphql.Object {
+			return []*graphql.Object{someObject, someOtherObject}
+		}),
+		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+			return nil
+		},
+	})
+
+	unionTypes := someUnion.Types()
+
+	if someUnion.Error() != nil {
+		t.Fatalf("unexpected error, got: %v", someUnion.Error().Error())
+	}
+	if len(unionTypes) != 2 {
+		t.Fatalf("Unexpected result, someUnion should have two unionTypes, has %d", len(unionTypes))
 	}
 }


### PR DESCRIPTION
In schemas, it is possible to define the Union type before the
definitions of the object types that are part of the union. This
change adds a "UnionTypesThunk" option when creating a new Union,
similar to the existing FieldsThunk and InterfacesThunk.

This more closely matches the interface in graphql-js:
  https://github.com/graphql/graphql-js/blob/47bd8c8897c72d3efc17ecb1599a95cee6bac5e8/src/type/definition.ts#L1307

It is a first step in closing out https://github.com/graphql-go/graphql/issues/624