### PR TITLE
Fix panic in DefaultResolveFn if uses the string type alias in source key

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/graphql-go/graphql/testutil"
 )
 
+func TestDefaultResolveFn(t *testing.T) {
+	type Key string
+	type Source map[Key]interface{}
+	source := Source{
+		"foo": "bar",
+	}
+	graphql.DefaultResolveFn(graphql.ResolveParams{
+		Source: source,
+	})
+}
+
 func TestExecutesArbitraryCode(t *testing.T) {
 
 	deepData := map[string]interface{}{}


### PR DESCRIPTION
This closes #700.