### PR TITLE
Expose ParseValue

### DIFF
--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -79,8 +79,8 @@ func Parse(p ParseParams) (*ast.Document, error) {
 	return doc, nil
 }
 
-// TODO: test and expose parseValue as a public
-func parseValue(p ParseParams) (ast.Value, error) {
+// ParseValue parses params and returns ast value
+func ParseValue(p ParseParams) (ast.Value, error) {
 	var value ast.Value
 	var sourceObj *source.Source
 	switch src := p.Source.(type) {


### PR DESCRIPTION
This PR marks ParseValue as a public method that allows it to be called directly. It is handy to get AST value as part of pre-processing / validation.