### PR TITLE
new plan abstract-field selections lazily to avoid exponential blow-up

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -55,6 +55,10 @@ type executionContext struct {
 	VariableValues map[string]interface{}
 	Errors         []gqlerrors.FormattedError
 	Context        context.Context
+
+	// plan is set on the ExecutePlan path; it lets abstract fields plan
+	// their concrete-type sub-selections lazily at execute time.
+	plan *Plan
 }
 
 func buildExecutionContext(p buildExecutionCtxParams) (*executionContext, error) {

--- a/plan.go
+++ b/plan.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/graphql-go/graphql/language/ast"
@@ -32,6 +33,11 @@ type Plan struct {
 	rootType   *Object
 	root       *selectionPlan
 	isMutation bool
+
+	// abstractMu guards lazy population of fieldPlan.abstractAlternatives,
+	// which happens at execute time (concurrently across fields) the
+	// first time each concrete type is encountered for an abstract field.
+	abstractMu sync.Mutex
 }
 
 // selectionPlan is a pre-collected, source-ordered list of fields to
@@ -198,23 +204,39 @@ func (p *Plan) planSelectionSet(parentType *Object, selectionSet *ast.SelectionS
 // fieldASTs, but at plan time so the executor can use the result
 // directly.
 func (p *Plan) planMergedFieldChildren(fp *fieldPlan) {
-	t := unwrapNamedType(fp.returnType)
-	switch concrete := t.(type) {
-	case *Object:
-		fp.sub = p.planMergedSelectionsForType(concrete, fp.fieldASTs)
-	case *Interface:
-		possibleTypes := p.schema.PossibleTypes(concrete)
-		fp.abstractAlternatives = make(map[*Object]*selectionPlan, len(possibleTypes))
-		for _, pt := range possibleTypes {
-			fp.abstractAlternatives[pt] = p.planMergedSelectionsForType(pt, fp.fieldASTs)
-		}
-	case *Union:
-		possibleTypes := p.schema.PossibleTypes(concrete)
-		fp.abstractAlternatives = make(map[*Object]*selectionPlan, len(possibleTypes))
-		for _, pt := range possibleTypes {
-			fp.abstractAlternatives[pt] = p.planMergedSelectionsForType(pt, fp.fieldASTs)
-		}
+	// Object returns resolve to a single concrete type, so plan their
+	// sub-selection eagerly.
+	if obj, ok := unwrapNamedType(fp.returnType).(*Object); ok {
+		fp.sub = p.planMergedSelectionsForType(obj, fp.fieldASTs)
+		return
 	}
+	// Abstract returns (Interface / Union) are planned lazily, per
+	// concrete type, the first time that type is actually encountered at
+	// execute time (see Plan.abstractAlternative). Eagerly expanding
+	// every possible type here is O(possibleTypes) per abstract field;
+	// because each expanded type's sub-selection can contain further
+	// abstract fields, it compounds to O(possibleTypes ^ nesting-depth)
+	// — which makes deeply-nested polymorphic queries on large schemas
+	// take minutes to plan, even though a single request only ever
+	// resolves one concrete type per level.
+}
+
+// abstractAlternative returns the planned sub-selection for an abstract
+// field's runtime concrete type, planning (and caching) it on first use.
+// Concurrency-safe: ExecutePlan resolves fields concurrently, so several
+// goroutines may reach the same abstract field at once.
+func (p *Plan) abstractAlternative(fp *fieldPlan, runtimeType *Object) *selectionPlan {
+	p.abstractMu.Lock()
+	defer p.abstractMu.Unlock()
+	if fp.abstractAlternatives == nil {
+		fp.abstractAlternatives = map[*Object]*selectionPlan{}
+	}
+	if sub, ok := fp.abstractAlternatives[runtimeType]; ok {
+		return sub
+	}
+	sub := p.planMergedSelectionsForType(runtimeType, fp.fieldASTs)
+	fp.abstractAlternatives[runtimeType] = sub
+	return sub
 }
 
 // planMergedSelectionsForType collects the union of every AST's
@@ -597,6 +619,7 @@ func ExecutePlan(plan *Plan, p ExecuteParams) (result *Result) {
 			Operation:      plan.operation,
 			VariableValues: variableValues,
 			Context:        ctx,
+			plan:           plan,
 		}
 
 		data := executePlannedSelection(eCtx, plan.root, p.Root, plan.rootType, nil)
@@ -891,12 +914,16 @@ func completePlannedAbstractValue(eCtx *executionContext, returnType Abstract, f
 			fmt.Sprintf(`Runtime Object type "%v" is not a possible type for "%v".`, runtimeType, returnType),
 		))
 	}
-	if sub, ok := fp.abstractAlternatives[runtimeType]; ok && sub != nil {
-		return executePlannedSelection(eCtx, sub, result, runtimeType, path)
+	// Plan (and cache) the concrete type's sub-selection on first use.
+	// Abstract alternatives are planned lazily so that only the types a
+	// request actually resolves are ever planned — see
+	// planMergedFieldChildren.
+	if eCtx.plan != nil {
+		if sub := eCtx.plan.abstractAlternative(fp, runtimeType); sub != nil {
+			return executePlannedSelection(eCtx, sub, result, runtimeType, path)
+		}
 	}
-	// Defensive fallback: unplanned concrete type (e.g. interface
-	// gained a new implementer between plan time and execute time —
-	// shouldn't happen in practice since schema rebuilds invalidate
-	// the plan, but stay correct).
+	// The concrete type contributes no selectable fields (e.g. only
+	// inline fragments on other types matched). Surface an empty object.
 	return map[string]interface{}{}
 }

--- a/plan_blowup_test.go
+++ b/plan_blowup_test.go
@@ -1,0 +1,175 @@
+package graphql
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/parser"
+)
+
+func parseQuery(t testing.TB, query string) *ast.Document {
+	t.Helper()
+	doc, err := parser.Parse(parser.ParseParams{Source: query})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return doc
+}
+
+// buildAbstractFanSchema builds a schema with a single interface `Node`
+// implemented by `numTypes` object types. The interface (and therefore
+// every implementer) exposes a `next: Node` field, so the type graph is
+// cyclic through the abstract type: planning a selection on `next` must
+// consider every possible type, each of which again has a `next`.
+//
+// A naive planner that eagerly expands every possible type for every
+// abstract field, at every nesting level, does O(numTypes ^ depth) work
+// — even though a single request only ever resolves one concrete type
+// per level. This is the shape that made a real, deeply-nested
+// polymorphic query take minutes to plan.
+func buildAbstractFanSchema(t testing.TB, numTypes int) Schema {
+	t.Helper()
+
+	nodeIface := NewInterface(InterfaceConfig{
+		Name: "Node",
+		Fields: Fields{
+			"id": &Field{Type: String},
+		},
+	})
+	// Self-reference: `next: Node` makes the type graph cyclic through
+	// the abstract type. Added after construction to reference the
+	// interface itself.
+	nodeIface.AddFieldConfig("next", &Field{Type: nodeIface})
+
+	objs := make([]*Object, numTypes)
+	for i := 0; i < numTypes; i++ {
+		objs[i] = NewObject(ObjectConfig{
+			Name:       fmt.Sprintf("T%d", i),
+			Interfaces: []*Interface{nodeIface},
+			Fields: Fields{
+				"id":   &Field{Type: String},
+				"next": &Field{Type: nodeIface},
+			},
+		})
+	}
+	// Resolve every abstract value to T0 so the correctness test has a
+	// deterministic concrete type.
+	nodeIface.ResolveType = func(p ResolveTypeParams) *Object { return objs[0] }
+
+	queryType := NewObject(ObjectConfig{
+		Name: "Query",
+		Fields: Fields{
+			"start": &Field{
+				Type: nodeIface,
+				Resolve: func(p ResolveParams) (interface{}, error) {
+					return map[string]interface{}{"id": "root"}, nil
+				},
+			},
+		},
+	})
+
+	schema, err := NewSchema(SchemaConfig{
+		Query: queryType,
+		Types: objectsToTypes(objs),
+	})
+	if err != nil {
+		t.Fatalf("build schema: %v", err)
+	}
+	return schema
+}
+
+func objectsToTypes(objs []*Object) []Type {
+	types := make([]Type, len(objs))
+	for i, o := range objs {
+		types[i] = o
+	}
+	return types
+}
+
+// nestedNextQuery builds `{ start { id next { id next { ... } } } }`
+// nested `depth` levels deep.
+func nestedNextQuery(depth int) string {
+	var b strings.Builder
+	b.WriteString("{ start { id ")
+	for i := 0; i < depth; i++ {
+		b.WriteString("next { id ")
+	}
+	for i := 0; i < depth; i++ {
+		b.WriteString("} ")
+	}
+	b.WriteString("} }")
+	return b.String()
+}
+
+// TestPlanQueryAbstractFanDoesNotExplode is the regression guard: a
+// deeply-nested abstract selection must plan in time linear in the
+// query size, not exponential in the number of possible types.
+//
+// With numTypes=16 and depth=12, an eager-expansion planner would do
+// ~16^12 (≈ 2.8e14) units of work and never return; the lazy planner
+// returns essentially instantly.
+func TestPlanQueryAbstractFanDoesNotExplode(t *testing.T) {
+	schema := buildAbstractFanSchema(t, 16)
+	doc := parseQuery(t, nestedNextQuery(12))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := PlanQuery(&schema, doc, "")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("PlanQuery returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("PlanQuery did not complete within 10s: abstract-type " +
+			"planning is expanding possible types exponentially with nesting depth")
+	}
+}
+
+// TestPlanQueryAbstractFanCorrectness ensures the lazy abstract planning
+// still resolves concrete types and returns correct data.
+func TestPlanQueryAbstractFanCorrectness(t *testing.T) {
+	schema := buildAbstractFanSchema(t, 4)
+	result := Do(Params{
+		Schema:        schema,
+		RequestString: "{ start { id next { id } } }",
+	})
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	data, _ := result.Data.(map[string]interface{})
+	start, _ := data["start"].(map[string]interface{})
+	if start == nil {
+		t.Fatalf("expected start object, got: %#v", result.Data)
+	}
+	if start["id"] != "root" {
+		t.Fatalf("expected start.id=root, got %#v", start["id"])
+	}
+	// next resolves to nil (no resolver returns a child) → null.
+	if v, ok := start["next"]; ok && v != nil {
+		t.Fatalf("expected start.next=nil, got %#v", v)
+	}
+}
+
+func BenchmarkPlanQueryAbstractFan(b *testing.B) {
+	for _, dims := range []struct{ numTypes, depth int }{
+		{8, 6}, {16, 8}, {32, 10},
+	} {
+		schema := buildAbstractFanSchema(b, dims.numTypes)
+		doc := parseQuery(b, nestedNextQuery(dims.depth))
+		b.Run(fmt.Sprintf("types=%d/depth=%d", dims.numTypes, dims.depth), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := PlanQuery(&schema, doc, ""); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
After recent changes introducing plan caching led to big performance regressions, complex queries took seconds to plan. This is mostly a Claude generated PR so I don't take any credit for it but after benchmarking it brought planning time to existing baseline.

PlanQuery eagerly expanded every possible type of every Interface/Union field at plan time. Because an expanded type's sub-selection can contain further abstract fields, this lead to a big blow up in planing time for complex schemas.

What this changes is to actually make it lazy: planMergedFieldChildren leaves abstract alternatives unplanned, and completePlannedAbstractValue plans (and caches) the concrete type's sub-selection the first time that type is encountered at runtime, guarded by a mutex since fields resolve concurrently.

Plan time for abstract fields is now proportional to the types a request actually resolves rather than schema_size ^ depth. 

Also adding a plan_blowup_test.go: a regression guard (deeply-nested abstract selection must plan within a deadline), a correctness test, and a benchmark. Without the fix the guard does ~16^12 units of work and times out; with it, PlanQuery is ~constant-time (6 allocs/op) regardless of depth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced concurrent execution safety for abstract field planning through lazy initialization.
  * Optimized query planning for abstract types (Interface/Union) to defer evaluation until execution time, improving performance with complex nested selections.

* **Tests**
  * Added performance regression tests to prevent slowdowns with deeply nested abstract type selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->