### PR TITLE
fix: Preserve Extensions in FormattedError during concurrent execution

### DIFF
--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -47,6 +47,9 @@ func FormatError(err error) FormattedError {
 			if extended, ok := err.(ExtendedError); ok {
 				ret.Extensions = extended.Extensions()
 			}
+			if formatted, ok := err.(FormattedError); ok {
+				ret.Extensions = formatted.Extensions
+			}
 		}
 		return ret
 	case Error:


### PR DESCRIPTION
When resolving fields concurrently, error extensions are lost in the error handling chain. 
This happens because:
1. The error is converted to `FormattedError` in `completeThunkValueCatchingError` through panic/recover flow
2. In `newLocatedError`, the `OriginalError` is set to a new `*gqlerrors.Error` created from the `FormattedError`
3. During `FormatError`, the extensions from the `FormattedError` are lost