### PR TITLE
fix: `DefaultResolveFn` should handle with `map[K]V` for `K` that has `string` as the underlying type

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -995,7 +995,7 @@ func DefaultResolveFn(p ResolveParams) (interface{}, error) {
 
 	// Try accessing as map via reflection
 	if r := reflect.ValueOf(p.Source); r.Kind() == reflect.Map && r.Type().Key().Kind() == reflect.String {
-		val := r.MapIndex(reflect.ValueOf(p.Info.FieldName).Convert(r.Type().Key()))
+		val := r.MapIndex(reflect.ValueOf(p.Info.FieldName))
 		if val.IsValid() {
 			property := val.Interface()
 			if val.Type().Kind() == reflect.Func {

--- a/executor.go
+++ b/executor.go
@@ -995,7 +995,7 @@ func DefaultResolveFn(p ResolveParams) (interface{}, error) {
 
 	// Try accessing as map via reflection
 	if r := reflect.ValueOf(p.Source); r.Kind() == reflect.Map && r.Type().Key().Kind() == reflect.String {
-		val := r.MapIndex(reflect.ValueOf(p.Info.FieldName))
+		val := r.MapIndex(reflect.ValueOf(p.Info.FieldName).Convert(r.Type().Key()))
 		if val.IsValid() {
 			property := val.Interface()
 			if val.Type().Kind() == reflect.Func {


### PR DESCRIPTION
The current implementation returns the following errors for maps with a custom type for keys:

```
reflect.Value.MapIndex: value of type string is not assignable to type .*
```