### PR TITLE
fixed_unicode: lexer increases runePosition by charWidth

### DIFF
--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -625,7 +625,7 @@ func positionAfterWhitespace(body []byte, startPosition int) (position int, rune
 						// SourceCharacter but not LineTerminator
 						(code > 0x001F || code == 0x0009) && code != 0x000A && code != 0x000D {
 						position += n
-						runePosition++
+						runePosition += n
 						continue
 					} else {
 						break

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -1069,3 +1069,25 @@ func TestLexer_ReportsUsefulInformationForDashesInNames(t *testing.T) {
 		t.Fatalf("unexpected error, token:%v\nexpected:\n%v\n\ngot:\n%v", token, errExpected, err.Error())
 	}
 }
+
+func TestLexer_CommentUnicodeSuccessful(t *testing.T) {
+
+	q := `
+		# Some german Letters: ÄÖÜ
+		enum UserType {
+			USER
+			ADMIN
+		}
+	`
+	lexer := Lex(createSource(q))
+	for {
+		token, err := lexer(0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if token.Kind == EOF {
+			break
+		}
+	}
+}


### PR DESCRIPTION
this one fixes #701

basically its a small fix where the lexer increased the runePosition by 1 instead of charWidth. After this change my initial problem is fixed.