### PR TITLE
fix: input object with a nullable field set to null was being removed…

### DIFF
--- a/values.go
+++ b/values.go
@@ -156,11 +156,12 @@ func coerceValue(ttype Input, value interface{}) interface{} {
 		}
 
 		for name, field := range ttype.Fields() {
-			fieldValue := coerceValue(field.Type, valueMap[name])
+			value, presentInValueMap := valueMap[name]
+			fieldValue := coerceValue(field.Type, value)
 			if isNullish(fieldValue) {
 				fieldValue = field.DefaultValue
 			}
-			if !isNullish(fieldValue) {
+			if !isNullish(fieldValue) || presentInValueMap {
 				obj[name] = fieldValue
 			}
 		}

--- a/variables_test.go
+++ b/variables_test.go
@@ -319,6 +319,43 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexInput
 	}
 }
 
+func TestVariables_ObjectsAndNullability_UsingVariables_PassesNullWhenNoDefaultIsProvided(t *testing.T) {
+
+	doc := `
+	  query q($input: TestInputObject) {
+		fieldWithObjectInput(input: $input)
+	  }
+	`
+	params := map[string]interface{}{
+		"input": map[string]interface{}{
+			"a": nil,
+			"b": []string{"bar"},
+			"c": "baz",
+		},
+	}
+	expected := &graphql.Result{
+		Data: map[string]interface{}{
+			"fieldWithObjectInput": `{"a":null,"b":["bar"],"c":"baz"}`,
+		},
+	}
+
+	withDefaultsAST := testutil.TestParse(t, doc)
+
+	// execute
+	ep := graphql.ExecuteParams{
+		Schema: variablesTestSchema,
+		AST:    withDefaultsAST,
+		Args:   params,
+	}
+	result := testutil.TestExecute(t, ep)
+	if len(result.Errors) > 0 {
+		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
+	}
+	if !reflect.DeepEqual(expected, result) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
+	}
+}
+
 func TestVariables_ObjectsAndNullability_UsingVariables_UsesDefaultValueWhenNotProvided(t *testing.T) {
 
 	doc := `


### PR DESCRIPTION
… from the `Args` map given to a resolver.