### PR TITLE
modify make token by byte position, not rune position at readName

### DIFF
--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -129,7 +129,7 @@ func readName(source *source.Source, position, runePosition int) Token {
 			break
 		}
 	}
-	return makeToken(NAME, runePosition, endRune, string(body[position:endByte]))
+	return makeToken(NAME, position, endByte, string(body[position:endByte]))
 }
 
 // Reads a number token from the source file, either a float

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -91,8 +91,8 @@ func TestLexer_AcceptsBOMHeader(t *testing.T) {
 			Body: "\uFEFF foo",
 			Expected: Token{
 				Kind:  NAME,
-				Start: 2,
-				End:   5,
+				Start: 4,
+				End:   7,
 				Value: "foo",
 			},
 		},

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -498,6 +498,19 @@ func TestParsesEnumValueDefinitionWithDescription(t *testing.T) {
 	}
 }
 
+func TestParsesTypeDefinitionWithMultiByteCharactersComment_UnicodeText(t *testing.T) {
+	source := `
+	    # This comment has a фы世界 character.
+	    type Foo implements Bar {
+	        foo: String!
+	    }
+	`
+	_, err := Parse(ParseParams{Source: source})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDefinitionsWithDescriptions(t *testing.T) {
 	testCases := []struct {
 		name            string


### PR DESCRIPTION
Incorporating the patch from this fork into our fork, which fixes a lexing bug with multi-byte comment sequences: https://github.com/graphql-go/graphql/pull/605