### PR TITLE
default value fixes

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -1243,8 +1243,8 @@ func PossibleFragmentSpreadsRule(context *ValidationContext) *ValidationRuleInst
 
 // ProvidedNonNullArgumentsRule Provided required arguments
 //
-// A field or directive is only valid if all required (non-null) field arguments
-// have been provided.
+// A field or directive is only valid if all required (non-null without a
+// default value) field arguments have been provided.
 func ProvidedNonNullArgumentsRule(context *ValidationContext) *ValidationRuleInstance {
 
 	visitorOpts := &visitor.VisitorOptions{
@@ -1271,7 +1271,7 @@ func ProvidedNonNullArgumentsRule(context *ValidationContext) *ValidationRuleIns
 						for _, argDef := range fieldDef.Args {
 							argAST, _ := argASTMap[argDef.Name()]
 							if argAST == nil {
-								if argDefType, ok := argDef.Type.(*NonNull); ok {
+								if argDefType, ok := argDef.Type.(*NonNull); ok && argDef.DefaultValue == nil {
 									fieldName := ""
 									if fieldAST.Name != nil {
 										fieldName = fieldAST.Name.Value
@@ -1312,7 +1312,7 @@ func ProvidedNonNullArgumentsRule(context *ValidationContext) *ValidationRuleIns
 						for _, argDef := range directiveDef.Args {
 							argAST, _ := argASTMap[argDef.Name()]
 							if argAST == nil {
-								if argDefType, ok := argDef.Type.(*NonNull); ok {
+								if argDefType, ok := argDef.Type.(*NonNull); ok && argDef.DefaultValue == nil {
 									directiveName := ""
 									if directiveAST.Name != nil {
 										directiveName = directiveAST.Name.Value

--- a/rules_provided_non_null_arguments_test.go
+++ b/rules_provided_non_null_arguments_test.go
@@ -175,3 +175,65 @@ func TestValidate_ProvidedNonNullArguments_DirectiveArguments_WithDirectiveWithM
 		testutil.RuleError(`Directive "@skip" argument "if" of type "Boolean!" is required but not provided.`, 4, 18),
 	})
 }
+
+func TestValidate_ProvidedNonNullArguments_FieldArguments_NoErrorOnNonNullArgumentWithDefaultValue(t *testing.T) {
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: graphql.NewObject(graphql.ObjectConfig{
+			Name: "Query",
+			Fields: graphql.Fields{
+				"fieldWithDefault": &graphql.Field{
+					Type: graphql.String,
+					Args: graphql.FieldConfigArgument{
+						"arg": &graphql.ArgumentConfig{
+							Type:         graphql.NewNonNull(graphql.Boolean),
+							DefaultValue: true,
+						},
+					},
+				},
+			},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error, got: %v", err)
+	}
+	testutil.ExpectPassesRuleWithSchema(t, &schema, graphql.ProvidedNonNullArgumentsRule, `
+        {
+          fieldWithDefault
+        }
+    `)
+}
+
+func TestValidate_ProvidedNonNullArguments_DirectiveArguments_NoErrorOnNonNullArgumentWithDefaultValue(t *testing.T) {
+	deferDirective := graphql.NewDirective(graphql.DirectiveConfig{
+		Name: "defer",
+		Locations: []string{
+			graphql.DirectiveLocationFragmentSpread,
+			graphql.DirectiveLocationInlineFragment,
+		},
+		Args: graphql.FieldConfigArgument{
+			"if": &graphql.ArgumentConfig{
+				Type:         graphql.NewNonNull(graphql.Boolean),
+				DefaultValue: true,
+			},
+		},
+	})
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: graphql.NewObject(graphql.ObjectConfig{
+			Name: "Query",
+			Fields: graphql.Fields{
+				"a": &graphql.Field{Type: graphql.String},
+			},
+		}),
+		Directives: []*graphql.Directive{deferDirective},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error, got: %v", err)
+	}
+	testutil.ExpectPassesRuleWithSchema(t, &schema, graphql.ProvidedNonNullArgumentsRule, `
+        {
+          ... on Query @defer {
+            a
+          }
+        }
+    `)
+}


### PR DESCRIPTION
Hi there! I'm the maintainer of [graphql-conformance](https://jbellenger.github.io/graphql-conformance/#), a GraphQL verifier similar to [thesis-graphql-go](https://github.com/chris-ramon/thesis-graphql-go). 

I noticed that graphql-go has a couple of deviations from the spec and I thought I might be able to contribute a fix for one of the easy ones (see [graphql-go's conformance page](https://jbellenger.github.io/graphql-conformance/#/impl/graphql-go) for other gaps).

This PR fixes an issue that prevents arguments with non-nullable types from having default values.

For example, in this configuration:
```graphql
# schema
type Query { x(y:Int! = 0): Int }

# query
{ x }
```

graphql-go returns this error:
```json
  {
    "data": null,
    "errors": [
      {
        "message": "Field \"x\" argument \"y\" of type \"Int!\" is required but not provided.",
        "locations": [
          {
            "line": 1,
            "column": 3
          }
        ]
      }
    ]
  }
```

With this PR applied, the above query now returns:
```json
  {
    "data": {
      "x": 0
    }
  }
```

This kind of usage is explicitly allowed by section [5.4.3](https://spec.graphql.org/draft/#sel-IALTJDBBFCAAFFFFBA0wa) of the graphql-spec:
> An argument is required if the argument type is non-null and does not have a default value. Otherwise, the argument is optional

Thank you for considering this PR! I'm not familiar with this code-base or its conventions, so please feel free to point out any issue no matter how small.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL argument validation to correctly recognize that non-null arguments with default values should not be required when omitted. This prevents false validation errors for properly defined schema arguments.

* **Tests**
  * Added test coverage for both field arguments and directive arguments with default values to ensure validation behaves correctly in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->