### PR TITLE
fix(rules): match spec for defaulted required args

### DIFF
--- a/rules_variables_in_allowed_position_test.go
+++ b/rules_variables_in_allowed_position_test.go
@@ -244,3 +244,13 @@ func TestValidate_VariablesInAllowedPosition_StringToNonNullableBooleanInDirecti
 			`expecting type "Boolean!".`, 2, 19, 3, 26),
 	})
 }
+func TestValidate_VariablesInAllowedPosition_IntToNonNullableIntArgDefaulted(t *testing.T) {
+	testutil.ExpectPassesRule(t, graphql.VariablesInAllowedPositionRule, `
+      query Query($intArg: Int)
+      {
+        complicatedArgs {
+          nonNullIntArgFieldWithDefault(nonNullIntArgWithDefault: $intArg)
+        }
+      }
+    `)
+}

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -316,6 +316,15 @@ func init() {
 					},
 				},
 			},
+			"nonNullIntArgFieldWithDefault": &graphql.Field{
+				Type: graphql.String,
+				Args: graphql.FieldConfigArgument{
+					"nonNullIntArgWithDefault": &graphql.ArgumentConfig{
+						Type:         graphql.NewNonNull(graphql.Int),
+						DefaultValue: 1,
+					},
+				},
+			},
 			"stringArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{

--- a/validator.go
+++ b/validator.go
@@ -238,9 +238,13 @@ func (ctx *ValidationContext) VariableUsages(node HasSelectionSet) []*VariableUs
 			kinds.Variable: {
 				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
 					if node, ok := p.Node.(*ast.Variable); ok && node != nil {
+						inputType := typeInfo.InputType()
+						if nonNull, ok := inputType.(*NonNull); ok && typeInfo.argument != nil && typeInfo.argument.DefaultValue != nil {
+							inputType = nonNull.OfType
+						}
 						usages = append(usages, &VariableUsage{
 							Node: node,
-							Type: typeInfo.InputType(),
+							Type: inputType,
 						})
 					}
 					return visitor.ActionNoChange, nil


### PR DESCRIPTION
This adds a new test, that fails on master, alongside with the correct changes for it to work as expected.

The validation was failing for arguments that are defined as required, but have a default value, preventing a non-required argument to override their value, while it should work as expected.