### PR TITLE
`{language/ast}`: Increases unit tests.

### DIFF
--- a/language/ast/definitions_extended_test.go
+++ b/language/ast/definitions_extended_test.go
@@ -1,0 +1,213 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/graphql-go/graphql/language/ast"
+)
+
+func TestOperationDefinition(t *testing.T) {
+	loc := &ast.Location{Start: 1, End: 2}
+	name := &ast.Name{Value: "MyQuery"}
+	variable := &ast.VariableDefinition{
+		Variable: &ast.Variable{Name: &ast.Name{Value: "id"}},
+		Type:     &ast.Named{Name: &ast.Name{Value: "String"}},
+	}
+	directive := &ast.Directive{Name: &ast.Name{Value: "include"}}
+	selection := &ast.Field{Name: &ast.Name{Value: "field1"}}
+	selSet := &ast.SelectionSet{Selections: []ast.Selection{selection}}
+
+	def := ast.NewOperationDefinition(&ast.OperationDefinition{
+		Loc:                 loc,
+		Operation:           "query",
+		Name:                name,
+		VariableDefinitions: []*ast.VariableDefinition{variable},
+		Directives:          []*ast.Directive{directive},
+		SelectionSet:        selSet,
+	})
+	if def.GetKind() != "OperationDefinition" {
+		t.Fatalf("expected OperationDefinition, got %s", def.GetKind())
+	}
+	if def.GetLoc() != loc {
+		t.Fatal("Loc mismatch")
+	}
+	if def.GetOperation() != "query" {
+		t.Fatalf("expected query, got %s", def.GetOperation())
+	}
+	if def.GetName() != name {
+		t.Fatal("Name mismatch")
+	}
+	if len(def.GetVariableDefinitions()) != 1 || def.GetVariableDefinitions()[0] != variable {
+		t.Fatal("VariableDefinitions mismatch")
+	}
+	if len(def.GetDirectives()) != 1 || def.GetDirectives()[0] != directive {
+		t.Fatal("Directives mismatch")
+	}
+	if def.GetSelectionSet() != selSet {
+		t.Fatal("SelectionSet mismatch")
+	}
+}
+
+func TestFragmentDefinition(t *testing.T) {
+	loc := &ast.Location{Start: 1, End: 2}
+	name := &ast.Name{Value: "MyFragment"}
+	typeCond := &ast.Named{Name: &ast.Name{Value: "Foo"}}
+	directive := &ast.Directive{Name: &ast.Name{Value: "include"}}
+	selection := &ast.Field{Name: &ast.Name{Value: "field1"}}
+	selSet := &ast.SelectionSet{Selections: []ast.Selection{selection}}
+
+	def := ast.NewFragmentDefinition(&ast.FragmentDefinition{
+		Loc:          loc,
+		Name:         name,
+		TypeCondition: typeCond,
+		Directives:   []*ast.Directive{directive},
+		SelectionSet: selSet,
+	})
+	if def.GetKind() != "FragmentDefinition" {
+		t.Fatalf("expected FragmentDefinition, got %s", def.GetKind())
+	}
+	if def.GetLoc() != loc {
+		t.Fatal("Loc mismatch")
+	}
+	if def.GetName() != name {
+		t.Fatal("Name mismatch")
+	}
+	if len(def.GetVariableDefinitions()) != 0 {
+		t.Fatal("expected empty VariableDefinitions")
+	}
+	if def.GetSelectionSet() != selSet {
+		t.Fatal("SelectionSet mismatch")
+	}
+	if def.GetOperation() != "" {
+		t.Fatal("expected empty operation")
+	}
+}
+
+func TestVariableDefinition(t *testing.T) {
+	loc := &ast.Location{Start: 1, End: 2}
+	variable := &ast.Variable{Name: &ast.Name{Value: "x"}}
+	namedType := &ast.Named{Name: &ast.Name{Value: "String"}}
+	defaultVal := &ast.StringValue{Value: "default"}
+
+	def := ast.NewVariableDefinition(&ast.VariableDefinition{
+		Loc:          loc,
+		Variable:     variable,
+		Type:         namedType,
+		DefaultValue: defaultVal,
+	})
+	if def.GetKind() != "VariableDefinition" {
+		t.Fatalf("expected VariableDefinition, got %s", def.GetKind())
+	}
+	if def.GetLoc() != loc {
+		t.Fatal("Loc mismatch")
+	}
+}
+
+func TestTypeExtensionDefinition(t *testing.T) {
+	loc := &ast.Location{Start: 1, End: 2}
+	innerDef := &ast.ObjectDefinition{
+		Kind: "ObjectDefinition",
+		Name: &ast.Name{Value: "ExtendedType"},
+		Fields: []*ast.FieldDefinition{
+			{Name: &ast.Name{Value: "newField"}},
+		},
+	}
+
+	def := ast.NewTypeExtensionDefinition(&ast.TypeExtensionDefinition{
+		Loc:        loc,
+		Definition: innerDef,
+	})
+	if def.GetKind() != "TypeExtensionDefinition" {
+		t.Fatalf("expected TypeExtensionDefinition, got %s", def.GetKind())
+	}
+	if def.GetLoc() != loc {
+		t.Fatal("Loc mismatch")
+	}
+	if len(def.GetVariableDefinitions()) != 0 {
+		t.Fatal("expected empty VariableDefinitions")
+	}
+	if def.GetSelectionSet() == nil {
+		t.Fatal("expected non-nil SelectionSet")
+	}
+	if def.GetOperation() != "" {
+		t.Fatal("expected empty operation")
+	}
+}
+
+func TestDirectiveDefinition(t *testing.T) {
+	loc := &ast.Location{Start: 1, End: 2}
+	name := &ast.Name{Value: "skip"}
+	desc := &ast.StringValue{Value: "Directive description"}
+	arg := &ast.InputValueDefinition{Name: &ast.Name{Value: "if"}}
+	location := &ast.Name{Value: "FIELD"}
+
+	def := ast.NewDirectiveDefinition(&ast.DirectiveDefinition{
+		Loc:         loc,
+		Name:        name,
+		Description: desc,
+		Arguments:   []*ast.InputValueDefinition{arg},
+		Locations:   []*ast.Name{location},
+	})
+	if def.GetKind() != "DirectiveDefinition" {
+		t.Fatalf("expected DirectiveDefinition, got %s", def.GetKind())
+	}
+	if def.GetLoc() != loc {
+		t.Fatal("Loc mismatch")
+	}
+	if def.GetDescription() != desc {
+		t.Fatal("Description mismatch")
+	}
+	if len(def.GetVariableDefinitions()) != 0 {
+		t.Fatal("expected empty VariableDefinitions")
+	}
+	if def.GetSelectionSet() == nil {
+		t.Fatal("expected non-nil SelectionSet")
+	}
+	if def.GetOperation() != "" {
+		t.Fatal("expected empty operation")
+	}
+}
+
+func TestDefinitionInterfaceCompileTimeChecks(t *testing.T) {
+	var d ast.Definition
+	d = ast.NewOperationDefinition(nil)
+	if d.GetKind() != "OperationDefinition" {
+		t.Fatal("expected OperationDefinition")
+	}
+	d = ast.NewFragmentDefinition(nil)
+	if d.GetKind() != "FragmentDefinition" {
+		t.Fatal("expected FragmentDefinition")
+	}
+
+	var tsd ast.TypeSystemDefinition
+	tsd = ast.NewTypeExtensionDefinition(nil)
+	if tsd.GetKind() != "TypeExtensionDefinition" {
+		t.Fatal("expected TypeExtensionDefinition")
+	}
+	tsd = ast.NewDirectiveDefinition(nil)
+	if tsd.GetKind() != "DirectiveDefinition" {
+		t.Fatal("expected DirectiveDefinition")
+	}
+
+	var n ast.Node
+	n = ast.NewOperationDefinition(nil)
+	if n.GetKind() != "OperationDefinition" {
+		t.Fatal("expected OperationDefinition as Node")
+	}
+	n = ast.NewFragmentDefinition(nil)
+	if n.GetKind() != "FragmentDefinition" {
+		t.Fatal("expected FragmentDefinition as Node")
+	}
+	n = ast.NewVariableDefinition(nil)
+	if n.GetKind() != "VariableDefinition" {
+		t.Fatal("expected VariableDefinition as Node")
+	}
+	n = ast.NewTypeExtensionDefinition(nil)
+	if n.GetKind() != "TypeExtensionDefinition" {
+		t.Fatal("expected TypeExtensionDefinition as Node")
+	}
+	n = ast.NewDirectiveDefinition(nil)
+	if n.GetKind() != "DirectiveDefinition" {
+		t.Fatal("expected DirectiveDefinition as Node")
+	}
+}

