### PR TITLE
Add nullvalue

### DIFF
--- a/language/ast/values.go
+++ b/language/ast/values.go
@@ -19,6 +19,7 @@ var _ Value = (*BooleanValue)(nil)
 var _ Value = (*EnumValue)(nil)
 var _ Value = (*ListValue)(nil)
 var _ Value = (*ObjectValue)(nil)
+var _ Value = (*NullValue)(nil)
 
 // Variable implements Node, Value
 type Variable struct {
@@ -200,6 +201,39 @@ func (v *EnumValue) GetLoc() *Location {
 
 func (v *EnumValue) GetValue() interface{} {
 	return v.Value
+}
+
+// NullValue represents the GraphQL null value.
+//
+// It is used to support passing null as an input value.
+//
+// Reference: https://spec.graphql.org/October2021/#sec-Null-Value
+type NullValue struct {
+	Kind  string
+	Loc   *Location
+	Value interface{}
+}
+
+func NewNullValue(v *NullValue) *NullValue {
+	if v == nil {
+		v = &NullValue{}
+	}
+	return &NullValue{
+		Kind:  kinds.NullValue,
+		Loc:   v.Loc,
+		Value: nil,
+	}
+}
+func (n *NullValue) GetKind() string {
+	return n.Kind
+}
+
+func (n *NullValue) GetLoc() *Location {
+	return n.Loc
+}
+
+func (n *NullValue) GetValue() interface{} {
+	return n.Value
 }
 
 // ListValue implements Node, Value

--- a/language/kinds/kinds.go
+++ b/language/kinds/kinds.go
@@ -27,6 +27,7 @@ const (
 	ListValue    = "ListValue"
 	ObjectValue  = "ObjectValue"
 	ObjectField  = "ObjectField"
+	NullValue    = "NullValue"
 
 	// Directives
 	Directive = "Directive"

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -34,6 +34,7 @@ const (
 	STRING
 	BLOCK_STRING
 	AMP
+	NULL
 )
 
 var tokenDescription = map[TokenKind]string{
@@ -57,6 +58,7 @@ var tokenDescription = map[TokenKind]string{
 	STRING:       "String",
 	BLOCK_STRING: "BlockString",
 	AMP:          "&",
+	NULL:         "null",
 }
 
 func (kind TokenKind) String() string {

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -614,6 +614,14 @@ func parseValueLiteral(parser *Parser, isConst bool) (ast.Value, error) {
 				Value: token.Value,
 				Loc:   loc(parser, token.Start),
 			}), nil
+		} else {
+			// If the value literal in the GraphQL input is `null`, converts it into a NullValue AST node.
+			if err := advance(parser); err != nil {
+				return nil, err
+			}
+			return ast.NewNullValue(&ast.NullValue{
+				Loc: loc(parser, token.Start),
+			}), nil
 		}
 	case lexer.DOLLAR:
 		if !isConst {
@@ -1562,7 +1570,8 @@ func unexpectedEmpty(parser *Parser, beginLoc int, openKind, closeKind lexer.Tok
 	return gqlerrors.NewSyntaxError(parser.Source, beginLoc, description)
 }
 
-//  Returns list of parse nodes, determined by
+//	Returns list of parse nodes, determined by
+//
 // the parseFn. This list begins with a lex token of openKind
 // and ends with a lex token of closeKind. Advances the parser
 // to the next lex token after the closing token.

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -183,15 +183,6 @@ func TestDoesNotAcceptFragmentsSpreadOfOn(t *testing.T) {
 	testErrorMessage(t, test)
 }
 
-func TestDoesNotAllowNullAsValue(t *testing.T) {
-	test := errorMessageTest{
-		`{ fieldWithNullableStringInput(input: null) }'`,
-		`Syntax Error GraphQL (1:39) Unexpected Name "null"`,
-		false,
-	}
-	testErrorMessage(t, test)
-}
-
 func TestParsesMultiByteCharacters_Unicode(t *testing.T) {
 
 	doc := `

--- a/language/printer/printer.go
+++ b/language/printer/printer.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/lexer"
 	"github.com/graphql-go/graphql/language/visitor"
 )
 
@@ -472,7 +473,13 @@ var printDocASTReducer = map[string]visitor.VisitFunc{
 		}
 		return visitor.ActionNoChange, nil
 	},
-
+	"NullValue": func(p visitor.VisitFuncParams) (string, interface{}) {
+		switch p.Node.(type) {
+		case *ast.NullValue:
+			return visitor.ActionUpdate, lexer.NULL.String()
+		}
+		return visitor.ActionNoChange, nil
+	},
 	// Type System Definitions
 	"SchemaDefinition": func(p visitor.VisitFuncParams) (string, interface{}) {
 		switch node := p.Node.(type) {

--- a/language/printer/printer_test.go
+++ b/language/printer/printer_test.go
@@ -200,3 +200,17 @@ func TestPrinter_CorrectlyPrintsStringArgumentsWithProperQuoting(t *testing.T) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, results))
 	}
 }
+
+func TestPrinter_CorrectlyPrintsNullArgumentsWithProperQuoting(t *testing.T) {
+	queryAst := `query { foo(nullArg: null) }`
+	expected := `{
+  foo(nullArg: null)
+}
+`
+	astDoc := parse(t, queryAst)
+	results := printer.Print(astDoc)
+
+	if !reflect.DeepEqual(expected, results) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, results))
+	}
+}

--- a/language/printer/printer_test.go
+++ b/language/printer/printer_test.go
@@ -201,7 +201,7 @@ func TestPrinter_CorrectlyPrintsStringArgumentsWithProperQuoting(t *testing.T) {
 	}
 }
 
-func TestPrinter_CorrectlyPrintsNullArgumentsWithProperQuoting(t *testing.T) {
+func TestPrinter_CorrectlyPrintsNullArguments(t *testing.T) {
 	queryAst := `query { foo(nullArg: null) }`
 	expected := `{
   foo(nullArg: null)

--- a/rules.go
+++ b/rules.go
@@ -1735,6 +1735,11 @@ func isValidLiteralValue(ttype Input, valueAST ast.Value) (bool, []string) {
 		if valueAST.GetKind() == kinds.Variable {
 			return true, nil
 		}
+		// Supplying a nullable variable type to a non-null input type is considered invalid.
+		// nullValue is only valid for nullable input types.
+		if valueAST.GetKind() == kinds.NullValue {
+			return true, nil
+		}
 	}
 	switch ttype := ttype.(type) {
 	case *NonNull:
@@ -1742,7 +1747,7 @@ func isValidLiteralValue(ttype Input, valueAST ast.Value) (bool, []string) {
 		if e := ttype.Error(); e != nil {
 			return false, []string{e.Error()}
 		}
-		if valueAST == nil {
+		if valueAST == nil || valueAST.GetKind() == kinds.NullValue {
 			if ttype.OfType.Name() != "" {
 				return false, []string{fmt.Sprintf(`Expected "%v!", found null.`, ttype.OfType.Name())}
 			}

--- a/rules_arguments_of_correct_type_test.go
+++ b/rules_arguments_of_correct_type_test.go
@@ -8,6 +8,41 @@ import (
 	"github.com/graphql-go/graphql/testutil"
 )
 
+func TestValidate_ArgValuesOfCorrectType_ValidValue_GoodNullValue(t *testing.T) {
+	testutil.ExpectPassesRule(t, graphql.ArgumentsOfCorrectTypeRule, `
+        {
+          complicatedArgs {
+            intArgField(intArg: null)
+          }
+        }
+    `)
+}
+
+func TestValidator_NonNullArgsUsingNullValue(t *testing.T) {
+	testutil.ExpectFailsRule(t, graphql.ArgumentsOfCorrectTypeRule, `
+     {      
+          complicatedArgs {
+            nonNullIntArgField(nonNullIntArg: null)
+          }
+        }
+    `, []gqlerrors.FormattedError{
+		testutil.RuleError(
+			"Argument \"nonNullIntArg\" has invalid value null.\nExpected \"Int!\", found null.",
+			4, 47,
+		),
+	})
+}
+
+func TestValidator_NullArgsUsingNullValue(t *testing.T) {
+	testutil.ExpectPassesRule(t, graphql.ArgumentsOfCorrectTypeRule, `
+     {
+          complicatedArgs {
+            stringArgField(stringArg: null)
+          }
+        }
+    `)
+}
+
 func TestValidate_ArgValuesOfCorrectType_ValidValue_GoodIntValue(t *testing.T) {
 	testutil.ExpectPassesRule(t, graphql.ArgumentsOfCorrectTypeRule, `
         {

--- a/scalars.go
+++ b/scalars.go
@@ -163,6 +163,7 @@ var Int = NewScalar(ScalarConfig{
 				return intValue
 			}
 		}
+
 		return nil
 	},
 })
@@ -332,6 +333,9 @@ var String = NewScalar(ScalarConfig{
 })
 
 func coerceBool(value interface{}) interface{} {
+	if value == nil {
+		return nil
+	}
 	switch value := value.(type) {
 	case bool:
 		return value

--- a/scalars_test.go
+++ b/scalars_test.go
@@ -240,6 +240,10 @@ func TestCoerceInt(t *testing.T) {
 			in:   make(map[string]interface{}),
 			want: nil,
 		},
+		{
+			in:   nil,
+			want: nil,
+		},
 	}
 
 	for i, tt := range tests {
@@ -436,6 +440,10 @@ func TestCoerceFloat(t *testing.T) {
 		},
 		{
 			in:   make(map[string]interface{}),
+			want: nil,
+		},
+		{
+			in:   nil,
 			want: nil,
 		},
 	}
@@ -739,6 +747,10 @@ func TestCoerceBool(t *testing.T) {
 		{
 			in:   make(map[string]interface{}),
 			want: false,
+		},
+		{
+			in:   nil,
+			want: nil,
 		},
 	}
 

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -563,6 +563,7 @@ func expectValidRule(t *testing.T, schema *graphql.Schema, rules []graphql.Valid
 
 }
 func expectInvalidRule(t *testing.T, schema *graphql.Schema, rules []graphql.ValidationRuleFn, queryString string, expectedErrors []gqlerrors.FormattedError) {
+	t.Helper()
 	source := source.NewSource(&source.Source{
 		Body: []byte(queryString),
 	})
@@ -595,6 +596,7 @@ func ExpectPassesRule(t *testing.T, rule graphql.ValidationRuleFn, queryString s
 	expectValidRule(t, TestSchema, []graphql.ValidationRuleFn{rule}, queryString)
 }
 func ExpectFailsRule(t *testing.T, rule graphql.ValidationRuleFn, queryString string, expectedErrors []gqlerrors.FormattedError) {
+	t.Helper()
 	expectInvalidRule(t, TestSchema, []graphql.ValidationRuleFn{rule}, queryString, expectedErrors)
 }
 func ExpectFailsRuleWithSchema(t *testing.T, schema *graphql.Schema, rule graphql.ValidationRuleFn, queryString string, expectedErrors []gqlerrors.FormattedError) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -45,6 +45,7 @@ func TestValidator_SupportsFullValidation_ValidatesQueries(t *testing.T) {
     `)
 }
 
+
 // NOTE: experimental
 func TestValidator_SupportsFullValidation_ValidatesUsingACustomTypeInfo(t *testing.T) {
 


### PR DESCRIPTION
Description:

I have noticed that the go-graphql project does not handle null values for input correctly. According to the GraphQL specification [GraphQL Spec](https://spec.graphql.org/October2021/#sec-Null-Value), there are two scenarios for handling null values in inputs:

1. When the input is required, null is not an acceptable value.
2. When the input parameter is optional, the null literal is acceptable.

For example, the following is not allowed:

Def:

``` graphql
NonNullField(arg: String!): String

```
Use:
``` graphql
{
    NonNullField(arg: null) // not allowed
}

```

After completing my changes, I found that @krasish has done similar work in pull request #683 , which has not yet been merged.

Please review this implementation, thank you very much.
