### PR TITLE
fix postData's operationName on http-post example

### DIFF
--- a/examples/http-post/main.go
+++ b/examples/http-post/main.go
@@ -11,7 +11,7 @@ import (
 
 type postData struct {
 	Query     string                 `json:"query"`
-	Operation string                 `json:"operation"`
+	Operation string                 `json:"operationName"`
 	Variables map[string]interface{} `json:"variables"`
 }
 


### PR DESCRIPTION
As per graphql's documentation the field should be `operationName`[1]

1: https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#post