--- a/language/ast/definitions_internal_test.go
+++ b/language/ast/definitions_internal_test.go
@@ -1,0 +1,143 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/graphql-go/graphql/language/kinds"
+)
+
+func TestDefConstructors_NilInput(t *testing.T) {
+	tests := []struct {
+		name string
+		got  Node
+	}{
+		{"NewOperationDefinition", NewOperationDefinition(nil)},
+		{"NewFragmentDefinition", NewFragmentDefinition(nil)},
+		{"NewVariableDefinition", NewVariableDefinition(nil)},
+		{"NewTypeExtensionDefinition", NewTypeExtensionDefinition(nil)},
+		{"NewDirectiveDefinition", NewDirectiveDefinition(nil)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got == nil {
+				t.Fatal("expected non-nil result")
+			}
+		})
+	}
+}
+
+func TestDefOperationDefinition_NewWithInput(t *testing.T) {
+	loc := &Location{Start: 1, End: 2}
+	name := &Name{Value: "MyOp"}
+	vd := &VariableDefinition{}
+	dir := &Directive{}
+	ss := &SelectionSet{}
+	op := NewOperationDefinition(&OperationDefinition{
+		Loc:                 loc,
+		Operation:           "query",
+		Name:                name,
+		VariableDefinitions: []*VariableDefinition{vd},
+		Directives:          []*Directive{dir},
+		SelectionSet:        ss,
+	})
+	if op.Kind != kinds.OperationDefinition {
+		t.Fatalf("expected kind %s, got %s", kinds.OperationDefinition, op.Kind)
+	}
+	if op.Loc != loc {
+		t.Fatal("Loc mismatch")
+	}
+	if op.Operation != "query" {
+		t.Fatal("Operation mismatch")
+	}
+	if op.Name != name {
+		t.Fatal("Name mismatch")
+	}
+	if len(op.VariableDefinitions) != 1 || op.VariableDefinitions[0] != vd {
+		t.Fatal("VariableDefinitions mismatch")
+	}
+	if len(op.Directives) != 1 || op.Directives[0] != dir {
+		t.Fatal("Directives mismatch")
+	}
+	if op.SelectionSet != ss {
+		t.Fatal("SelectionSet mismatch")
+	}
+}
+
+func TestDefVariableDefinition_NewWithInput(t *testing.T) {
+	loc := &Location{Start: 1, End: 2}
+	variable := &Variable{Name: &Name{Value: "x"}}
+	typ := &Named{Name: &Name{Value: "String"}}
+	defaultVal := &StringValue{Value: "hello"}
+	vd := NewVariableDefinition(&VariableDefinition{
+		Loc:          loc,
+		Variable:     variable,
+		Type:         typ,
+		DefaultValue: defaultVal,
+	})
+	if vd.Kind != kinds.VariableDefinition {
+		t.Fatalf("expected kind %s, got %s", kinds.VariableDefinition, vd.Kind)
+	}
+	if vd.Loc != loc {
+		t.Fatal("Loc mismatch")
+	}
+	if vd.Variable != variable {
+		t.Fatal("Variable mismatch")
+	}
+	if vd.Type != typ {
+		t.Fatal("Type mismatch")
+	}
+	if vd.DefaultValue != defaultVal {
+		t.Fatal("DefaultValue mismatch")
+	}
+}
+
+func TestDefTypeExtensionDefinition_NewWithInput(t *testing.T) {
+	loc := &Location{Start: 1, End: 2}
+	def := &ObjectDefinition{Name: &Name{Value: "ExtendedType"}}
+	ted := NewTypeExtensionDefinition(&TypeExtensionDefinition{
+		Loc:        loc,
+		Definition: def,
+	})
+	if ted.Kind != kinds.TypeExtensionDefinition {
+		t.Fatalf("expected kind %s, got %s", kinds.TypeExtensionDefinition, ted.Kind)
+	}
+	if ted.Loc != loc {
+		t.Fatal("Loc mismatch")
+	}
+	if ted.Definition != def {
+		t.Fatal("Definition mismatch")
+	}
+}
+
+func TestDefDirectiveDefinition_NewWithInput(t *testing.T) {
+	loc := &Location{Start: 1, End: 2}
+	name := &Name{Value: "skip"}
+	desc := &StringValue{Value: "Directive description"}
+	arg := &InputValueDefinition{Name: &Name{Value: "if"}}
+	location := &Name{Value: "FIELD"}
+	dd := NewDirectiveDefinition(&DirectiveDefinition{
+		Loc:         loc,
+		Name:        name,
+		Description: desc,
+		Arguments:   []*InputValueDefinition{arg},
+		Locations:   []*Name{location},
+	})
+	if dd.Kind != kinds.DirectiveDefinition {
+		t.Fatalf("expected kind %s, got %s", kinds.DirectiveDefinition, dd.Kind)
+	}
+	if dd.Loc != loc {
+		t.Fatal("Loc mismatch")
+	}
+	if dd.Name != name {
+		t.Fatal("Name mismatch")
+	}
+	if dd.Description != desc {
+		t.Fatal("Description mismatch")
+	}
+	if len(dd.Arguments) != 1 || dd.Arguments[0] != arg {
+		t.Fatal("Arguments mismatch")
+	}
+	if len(dd.Locations) != 1 || dd.Locations[0] != location {
+		t.Fatal("Locations mismatch")
+	}
+}


### PR DESCRIPTION
#### Details
- `language/ast`: adds unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Abstract Syntax Tree definition constructors and their validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->