### PR TITLE
{types,graphql_test}: Adds `Result.ErrorsJoined` implementation.

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2,10 +2,12 @@ package graphql_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/testutil"
 )
 
@@ -267,4 +269,33 @@ func TestEmptyStringIsNotNull(t *testing.T) {
 	if !reflect.DeepEqual(result.Data, expected) {
 		t.Errorf("wrong result, query: %v, graphql result diff: %v", query, testutil.Diff(expected, result))
 	}
+}
+
+func TestResultErrorsJoinedFailure(t *testing.T) {
+	r := graphql.Result{}
+
+	if err := r.ErrorsJoined(); err != nil {
+		t.Fatalf("wrong result, want: nil, got: %v", err)
+	}
+}
+
+func TestResultErrorsJoinedSuccess(t *testing.T) {
+	r := graphql.Result{
+		Errors: []gqlerrors.FormattedError{
+			{Message: "first error"},
+			{Message: "second error"},
+		},
+	}
+
+	expected := errors.New("second error: first error")
+
+	if err := r.ErrorsJoined(); err != nil {
+		if !reflect.DeepEqual(err.Error(), expected.Error()) {
+			t.Fatalf("wrong result, want: %v, got: %v", expected, err)
+		}
+
+		return
+	}
+
+	t.Fatalf("wrong result, got: nil, want: %v", expected)
 }

--- a/types.go
+++ b/types.go
@@ -1,6 +1,8 @@
 package graphql
 
 import (
+	"fmt"
+
 	"github.com/graphql-go/graphql/gqlerrors"
 )
 
@@ -16,4 +18,24 @@ type Result struct {
 // HasErrors just a simple function to help you decide if the result has errors or not
 func (r *Result) HasErrors() bool {
 	return len(r.Errors) > 0
+}
+
+// ErrorsJoined joins and returns the result errors.
+func (r *Result) ErrorsJoined() error {
+	if r.Errors == nil {
+		return nil
+	}
+
+	var result error
+	for _, err := range r.Errors {
+		if result == nil {
+			result = fmt.Errorf("%w", err)
+
+			continue
+		}
+
+		result = fmt.Errorf("%w: %w", err, result)
+	}
+
+	return result
 }


### PR DESCRIPTION
#### Details
- `types`: adds `Result.ErrorsJoined` method.
- `graphql_test`: adds `Result.ErrorsJoined` 100& test coverage unit tests.

Added in order to be able to join errors because currently `Result.Errors` returns an slice of errors and is common use case to have it consolidated into a single error.


#### Test Plan
:heavy_check_mark: Tested that `Result.ErrorsJoined` works as expected via `go test -cover ...`:

```
go clean -testcache && go test -cover -coverprofile=coverage.out ./... && go tool cover -html=coverage.out -o coverage.html; sed -i'' -e's/black/whitesmoke/g' coverage.html && open coverage.html
```

![Screenshot from 2025-03-28 16-11-33](https://github.com/user-attachments/assets/6bd756f9-3dc4-4e42-bb09-67ef2bacb163)

