### PR TITLE
fix: terminate overlapping-fields rule on cyclic fragment spreads

### DIFF
--- a/rules_overlapping_fields_can_be_merged.go
+++ b/rules_overlapping_fields_can_be_merged.go
@@ -50,6 +50,12 @@ func OverlappingFieldsCanBeMergedRule(context *ValidationContext) *ValidationRul
 	// dramatically improve the performance of this validator.
 	comparedSet := newPairSet()
 
+	// Memoizes (fields, fragment, areMutuallyExclusive) triples that have
+	// been compared by collectConflictsBetweenFieldsAndFragment in this
+	// validation pass. Subsequent calls on the same triple return without
+	// re-walking the fragment.
+	comparedFieldsAndFragmentSet := newFieldsAndFragmentSet()
+
 	// A cache for the "field map" and list of fragment names found in any given
 	// selection set. Selection sets may be asked for this information multiple
 	// times, so this improves the performance of this validator.
@@ -63,9 +69,10 @@ func OverlappingFieldsCanBeMergedRule(context *ValidationContext) *ValidationRul
 						parentType, _ := context.ParentType().(Named)
 
 						rule := &overlappingFieldsCanBeMergedRule{
-							context:     context,
-							comparedSet: comparedSet,
-							cacheMap:    cacheMap,
+							context:                      context,
+							comparedSet:                  comparedSet,
+							comparedFieldsAndFragmentSet: comparedFieldsAndFragmentSet,
+							cacheMap:                     cacheMap,
 						}
 						conflicts := rule.findConflictsWithinSelectionSet(parentType, selectionSet)
 						if len(conflicts) > 0 {
@@ -154,6 +161,12 @@ type overlappingFieldsCanBeMergedRule struct {
 	// dramatically improve the performance of this validator.
 	comparedSet *pairSet
 
+	// Memoizes (fields, fragment, areMutuallyExclusive) triples that have
+	// been compared by collectConflictsBetweenFieldsAndFragment in this
+	// validation pass. Subsequent calls on the same triple return without
+	// re-walking the fragment.
+	comparedFieldsAndFragmentSet *fieldsAndFragmentSet
+
 	// A cache for the "field map" and list of fragment names found in any given
 	// selection set. Selection sets may be asked for this information multiple
 	// times, so this improves the performance of this validator.
@@ -192,12 +205,23 @@ func (rule *overlappingFieldsCanBeMergedRule) findConflictsWithinSelectionSet(pa
 // Collect all conflicts found between a set of fields and a fragment reference
 // including via spreading in any nested fragments.
 func (rule *overlappingFieldsCanBeMergedRule) collectConflictsBetweenFieldsAndFragment(conflicts []conflict, areMutuallyExclusive bool, fieldsInfo *fieldsAndFragmentNames, fragmentName string) []conflict {
+	// Skip if this fields/fragment pair has already been compared.
+	if rule.comparedFieldsAndFragmentSet.Has(fieldsInfo, fragmentName, areMutuallyExclusive) {
+		return conflicts
+	}
+	rule.comparedFieldsAndFragmentSet.Add(fieldsInfo, fragmentName, areMutuallyExclusive)
+
 	fragment := rule.context.Fragment(fragmentName)
 	if fragment == nil {
 		return conflicts
 	}
 
 	fieldsInfo2 := rule.getReferencedFieldsAndFragmentNames(fragment)
+
+	// Do not compare a fragment's fields with itself.
+	if fieldsInfo == fieldsInfo2 {
+		return conflicts
+	}
 
 	// (D) First collect any conflicts between the provided collection of fields
 	// and the collection of fields represented by the given fragment.
@@ -560,6 +584,49 @@ type fieldsAndFragmentNames struct {
 	fieldMap      astAndDefCollection
 	fieldsOrder   []string // stores the order of field names in fieldMap
 	fragmentNames []string
+}
+
+// fieldsAndFragmentSet tracks (fieldsAndFragmentNames, fragmentName,
+// areMutuallyExclusive) triples that have already been compared by
+// collectConflictsBetweenFieldsAndFragment. The pair is ordered: the
+// fields side is identified by pointer (it is always one of the values
+// produced by getFieldsAndFragmentNames or
+// getReferencedFieldsAndFragmentNames), the fragment side by name.
+type fieldsAndFragmentSet struct {
+	data map[*fieldsAndFragmentNames]map[string]bool
+}
+
+func newFieldsAndFragmentSet() *fieldsAndFragmentSet {
+	return &fieldsAndFragmentSet{
+		data: map[*fieldsAndFragmentNames]map[string]bool{},
+	}
+}
+
+func (s *fieldsAndFragmentSet) Has(fields *fieldsAndFragmentNames, fragmentName string, areMutuallyExclusive bool) bool {
+	inner, ok := s.data[fields]
+	if !ok || inner == nil {
+		return false
+	}
+	stored, ok := inner[fragmentName]
+	if !ok {
+		return false
+	}
+	// An entry stored with areMutuallyExclusive=false reflects the
+	// stricter non-exclusive comparison; it satisfies a query for either
+	// value. An entry stored with true only satisfies queries for true.
+	if !areMutuallyExclusive {
+		return stored == false
+	}
+	return true
+}
+
+func (s *fieldsAndFragmentSet) Add(fields *fieldsAndFragmentNames, fragmentName string, areMutuallyExclusive bool) {
+	inner, ok := s.data[fields]
+	if !ok || inner == nil {
+		inner = map[string]bool{}
+		s.data[fields] = inner
+	}
+	inner[fragmentName] = areMutuallyExclusive
 }
 
 // pairSet A way to keep track of pairs of things when the ordering of the pair does

--- a/rules_overlapping_fields_can_be_merged_test.go
+++ b/rules_overlapping_fields_can_be_merged_test.go
@@ -2,6 +2,7 @@ package graphql_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/gqlerrors"
@@ -899,4 +900,38 @@ func TestValidate_OverlappingFieldsCanBeMerged_ReturnTypesMustBeUnambiguous_Igno
 
 func TestValidate_OverlappingFieldsCanBeMerged_NilCrash(t *testing.T) {
 	testutil.ExpectPassesRule(t, graphql.OverlappingFieldsCanBeMergedRule, `subscription {e}`)
+}
+
+// The overlapping-fields rule must terminate on a document with a
+// cyclic fragment spread. The cycle itself is reported separately by
+// NoFragmentCyclesRule.
+func TestValidate_OverlappingFieldsCanBeMerged_CyclicFragmentTerminates(t *testing.T) {
+	// Parse on the main goroutine so any parse error fails cleanly.
+	astDoc := testutil.TestParse(t, `
+      fragment A on Dog { ...B }
+      fragment B on Dog { ...A }
+      { ...A }
+    `)
+
+	// Run only ValidateDocument in the worker goroutine; assertions happen
+	// on the main goroutine after the result arrives, since t.Fatal is
+	// unsafe to call from a non-test goroutine.
+	done := make(chan graphql.ValidationResult, 1)
+	go func() {
+		done <- graphql.ValidateDocument(testutil.TestSchema, astDoc, []graphql.ValidationRuleFn{
+			graphql.OverlappingFieldsCanBeMergedRule,
+		})
+	}()
+
+	select {
+	case res := <-done:
+		if len(res.Errors) > 0 {
+			t.Fatalf("Should validate, got %v", res.Errors)
+		}
+		if !res.IsValid {
+			t.Fatalf("IsValid should be true, got %v", res.IsValid)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OverlappingFieldsCanBeMergedRule did not terminate on cyclic fragment")
+	}
 }


### PR DESCRIPTION
The overlapping-fields validator infinitely recurses on cyclic fragment spreads.                         
                                                                                                         
## How to reproduce                                                                                     
                                                                                                         
```graphql                                                                                             
  fragment A on Dog { ...B }                                                                             
  fragment B on Dog { ...A }                                                                             
  { ...A }                                                                                               
```                                                                                                
Before this patch: runtime: goroutine stack exceeds 1000000000-byte limit; fatal error: stack overflow inside collectConflictsBetweenFieldsAndFragment at rules_overlapping_fields_can_be_merged.go:209.      
                                                                                                         
After: validation returns Cannot spread fragment "A" within itself via B. from NoFragmentCyclesRule.
                                                                                                         
## Root cause                                                                           
                                          
collectConflictsBetweenFieldsAndFragment recurses through nested spreads without memoization. Its sibling collectConflictsBetweenFragments already has the equivalent guard via rule.comparedSet; this one was missing it.                     
                                                                                                         
## Changes                                                                                                
                                     
  - New fieldsAndFragmentSet memo keyed by (*fieldsAndFragmentNames, fragmentName, areMutuallyExclusive), same Has/Add shape as the existing pairSet.                                         
  - Wired into the rule constructor and struct alongside comparedSet and cacheMap.
  - Function-entry check skips repeat triples.
  - Added a fieldsInfo == fieldsInfo2 guard so a fragment is not compared against itself.
                                                                                                         
## Test                                        
                                                                                                         
TestValidate_OverlappingFieldsCanBeMerged_CyclicFragmentTerminates runs the rule inside a goroutine with a 2s deadline. Fails on the unpatched code (the goroutine never finishes), passes after the fix.
Existing OverlappingFields* tests still pass.
## Closes 
#742 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation no longer hangs on documents with cyclic fragment spreads; overlapping-fields checks terminate reliably and run faster thanks to per-pass memoization.

* **Tests**
  * Added a test ensuring validation completes for cyclic fragment structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/graphql-go/graphql/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->